### PR TITLE
Add 'volumes' parameter to Docker template

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -77,6 +77,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
 
     public final int instanceCap;
     public final String[] dnsHosts;
+    public final String[] volumes;
 
     private transient /*almost final*/ Set<LabelAtom> labelSet;
     public transient DockerCloud parent;
@@ -90,6 +91,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
                           String prefixStartSlaveCmd, String suffixStartSlaveCmd,
                           String instanceCapStr, String dnsString,
                           String dockerCommand,
+                          String volumesString,
                           boolean privileged
 
     ) {
@@ -112,6 +114,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         }
 
         this.dnsHosts = dnsString.split(" ");
+        this.volumes = volumesString.split(" ");
 
         readResolve();
     }
@@ -126,6 +129,10 @@ public class DockerTemplate implements Describable<DockerTemplate> {
 
     public String getDnsString() {
         return Joiner.on(" ").join(dnsHosts);
+    }
+
+    public String getVolumesString() {
+	return Joiner.on(" ").join(volumes);
     }
 
     public Descriptor<DockerTemplate> getDescriptor() {
@@ -237,6 +244,9 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         hostConfig.setPrivileged(this.privileged);
         if( dnsHosts.length > 0 )
             hostConfig.setDns(dnsHosts);
+
+        if (volumes.length > 0)
+            hostConfig.setBinds(volumes);
 
         dockerClient.container(container.getId()).start(hostConfig);
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
@@ -47,6 +47,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
     public final String instanceCapStr;
     public final String dnsString;
     public final String dockerCommand;
+    public final String volumesString;
     public final boolean privileged;
 
     @DataBoundConstructor
@@ -55,6 +56,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
                                               String prefixStartSlaveCmd, String suffixStartSlaveCmd,
                                               String instanceCapStr, String dnsString,
                                               String dockerCommand,
+                                              String volumesString,
                                               boolean privileged) {
 
         this.image = image;
@@ -68,6 +70,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
         this.instanceCapStr = instanceCapStr;
         this.dnsString = dnsString;
         this.dockerCommand = dockerCommand;
+        this.volumesString = volumesString;
         this.privileged = privileged;
     }
 
@@ -108,7 +111,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
                         jvmOptions, javaPath, prefixStartSlaveCmd,
                         suffixStartSlaveCmd, instanceCapStr,
                         dnsString, dockerCommand,
-                        privileged);
+                        volumesString, privileged);
                 ((DockerCloud) c).addTemplate(t);
             }
         }

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
@@ -40,6 +40,10 @@
             <f:textbox />
         </f:entry>
 
+        <f:entry title="${%Volumes}" field="volumesString">
+            <f:textbox/>
+        </f:entry>
+
         <f:entry title="${%Run container privileged}" field="privileged">
             <f:checkbox/>
         </f:entry>


### PR DESCRIPTION
I have added new text field on docker template form where you can put volume binds separated by space, for example:
/host/path:/container/path:ro
