### PR TITLE
Fix(?) for DockerTemplate volumes param

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.nirima</groupId>
     <artifactId>docker-plugin</artifactId>
-    <version>0.6</version>
+    <version>0.6.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Docker plugin</name>
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -114,7 +114,12 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         }
 
         this.dnsHosts = dnsString.split(" ");
-        this.volumes = volumesString.split(" ");
+		  //remove all empty volume entries
+		  List<String> temp = new ArrayList<String>();
+		  for(String vol:volumesString.split(" ")) {
+					 if(!vol.isEmpty()) temp.add(vol);
+		  }
+        this.volumes = temp.toArray(new String[temp.size()]);
 
         readResolve();
     }


### PR DESCRIPTION
Not 100% sure I know enough about the code to say for sure, but I _think_ I encountered an issue with the latest (0.6) release of the plugin regarding the "volumes" parameter that was introduced a few commits ago. Looks like the parsing of the "volumeString" parameter was somehow producing and array containing an empty string [" "], which the Docker API didn't like (see below). This code change seems to have fixe the issue that I was seeing tho' I wasn't able to verify whether the "volumes" feature was still working.

With docker-plugin-0.6 (Docker 1.0.0), seeing 500 on `POST` to `/containers/{id}/start`:

```
      Jun 16, 2014 1:53:59 AM org.glassfish.jersey.filter.LoggingFilter log
      INFO: 11 * Sending client request on thread Computer.threadPoolForRemoting [#3]
      11 > POST http://localhost:4243/containers/065824b714bb1865d4a293867b66d29aff164b93ff877a5b108199b0c0388014/start
      11 > Content-Type: application/json
      {"Binds":[""],"PortBindings":{"22/tcp":[{"HostIp":"0.0.0.0"}]},"Privileged":false,"Dns":[""]}

      Jun 16, 2014 1:53:59 AM org.glassfish.jersey.filter.LoggingFilter log
      INFO: 12 * Client response received on thread Computer.threadPoolForRemoting [#3]
      12 < 500
      12 < Content-Length: 87
      12 < Content-Type: text/plain; charset=utf-8
      12 < Date: Mon, 16 Jun 2014 01:53:59 GMT
      Could not create local directory '' for bind mount: mkdir : no such file or directory!
```

After this fix, getting 204 as expected:

```
      Jun 16, 2014 2:41:29 AM org.glassfish.jersey.filter.LoggingFilter log
      INFO: 3 * Sending client request on thread Computer.threadPoolForRemoting [#3]
      3 > POST http://localhost:4243/containers/9158b1c4d44cebc8c86deb04952cd66d852b27428aa28878c92a5b03804b1f60/start
      3 > Content-Type: application/json
      {"PortBindings":{"22/tcp":[{"HostIp":"0.0.0.0"}]},"Privileged":false,"Dns":[""]}

      Jun 16, 2014 2:41:30 AM org.glassfish.jersey.filter.LoggingFilter log
      INFO: 4 * Client response received on thread Computer.threadPoolForRemoting [#3]
      4 < 204
      4 < Content-Length: 0
      4 < Content-Type: text/plain; charset=utf-8
      4 < Date: Mon, 16 Jun 2014 02:41:30 GMT
```
