### PR TITLE
Lock guava version to the version used in Jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,17 @@
         </dependency>
     </dependencies>
 
+    <!-- lock dependencies to versions included in Jenkins -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>11.0.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -87,8 +87,11 @@ public abstract class DockerTemplateBase {
     }
 
     public String[] splitAndFilterEmpty(String s) {
-        List<String> list = Splitter.on(' ').omitEmptyStrings().splitToList(s);
-        return list.toArray(new String[0]);
+        List<String> temp = new ArrayList<String>();
+        for (String item : Splitter.on(' ').omitEmptyStrings().split(s)) {
+            temp.add(item);
+        }
+        return temp.toArray(new String[temp.size()]);
     }
 
     public String getDnsString() {


### PR DESCRIPTION
To avoid runtime NoSuchMethodError
If newer guava is needed then would need to use the pluginFirstClassLoader

Fix compilation error in older guava

This doesn't fix the bigger issue, com.nirima.docker-java:docker-java depends on that newer version of guava. If they use some new methods then the only option is to use `pluginFirstClassLoader`
