### PR TITLE
Add timeout for a slave that gets provisioned but then has no work

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -52,6 +52,11 @@ public class DockerTemplate implements Describable<DockerTemplate> {
     public final String dockerCommand;
 
     /**
+     * Minutes before terminating an idle slave
+     */
+    public final String idleTerminationMinutes;
+
+    /**
      * Field jvmOptions.
      */
     public final String jvmOptions;
@@ -89,7 +94,8 @@ public class DockerTemplate implements Describable<DockerTemplate> {
     @DataBoundConstructor
     public DockerTemplate(String image, String labelString,
                           String remoteFs,
-                          String credentialsId, String jvmOptions, String javaPath,
+                          String credentialsId, String idleTerminationMinutes,
+                          String jvmOptions, String javaPath,
                           String prefixStartSlaveCmd, String suffixStartSlaveCmd,
                           String instanceCapStr, String dnsString,
                           String dockerCommand,
@@ -101,6 +107,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         this.image = image;
         this.labelString = Util.fixNull(labelString);
         this.credentialsId = credentialsId;
+        this.idleTerminationMinutes = idleTerminationMinutes;
         this.jvmOptions = jvmOptions;
         this.javaPath = javaPath;
         this.prefixStartSlaveCmd = prefixStartSlaveCmd;
@@ -189,7 +196,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         Node.Mode mode = Node.Mode.EXCLUSIVE;
 
 
-        RetentionStrategy retentionStrategy = new DockerRetentionStrategy();
+        RetentionStrategy retentionStrategy = new DockerRetentionStrategy(idleTerminationMinutes);
 
         List<? extends NodeProperty<?>> nodeProperties = new ArrayList();
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
@@ -40,6 +40,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
     public final String labelString;
     public final String remoteFs;
     public final String credentialsId;
+    public final String idleTerminationMinutes;
     public final String jvmOptions;
     public final String javaPath;
     public final String prefixStartSlaveCmd;
@@ -54,7 +55,8 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
 
     @DataBoundConstructor
     public DockerBuilderNewTemplate(String image, String labelString, String remoteFs,
-                                              String credentialsId, String jvmOptions, String javaPath,
+                                              String credentialsId, String idleTerminationMinutes,
+                                              String jvmOptions, String javaPath,
                                               String prefixStartSlaveCmd, String suffixStartSlaveCmd,
                                               String instanceCapStr, String dnsString,
                                               String dockerCommand,
@@ -66,6 +68,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
         this.labelString = labelString;
         this.remoteFs = remoteFs;
         this.credentialsId = credentialsId;
+        this.idleTerminationMinutes = idleTerminationMinutes;
         this.jvmOptions = jvmOptions;
         this.javaPath = javaPath;
         this.prefixStartSlaveCmd = prefixStartSlaveCmd;
@@ -112,8 +115,10 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
         for (Cloud c : Jenkins.getInstance().clouds) {
             if (c instanceof DockerCloud && ((DockerCloud) c).getTemplate(image) == null) {
                 LOGGER.log(Level.INFO, "Adding new template « "+image+" » to cloud " + ((DockerCloud) c).name);
-                DockerTemplate t = new DockerTemplate(image, labelString, remoteFs, credentialsId,
-                        jvmOptions, javaPath, prefixStartSlaveCmd,
+                DockerTemplate t = new DockerTemplate(image, labelString, remoteFs,
+                        credentialsId, idleTerminationMinutes,
+                        jvmOptions, javaPath,
+                        prefixStartSlaveCmd,
                         suffixStartSlaveCmd, instanceCapStr,
                         dnsString, dockerCommand,
                         volumesString, volumesFrom, hostname, privileged);

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
@@ -32,6 +32,10 @@
 
         <f:advanced>
 
+            <f:entry title="${%Idle termination time}" field="idleTerminationMinutes">
+                <f:textbox default="5" />
+            </f:entry>
+
             <f:entry title="${%JavaPath}" field="javaPath">
                 <f:textbox/>
             </f:entry>

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
@@ -2,11 +2,12 @@ package com.nirima.jenkins.plugins.docker;
 
 import org.junit.Test;
 import static org.junit.Assert.*;
+import hudson.model.Node;
 
 public class DockerTemplateTest {
 
     private DockerTemplate getDockerTemplateInstanceWithDNSHost(String dnsString) {
-        DockerTemplate instance = new DockerTemplate("image", null, "remoteFs", "credentialsId", " jvmOptions", " javaPath", "prefixStartSlaveCmd", " suffixStartSlaveCmd", "", dnsString, "dockerCommand", "volumes", "hostname", false);
+        DockerTemplate instance = new DockerTemplate("image", null, "remoteFs", "credentialsId", "idleTerminationMinutes", " jvmOptions", " javaPath", "prefixStartSlaveCmd", " suffixStartSlaveCmd", "", dnsString, "dockerCommand", "volumes", "volumesFrom", "hostname", false);
         return instance;
     }
 


### PR DESCRIPTION
Resolves effect of #54

Also fix DockerTemplateTest
This was broken before by #46, but also needed to be updated for my changes

This pull request partially supersedes #59 (I broke the two fixes in two).
