### PR TITLE
New builder to add a new docker template to all docker clouds

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -42,7 +42,7 @@ public class DockerCloud extends Cloud {
 
     public static final String CLOUD_ID_PREFIX = "docker-";
 
-    public final List<? extends DockerTemplate> templates;
+    public final List<DockerTemplate> templates;
     public final String serverUrl;
 
     private transient DockerClient connection;
@@ -55,9 +55,9 @@ public class DockerCloud extends Cloud {
         this.serverUrl = serverUrl;
 
         if( templates != null )
-            this.templates = templates;
+            this.templates = new ArrayList<DockerTemplate>(templates);
         else
-            this.templates = Collections.emptyList();
+            this.templates = new ArrayList<DockerTemplate>();
 
 
 
@@ -188,6 +188,14 @@ public class DockerCloud extends Cloud {
             }
         }
         return null;
+    }
+
+    /**
+     * Add a new template to the cloud
+     */
+    public void addTemplate(DockerTemplate t) {
+        this.templates.add(t);
+        t.parent = this;
     }
 
     /**

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/config.jelly
@@ -1,75 +1,10 @@
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form"
-         xmlns:c="/lib/credentials"
+         xmlns:st="jelly:stapler"
         >
     <table width="100%">
 
-        <f:entry title="${%ID}" field="image">
-            <f:textbox/>
-        </f:entry>
-
-        <f:entry title="${%Labels}" field="labelString">
-            <f:textbox/>
-        </f:entry>
-
-        <f:entry title="${%Credentials}" field="credentialsId">
-            <c:select/>
-        </f:entry>
-
-        <f:entry title="${%Remote Filing System Root}" field="remoteFs">
-            <f:textbox/>
-        </f:entry>
-
-        <f:entry title="${%Tag on Completion}" field="tagOnCompletion">
-            <f:checkbox/>
-        </f:entry>
-
-        <f:entry title="${%Instance Cap}" field="instanceCapStr">
-            <f:textbox/>
-        </f:entry>
-
-        <f:entry title="${%DNS}" field="dnsString">
-            <f:textbox/>
-        </f:entry>
-
-        <f:advanced>
-
-            <f:entry title="${%Additional tag to add}" field="additionalTag">
-                <f:textbox/>
-            </f:entry>
-
-
-            <f:entry title="${%Push on successful build}" field="pushOnSuccess">
-                <f:checkbox/>
-            </f:entry>
-
-
-            <f:entry title="${%JavaPath}" field="javaPath">
-                <f:textbox/>
-            </f:entry>
-
-       <f:entry title="${%JVM Options}" field="jvmOptions">
-           <f:textbox/>
-       </f:entry>
-
-        <f:entry title="${%Docker Command}" field="dockerCommand">
-            <f:textbox />
-        </f:entry>
-
-        <f:entry title="${%Run container privileged}" field="privileged">
-            <f:checkbox/>
-        </f:entry>
-
-       <f:entry title="${%Prefix Start Slave Command}" field="prefixStartSlaveCmd">
-           <f:textbox/>
-       </f:entry>
-
-       <f:entry title="${%Suffix Start Slave Command}" field="suffixStartSlaveCmd">
-           <f:textbox/>
-       </f:entry>
-
-        </f:advanced>
-
+        <st:include page="template.jelly" class="${descriptor.clazz}" />
         <f:entry title="">
             <div align="right">
                 <f:repeatableDeleteButton/>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
@@ -1,0 +1,70 @@
+<j:jelly xmlns:j="jelly:core"
+         xmlns:f="/lib/form"
+         xmlns:c="/lib/credentials"
+        >
+        <f:entry title="${%ID}" field="image">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry title="${%Labels}" field="labelString">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry title="${%Credentials}" field="credentialsId">
+            <c:select/>
+        </f:entry>
+
+        <f:entry title="${%Remote Filing System Root}" field="remoteFs">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry title="${%Tag on Completion}" field="tagOnCompletion">
+            <f:checkbox/>
+        </f:entry>
+
+        <f:entry title="${%Instance Cap}" field="instanceCapStr">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry title="${%DNS}" field="dnsString">
+            <f:textbox/>
+        </f:entry>
+
+        <f:advanced>
+
+            <f:entry title="${%Additional tag to add}" field="additionalTag">
+                <f:textbox/>
+            </f:entry>
+
+
+            <f:entry title="${%Push on successful build}" field="pushOnSuccess">
+                <f:checkbox/>
+            </f:entry>
+
+
+            <f:entry title="${%JavaPath}" field="javaPath">
+                <f:textbox/>
+            </f:entry>
+
+       <f:entry title="${%JVM Options}" field="jvmOptions">
+           <f:textbox/>
+       </f:entry>
+
+        <f:entry title="${%Docker Command}" field="dockerCommand">
+            <f:textbox />
+        </f:entry>
+
+        <f:entry title="${%Run container privileged}" field="privileged">
+            <f:checkbox/>
+        </f:entry>
+
+       <f:entry title="${%Prefix Start Slave Command}" field="prefixStartSlaveCmd">
+           <f:textbox/>
+       </f:entry>
+
+       <f:entry title="${%Suffix Start Slave Command}" field="suffixStartSlaveCmd">
+           <f:textbox/>
+       </f:entry>
+
+        </f:advanced>
+</j:jelly>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate/config.jelly
@@ -1,0 +1,5 @@
+<j:jelly xmlns:j="jelly:core"
+         xmlns:st="jelly:stapler"
+        >
+    <st:include page="template.jelly" class="com.nirima.jenkins.plugins.docker.DockerTemplate" />
+</j:jelly>


### PR DESCRIPTION
Hi there,

So this commit allows you to dynamically add a new template to all Docker clouds at build time. It is useful when you want to use an image built in a previous build step to provision a container in a following step.

Build scenario:
- Create a new image (using a dockerfile) and push it to a docker registry
- Add the image to all Dockers clouds
- Launch X builds in parallel (using the Parallel Test Executor Plugin for example), each running inside a container provisioned with the previously built image.
