### PR TITLE
Temp fix tag issue.

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
@@ -8,12 +8,15 @@ import hudson.model.Descriptor;
 import hudson.model.Job;
 import hudson.model.JobPropertyDescriptor;
 import hudson.tasks.Publisher;
+import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 
 public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<?, ?>> {
@@ -60,6 +63,19 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
 
     @Extension
     public static final class DescriptorImpl extends JobPropertyDescriptor {
+        public FormValidation doCheckAdditionalTag(@QueryParameter String additionalTag){
+            if (additionalTag.trim().length() == 0){
+                return FormValidation.ok(); // skip zero value
+            }
+            // Exclude 500 error during commit
+            if ((additionalTag.length() < 2) || (additionalTag.length() > 30) ||
+                    (!additionalTag.matches("[a-zA-Z_][a-zA-Z0-9_]*"))){
+                return FormValidation.error("Illegal tag name: only [a-zA-Z_][a-zA-Z0-9_]* are allowed, " +
+                        "minimum 2, maximum 30 in length");
+            }
+            return FormValidation.ok();
+        }
+
         public String getDisplayName() {
             return "Docker Job Properties";
         }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -126,7 +126,7 @@ public class DockerSlave extends AbstractCloudSlave {
          // Commit
         String tag_image = client.commitCmd(containerId)
                     .withRepository(theRun.getParent().getDisplayName())
-                    .withTag(theRun.getDisplayName())
+                    .withTag(theRun.getDisplayName().replace("#","b")) // allowed only ([a-zA-Z_][a-zA-Z0-9_]*)
                     .withAuthor("Jenkins")
                     .exec();
 


### PR DESCRIPTION
In general docker sources has different regexp for tag in different places. This fixes docker commit because display name contains ```#1``` also `#` can't be cut because tag must contain at least 2 letters. 
Fix was tested on jDocker library. 