### PR TITLE
Fixes issue#77: "Docker Cloud name" parameter will be stored

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStart.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStart.java
@@ -12,8 +12,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class DockerBuilderControlOptionStart extends DockerBuilderControlOptionStopStart {
 
     @DataBoundConstructor
-    public DockerBuilderControlOptionStart(String cloudId, String containerId) {
-        super(cloudId, containerId);
+    public DockerBuilderControlOptionStart(String cloudName, String containerId) {
+        super(cloudName, containerId);
     }
 
     @Override

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStop.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStop.java
@@ -14,8 +14,8 @@ public class DockerBuilderControlOptionStop extends DockerBuilderControlOptionSt
     public final boolean remove;
 
     @DataBoundConstructor
-    public DockerBuilderControlOptionStop(String cloudId, String containerId, boolean remove) {
-        super(cloudId, containerId);
+    public DockerBuilderControlOptionStop(String cloudName, String containerId, boolean remove) {
+        super(cloudName, containerId);
         this.remove = remove;
     }
 


### PR DESCRIPTION
Fixes: #77 The parameter names in the constructor did not match the field names in the jelly templates
