### PR TITLE
add options to push container on unstable/failed builds

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
@@ -24,17 +24,22 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
     public final boolean tagOnCompletion;
     public final String additionalTag;
     public final boolean pushOnSuccess;
+    public final boolean pushOnUnstable;
+    public final boolean pushOnFailure;
     public final boolean cleanImages;
 
     @DataBoundConstructor
     public DockerJobProperty(
             boolean tagOnCompletion,
             String additionalTag,
-            boolean pushOnSuccess, boolean cleanImages)
+            boolean pushOnSuccess, boolean pushOnUnstable,
+            boolean pushOnFailure, boolean cleanImages)
     {
         this.tagOnCompletion = tagOnCompletion;
         this.additionalTag = additionalTag;
         this.pushOnSuccess = pushOnSuccess;
+        this.pushOnUnstable = pushOnUnstable;
+        this.pushOnFailure = pushOnFailure;
         this.cleanImages = cleanImages;
     }
 
@@ -46,6 +51,14 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
     @Exported
     public boolean isPushOnSuccess() {
         return pushOnSuccess;
+    }
+
+    @Exported
+    public boolean isPushOnUnstable() { return pushOnUnstable; }
+
+    @Exported
+    public boolean isPushOnFailure() {
+        return pushOnFailure;
     }
 
     @Exported
@@ -75,6 +88,8 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
                     (Boolean)formData.get("tagOnCompletion"),
                     (String)formData.get("additionalTag"),
                     (Boolean)formData.get("pushOnSuccess"),
+                    (Boolean)formData.get("pushOnUnstable"),
+                    (Boolean)formData.get("pushOnFailure"),
                     (Boolean)formData.get("cleanImages"));
         }
     }

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/config.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:section title="Docker Container">
-        <f:entry title="${%Commit on successful build}" field="tagOnCompletion">
+        <f:entry title="${%Commit on completed build}" field="tagOnCompletion">
             <f:checkbox default="false"/>
         </f:entry>
 
@@ -11,6 +11,14 @@
         </f:entry>
 
         <f:entry title="${%Push on successful build}" field="pushOnSuccess">
+            <f:checkbox/>
+        </f:entry>
+
+        <f:entry title="${%Push on unstable build}" field="pushOnUnstable">
+            <f:checkbox/>
+        </f:entry>
+
+        <f:entry title="${%Push on failed build}" field="pushOnFailure">
             <f:checkbox/>
         </f:entry>
 


### PR DESCRIPTION
Add two options to push the container at the end of a build in case the build is unstable or the build fails.
This changes the original behavior, the original push if successful check box triggered a push even if the build failed.

I use these new flags to store the builds for inspection on our private docker registry in case of test or build failures.

This merge request implements #91.