### PR TITLE
Pull image if none

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -25,6 +25,7 @@ import org.kohsuke.stapler.QueryParameter;
 import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -244,8 +245,14 @@ public class DockerCloud extends Cloud {
         LOGGER.log(Level.INFO, "Images found: " + images);
 
         if (images.size() == 0) {
-            LOGGER.log(Level.INFO, "Pulling image " + ami + " since one was not found.");
-            dockerClient.createPullCommand().image(ami).withTag("latest").execute();
+            LOGGER.log(Level.INFO, "Pulling image " + ami + " since one was not found.  This may take awhile...");
+            InputStream imageStream = dockerClient.createPullCommand().image(ami).withTag("latest").execute();
+            int streamValue = 0;
+            while (streamValue != -1) {
+                streamValue = imageStream.read();
+            }
+            imageStream.close();
+            LOGGER.log(Level.INFO, "Finished pulling image " + ami);
         }
 
         final ImageInspectResponse ir = dockerClient.image(ami).inspect();


### PR DESCRIPTION
This makes the docker plugin run more like the `docker run` command itself works.  If the image is not found, then we pull it.
