### PR TITLE
Adding HostConfig to ContainerConfig to fix Bind Volumes

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -169,6 +169,10 @@ public abstract class DockerTemplateBase {
         if(environment != null && environment.length > 0)
             containerConfig.setEnv(environment);
 
+        HostConfig hostConfig = createHostConfig();
+
+        containerConfig.setHostConfig(hostConfig);
+
         return containerConfig;
     }
 


### PR DESCRIPTION
as to the docker API documentation (1.16) the HostConfig part of the create container call  is used to setup a container with bind volumes (binding a host dir to a container dir). As of now the HostConfig is only passed into the start container call (in which it get discarded in docker 1.4).

this needs https://github.com/nirima/jDocker/pull/5