### PR TITLE
Fix a discrepancy with untied jobs

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -186,7 +186,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         logger.println("Launching " + image );
 
         int numExecutors = 1;
-        Node.Mode mode = Node.Mode.EXCLUSIVE;
+        Node.Mode mode = Node.Mode.NORMAL;
 
 
         RetentionStrategy retentionStrategy = new DockerRetentionStrategy();


### PR DESCRIPTION
The plugin advertised supporting untied jobs but then all slaves were EXCLUSIVE

Fixes the root cause of #54

This pull request partially supersedes #59 (I broke the two fixes in two).
