### PR TITLE
Adding a sleep time for the container to start its processes

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -36,7 +36,6 @@ import java.util.logging.Level;
 
 public class DockerTemplate implements Describable<DockerTemplate> {
     private static final Logger LOGGER = Logger.getLogger(DockerTemplate.class.getName());
-    private static final int CONTAINER_START_TIME = 2000;
 
     public final String image;
     public final String labelString;
@@ -51,6 +50,11 @@ public class DockerTemplate implements Describable<DockerTemplate> {
      * Field dockerCommand
      */
     public final String dockerCommand;
+
+    /**
+     * Field container start up time
+     */
+    public final int containerStartTime;
 
     /**
      * Field jvmOptions.
@@ -92,7 +96,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
                           String credentialsId, String jvmOptions, String javaPath,
                           String prefixStartSlaveCmd, String suffixStartSlaveCmd,
                           String instanceCapStr, String dnsString,
-                          String dockerCommand,
+                          String dockerCommand, String containerStartTime,
                           String volumesString,
                           String hostname,
                           boolean privileged
@@ -108,6 +112,11 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         this.remoteFs =  Strings.isNullOrEmpty(remoteFs)?"/home/jenkins":remoteFs;
 
         this.dockerCommand = dockerCommand;
+        if (containerStartTime.equals("")) {
+            this.containerStartTime = 0;
+        } else {
+            this.containerStartTime = Integer.parseInt(containerStartTime);
+        }
         this.privileged = privileged;
         this.hostname = hostname;
 
@@ -263,8 +272,8 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         dockerClient.container(container.getId()).start(hostConfig);
 
         // Give the container time to start up
-        LOGGER.log(Level.INFO, "Waiting for the container processes to start...");
-        Thread.sleep(CONTAINER_START_TIME);
+        LOGGER.log(Level.INFO, "Waiting " + containerStartTime + " seconds for container processes to start.");
+        Thread.sleep(containerStartTime * 1000);
 
         String containerId = container.getId();
 

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
@@ -44,6 +44,10 @@
             <f:textbox />
         </f:entry>
 
+        <f:entry title="${%Container Start Up Time}" field="containerStartTime">
+            <f:textbox />
+        </f:entry>
+
         <f:entry title="${%Volumes}" field="volumesString">
             <f:textbox/>
         </f:entry>


### PR DESCRIPTION
For https://github.com/jenkinsci/docker-plugin/issues/36

The first thing I tried to do was redo the connect step (https://github.com/jenkinsci/docker-plugin/blob/master/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java#L167) if it failed to connect, however this was creating more problems (and should probably be at the SlaveComputer level?) and even then wasn't connecting.  If someone else has an idea of where to retry connecting to the slave then I'll be more than happy to look into that though.
