### PR TITLE
Use public methods in DockerTemplate to allow reuse

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -217,7 +217,7 @@ public class DockerTemplate extends DockerTemplateBase implements Describable<Do
         return parent;
     }
 
-    private int idleTerminationMinutes() {
+    public int idleTerminationMinutes() {
         if (idleTerminationMinutes == null || idleTerminationMinutes.trim().isEmpty()) {
             return 0;
         } else {
@@ -286,11 +286,11 @@ public class DockerTemplate extends DockerTemplateBase implements Describable<Do
     }
 
     @Override
-    protected String[] getDockerCommandArray() {
+    public String[] getDockerCommandArray() {
         String[] cmd = super.getDockerCommandArray();
 
         if( cmd.length == 0 ) {
-            //default value to preserve comptability
+            //default value to preserve compatibility
             cmd = new String[]{"/usr/sbin/sshd", "-D"};
         }
 
@@ -302,7 +302,7 @@ public class DockerTemplate extends DockerTemplateBase implements Describable<Do
      * Provide a sensible default - templates are for slaves, and you're mostly going
      * to want port 22 exposed.
      */
-    protected Iterable<PortBinding> getPortMappings() {
+    public Iterable<PortBinding> getPortMappings() {
 
         if(Strings.isNullOrEmpty(bindPorts) ) {
              return ImmutableList.<PortBinding>builder()

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -144,17 +144,6 @@ public class DockerTemplate extends DockerTemplateBase implements Describable<Do
         readResolve();
     }
 
-    private String[] splitAndFilterEmpty(String s) {
-        List<String> temp = new ArrayList<String>();
-        for (String item : s.split(" ")) {
-            if (!item.isEmpty())
-                temp.add(item);
-        }
-
-        return temp.toArray(new String[temp.size()]);
-
-    }
-
     public String getInstanceCapStr() {
         if (instanceCap==Integer.MAX_VALUE) {
             return "";

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -86,17 +86,10 @@ public abstract class DockerTemplateBase {
         return this;
     }
 
-    private String[] splitAndFilterEmpty(String s) {
-        List<String> temp = new ArrayList<String>();
-        for (String item : s.split(" ")) {
-            if (!item.isEmpty())
-                temp.add(item);
-        }
-
-        return temp.toArray(new String[temp.size()]);
-
+    public String[] splitAndFilterEmpty(String s) {
+        List<String> list = Splitter.on(' ').omitEmptyStrings().splitToList(s);
+        return list.toArray(new String[0]);
     }
-
 
     public String getDnsString() {
         return Joiner.on(" ").join(dnsHosts);

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -5,9 +5,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterables;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.DockerException;
 import com.github.dockerjava.api.command.CreateContainerCmd;
@@ -136,7 +134,7 @@ public abstract class DockerTemplateBase {
 
     }
 
-    protected String[] getDockerCommandArray() {
+    public String[] getDockerCommandArray() {
          String[] dockerCommandArray = new String[0];
 
         if(dockerCommand != null && !dockerCommand.isEmpty()){
@@ -145,7 +143,7 @@ public abstract class DockerTemplateBase {
         return dockerCommandArray;
     }
 
-    protected Iterable<PortBinding> getPortMappings() {
+    public Iterable<PortBinding> getPortMappings() {
 
         if(Strings.isNullOrEmpty(bindPorts) ) {
             return Collections.EMPTY_LIST;
@@ -224,7 +222,7 @@ public abstract class DockerTemplateBase {
     }
 
 
-    protected List<LxcConf> getLxcConf() {
+    public List<LxcConf> getLxcConf() {
         List<LxcConf> temp = new ArrayList<LxcConf>();
         if( lxcConfString == null || lxcConfString.trim().equals(""))
             return temp;


### PR DESCRIPTION
I'm reusing the DockerTemplate for the [Kubernetes plugin](https://github.com/carlossg/jenkins-kubernetes-plugin) and it would be nice to have access to the methods that are now set as protected