### PR TITLE
Split lxc-conf field on comma instead of space

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -209,7 +209,7 @@ public abstract class DockerTemplateBase {
         List<HostConfig.LxcConf> temp = new ArrayList<HostConfig.LxcConf>();
         if( lxcConfString == null )
             return temp;
-        for (String item : lxcConfString.split(" ")) {
+        for (String item : lxcConfString.split(",")) {
             String[] keyValuePairs = item.split("=");
             if (keyValuePairs.length == 2 )
             {


### PR DESCRIPTION
Splitting on space causes issues with config options such as: lxc.cgroup.devices.allow=c 10:229 rwm
which is needed to allow FUSE mounts inside the containers