### PR TITLE
Proper parsing of empty dnsHosts string

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -116,15 +116,21 @@ public class DockerTemplate implements Describable<DockerTemplate> {
             this.instanceCap = Integer.parseInt(instanceCapStr);
         }
 
-        this.dnsHosts = dnsString.split(" ");
-		  //remove all empty volume entries
-		  List<String> temp = new ArrayList<String>();
-		  for(String vol:volumesString.split(" ")) {
-					 if(!vol.isEmpty()) temp.add(vol);
-		  }
-        this.volumes = temp.toArray(new String[temp.size()]);
+        this.dnsHosts = splitAndFilterEmpty(dnsString);
+        this.volumes = splitAndFilterEmpty(volumesString);
 
         readResolve();
+    }
+
+    private String[] splitAndFilterEmpty(String s) {
+        List<String> temp = new ArrayList<String>();
+        for (String item : s.split(" ")) {
+            if (!item.isEmpty())
+                temp.add(item);
+        }
+
+        return temp.toArray(new String[temp.size()]);
+
     }
 
     public String getInstanceCapStr() {

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
@@ -1,0 +1,35 @@
+package com.nirima.jenkins.plugins.docker;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DockerTemplateTest {
+
+    private DockerTemplate getDockerTemplateInstanceWithDNSHost(String dnsString) {
+        DockerTemplate instance = new DockerTemplate("image", null, "remoteFs", "credentialsId", " jvmOptions", " javaPath", "prefixStartSlaveCmd", " suffixStartSlaveCmd", "", dnsString, "dockerCommand", "volumes", "hostname", false);
+        return instance;
+    }
+
+    @Test
+    public void testDnsHosts() {
+        DockerTemplate instance;
+        String[] expected;
+
+        instance = getDockerTemplateInstanceWithDNSHost("");
+        assertEquals(0, instance.dnsHosts.length);
+
+        instance = getDockerTemplateInstanceWithDNSHost("8.8.8.8");
+        expected = new String[]{"8.8.8.8"};
+
+        assertEquals(1, instance.dnsHosts.length);
+        assertArrayEquals(expected, instance.dnsHosts);
+
+        instance = getDockerTemplateInstanceWithDNSHost("8.8.8.8 8.8.4.4");
+        expected = new String[]{"8.8.8.8", "8.8.4.4"};
+
+        assertEquals(2, instance.dnsHosts.length);
+        assertArrayEquals(expected, instance.dnsHosts);
+
+    }
+
+}


### PR DESCRIPTION
When DNS hosts are empty, plugin sends DNS override to docker container
("Dns":[""]).  With this patch, correctly declines to override dns when
the cloud configuration does not ask for it.
