### PR TITLE
Added mapped remote filesystem support for workspace browsing.

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -192,7 +192,7 @@ public class DockerSlave extends AbstractCloudSlave {
      * @throws IOException
      */
     private void addJenkinsAction(String tag_image) throws IOException {
-        theRun.addAction( new DockerBuildAction(getCloud().serverUrl, containerId, tag_image) );
+        theRun.addAction( new DockerBuildAction(getCloud().serverUrl, containerId, tag_image, dockerTemplate.remoteFsMapping) );
         theRun.save();
     }
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -81,6 +81,10 @@ public class DockerTemplate implements Describable<DockerTemplate> {
      */
     public final String suffixStartSlaveCmd;
 
+    /**
+     *  Field remoteFSMapping.
+     */
+    public final String remoteFsMapping;
 
     public final String remoteFs; // = "/home/jenkins";
 
@@ -99,6 +103,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
     @DataBoundConstructor
     public DockerTemplate(String image, String labelString,
                           String remoteFs,
+                          String remoteFsMapping,
                           String credentialsId, String idleTerminationMinutes,
                           String jvmOptions, String javaPath,
                           String prefixStartSlaveCmd, String suffixStartSlaveCmd,
@@ -119,6 +124,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         this.prefixStartSlaveCmd = prefixStartSlaveCmd;
         this.suffixStartSlaveCmd = suffixStartSlaveCmd;
         this.remoteFs =  Strings.isNullOrEmpty(remoteFs)?"/home/jenkins":remoteFs;
+        this.remoteFsMapping = remoteFsMapping;
 
         this.dockerCommand = dockerCommand;
         this.lxcConfString = lxcConfString;
@@ -167,6 +173,10 @@ public class DockerTemplate implements Describable<DockerTemplate> {
 
     public String getVolumesFrom() {
         return volumesFrom;
+    }
+
+    public String getRemoteFsMapping() {
+        return remoteFsMapping;
     }
 
     public Descriptor<DockerTemplate> getDescriptor() {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildAction.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildAction.java
@@ -21,10 +21,13 @@ public class DockerBuildAction implements Action, Serializable, Cloneable, Descr
 
     public final String taggedId;
 
-    public DockerBuildAction(String containerHost, String containerId, String taggedId) {
+    public final String remoteFsMapping;
+
+    public DockerBuildAction(String containerHost, String containerId, String taggedId, String remoteFsMapping) {
         this.containerHost = containerHost;
         this.containerId = containerId;
         this.taggedId = taggedId;
+        this.remoteFsMapping = remoteFsMapping;
     }
 
     public String getIconFileName() {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
@@ -38,6 +38,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
 
     public final String image;
     public final String labelString;
+    public final String remoteFsMapping;
     public final String remoteFs;
     public final String credentialsId;
     public final String idleTerminationMinutes;
@@ -55,7 +56,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
     public final String hostname;
 
     @DataBoundConstructor
-    public DockerBuilderNewTemplate(String image, String labelString, String remoteFs,
+    public DockerBuilderNewTemplate(String image, String labelString, String remoteFs, String remoteFsMapping,
                                               String credentialsId, String idleTerminationMinutes,
                                               String jvmOptions, String javaPath,
                                               String prefixStartSlaveCmd, String suffixStartSlaveCmd,
@@ -69,6 +70,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
         this.image = image;
         this.labelString = labelString;
         this.remoteFs = remoteFs;
+        this.remoteFsMapping = remoteFsMapping;
         this.credentialsId = credentialsId;
         this.idleTerminationMinutes = idleTerminationMinutes;
         this.jvmOptions = jvmOptions;
@@ -118,7 +120,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
         for (Cloud c : Jenkins.getInstance().clouds) {
             if (c instanceof DockerCloud && ((DockerCloud) c).getTemplate(image) == null) {
                 LOGGER.log(Level.INFO, "Adding new template « "+image+" » to cloud " + ((DockerCloud) c).name);
-                DockerTemplate t = new DockerTemplate(image, labelString, remoteFs,
+                DockerTemplate t = new DockerTemplate(image, labelString, remoteFs, remoteFsMapping, 
                         credentialsId, idleTerminationMinutes,
                         jvmOptions, javaPath,
                         prefixStartSlaveCmd,

--- a/src/main/java/com/nirma/jenkins/plugins/docker/ws/MappedFsWorkspaceBrowser.java
+++ b/src/main/java/com/nirma/jenkins/plugins/docker/ws/MappedFsWorkspaceBrowser.java
@@ -1,0 +1,40 @@
+package com.nirma.jenkins.plugins.docker.ws;
+
+import com.google.common.base.Strings;
+import com.nirima.jenkins.plugins.docker.DockerJobProperty;
+import com.nirima.jenkins.plugins.docker.action.DockerBuildAction;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.model.AbstractBuild;
+import hudson.model.Job;
+import hudson.model.WorkspaceBrowser;
+import java.io.File;
+import java.util.logging.Logger;
+
+
+@Extension
+public class MappedFsWorkspaceBrowser extends WorkspaceBrowser  {
+
+    private static final Logger LOGGER = Logger.getLogger(MappedFsWorkspaceBrowser.class.getName());
+
+    public MappedFsWorkspaceBrowser() {
+        LOGGER.info(this.getClass().getName() + " initializing.");
+    }
+
+    @Override
+    public FilePath getWorkspace(Job job) {
+
+        DockerBuildAction a = (DockerBuildAction) job.getLastBuild().getAction(DockerBuildAction.class);
+
+        if (a!= null) {
+            if (! Strings.isNullOrEmpty(a.remoteFsMapping)) {
+                File mappedRemoteWorkspace = new File(a.remoteFsMapping);
+                mappedRemoteWorkspace = new File(mappedRemoteWorkspace, "workspace");
+                mappedRemoteWorkspace = new File(mappedRemoteWorkspace, job.getName());
+                return new FilePath(mappedRemoteWorkspace);
+            }
+        }
+        return null;
+
+    }
+}

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
@@ -18,6 +18,10 @@
             <f:textbox/>
         </f:entry>
 
+       <f:entry title="${%Remote FS Root Mapping}" field="remoteFsMapping">
+           <f:textbox/>
+       </f:entry>
+
         <f:entry title="${%Instance Cap}" field="instanceCapStr">
             <f:textbox/>
         </f:entry>

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
@@ -7,7 +7,7 @@ import hudson.model.Node;
 public class DockerTemplateTest {
 
     private DockerTemplate getDockerTemplateInstanceWithDNSHost(String dnsString) {
-        DockerTemplate instance = new DockerTemplate("image", null, "remoteFs", "credentialsId", "idleTerminationMinutes", " jvmOptions", " javaPath", "prefixStartSlaveCmd", " suffixStartSlaveCmd", "", dnsString, "dockerCommand", "volumes", "volumesFrom", "lxcConf", "hostname", false);
+        DockerTemplate instance = new DockerTemplate("image", null, "remoteFs", "remoteFsMapping", "credentialsId", "idleTerminationMinutes", " jvmOptions", " javaPath", "prefixStartSlaveCmd", " suffixStartSlaveCmd", "", dnsString, "dockerCommand", "volumes", "volumesFrom", "lxcConf", "hostname", false);
         return instance;
     }
 


### PR DESCRIPTION
This pull request adds capabilty to browse workspaces of jobs being built using docker containers whose workspace is available on master node (via mapped volumes, network shares, etc.).

User just need to specify in image template the directory on master node where the container remote FS is mapped.
