### PR TITLE
Fixing Option "Provision and Start Container"

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionProvisionAndStart.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionProvisionAndStart.java
@@ -32,7 +32,7 @@ public class DockerBuilderControlOptionProvisionAndStart extends DockerBuilderCo
 
         LOGGER.info("Starting container " + containerId);
         DockerClient client = getClient(build);
-        client.container(containerId).start();
+        
         getLaunchAction(build).started(client, containerId);
     }
 


### PR DESCRIPTION
I discovered this little bug in this option of the start container step. Is it correct, that this option should not launch an ssh-connection and a slave?

What about an option to also wrap a DockerComputer around the container invocation?
