### PR TITLE
[JENKINS-26514] Lock Queue before calling Jenkins.addNode()

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -163,7 +163,11 @@ public class DockerCloud extends Cloud {
                                 DockerSlave slave = null;
                                 try {
                                     slave = t.provision(new StreamTaskListener(System.out));
-                                    Jenkins.getInstance().addNode(slave);
+                                    final Jenkins jenkins = Jenkins.getInstance();
+                                    // TODO once the baseline is 1.592+ switch to Queue.withLock
+                                    synchronized (jenkins.getQueue()) {
+                                        jenkins.addNode(slave);
+                                    }
                                     // Docker instances may have a long init script. If we declare
                                     // the provisioning complete by returning without the connect
                                     // operation, NodeProvisioner may decide that it still wants


### PR DESCRIPTION
As described in JENKINS-26514, a deadlock can occur if the Docker plugin adds a node at the same time as a CloudRetentionStrategy.check() is performed. This is a similar change to part of the change here: https://github.com/jenkinsci/durable-task-plugin/commit/cce88cad22f78997d6a7b839fb3f2f75b4ce94c9, where the DockerCloud ensures that the Queue is locked before calling a synchronized method on the Jenkins instance.