### PR TITLE
Check if we have tried, pause if we have

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/utils/RetryingComputerLauncher.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/utils/RetryingComputerLauncher.java
@@ -16,14 +16,14 @@ public class RetryingComputerLauncher extends DelegatingComputerLauncher {
     private static final Logger log = LoggerFactory.getLogger(RetryingComputerLauncher.class);
 
     /**
-     * How many times to retry the launch?
-     */
-    private final int retries = 3;
-
-    /**
      * time (ms) to back off between retries?
      */
     private final int pause   = 5000;
+
+    /**
+     * Let us know when to pause the launch.
+     */
+    private boolean hasTried = false;
 
     public RetryingComputerLauncher(ComputerLauncher delegate) {
         super(delegate);
@@ -31,16 +31,11 @@ public class RetryingComputerLauncher extends DelegatingComputerLauncher {
 
     @Override
     public void launch(SlaveComputer computer, TaskListener listener) throws IOException, InterruptedException {
-
-        for( int i=0;i<retries;i++) {
-            try {
-                super.launch(computer, listener);
-                return;
-            } catch(Exception ex) {
-                log.info("Launch failed on attempt {}", i);
-            }
+        if (hasTried) {
+            log.info("Launch failed, pausing before retry.");
             Thread.sleep(pause);
         }
-        throw new IOException("SSH Launch failed");
+        super.launch(computer, listener);
+        hasTried = true;
     }
 }


### PR DESCRIPTION
For https://github.com/jenkinsci/docker-plugin/issues/36

The launch in the SSH Launcher is catching everything (https://github.com/jenkinsci/ssh-slaves-plugin/blob/master/src/main/java/hudson/plugins/sshslaves/SSHLauncher.java#L667) so we aren't actually able to catch anything ourselves here.  However, it does appear that /somewhere/ there is logic for the ssh launch to retry.  From what I observed, it doesn't always do this and I didn't see any sort of thing in the SSH Launcher, so I guess it might be somewhere related to when Jenkins is actually creating the job.  But anyways, it does appear to keep the same instance of the object when it does retry the launch, so I was able to just create a flag to check if we have tried previously or not.
