### PR TITLE
Fix trying to parse empty lxcConfString

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -207,7 +207,7 @@ public abstract class DockerTemplateBase {
 
     protected List<HostConfig.LxcConf> getLxcConf(HostConfig hostConfig) {
         List<HostConfig.LxcConf> temp = new ArrayList<HostConfig.LxcConf>();
-        if( lxcConfString == null )
+        if( lxcConfString == null || lxcConfString.trim().equals("") )
             return temp;
         for (String item : lxcConfString.split(" ")) {
             String[] keyValuePairs = item.split("=");


### PR DESCRIPTION
This resulted in logging a warning whenever a container was started