### PR TITLE
Fix a race that may cause commit and push to fail

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerComputer.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerComputer.java
@@ -31,9 +31,10 @@ public class DockerComputer extends AbstractCloudComputer<DockerSlave> {
 
     @Override
     public void taskCompleted(Executor executor, Queue.Task task, long durationMS) {
-        super.taskCompleted(executor, task, durationMS);
-
         Queue.Executable executable = executor.getCurrentExecutable();
+
+        LOGGER.log(Level.FINE, " Computer " + this + " taskCompleted");
+
         if( executable instanceof Run) {
             Run build = (Run) executable;
             DockerSlave slave = getNode();
@@ -43,10 +44,11 @@ public class DockerComputer extends AbstractCloudComputer<DockerSlave> {
             } else {
                 slave.setRun(build);
             }
-
         }
-        LOGGER.log(Level.FINE, " Computer " + this + " taskCompleted");
 
+        // May take the slave offline and remove it, in which case getNode()
+        // above would return null and we'd not find our DockerSlave anymore.
+        super.taskCompleted(executor, task, durationMS);
     }
 
 


### PR DESCRIPTION
Defer the super.taskCompleted() call on DockerComputer until we told the
Docker slave node which build it has run last.  The DockerSlave needs
that link to the latest build in order to decide whether it should tag
and push the container.  However, if super.taskCompleted() is called too
early then the slave will already have been taken offline, the node will
have been deleted and slaveShutdown() will never be called.
