### PR TITLE
README: link to Jenkins wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@ docker-plugin
 =============
 
 Jenkins Cloud Plugin for Docker
+
+The aim of the docker plugin is to be able to use a docker host to
+dynamically provision a slave, run a single build, then tear-down
+that slave.
+
+More documentation available on the Jenkins wiki:
+
+https://wiki.jenkins-ci.org/display/JENKINS/Docker+Plugin


### PR DESCRIPTION
Since README files in github repositories have high exposure,
I thought it would be a good idea to point back to the Jenkins
wiki page.
