### PR TITLE
Support allocating a pseudo-TTY

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,11 @@
 
 
     <dependencies>
+        <dependency> <!-- Overwrites transitive dependency, otherwise fails with java.lang.ClassNotFoundException: org.apache.http.config.Lookup-->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.6</version>
+        </dependency>
         <dependency>
             <groupId>com.nirima.docker-java</groupId>
             <artifactId>docker-java</artifactId>

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate.java
@@ -19,7 +19,8 @@ public class DockerSimpleTemplate extends DockerTemplateBase implements Describa
                                 String hostname,
                                 String bindPorts,
                                 boolean bindAllPorts,
-                                boolean privileged) {
+                                boolean privileged,
+                                boolean tty) {
         super(image,
                 dnsString,
                 dockerCommand,
@@ -30,7 +31,8 @@ public class DockerSimpleTemplate extends DockerTemplateBase implements Describa
                 hostname,
                 bindPorts,
                 bindAllPorts,
-                privileged);
+                privileged,
+                tty);
     }
 
     public Descriptor<DockerSimpleTemplate> getDescriptor() {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -116,12 +116,13 @@ public class DockerTemplate extends DockerTemplateBase implements Describable<Do
                           String hostname,
                           String bindPorts,
                           boolean bindAllPorts,
-                          boolean privileged
+                          boolean privileged,
+                          boolean tty
 
     ) {
         super(image, dnsString,dockerCommand,volumesString,volumesFrom,environmentsString,lxcConfString,hostname,
                 Objects.firstNonNull(bindPorts, "0.0.0.0:22"), bindAllPorts,
-                privileged);
+                privileged, tty);
 
 
         this.labelString = Util.fixNull(labelString);

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -53,6 +53,7 @@ public abstract class DockerTemplateBase {
     public final boolean bindAllPorts;
 
     public final boolean privileged;
+    public final boolean tty;
 
     public DockerTemplateBase(String image,
                           String dnsString,
@@ -63,7 +64,8 @@ public abstract class DockerTemplateBase {
                           String hostname,
                           String bindPorts,
                           boolean bindAllPorts,
-                          boolean privileged
+                          boolean privileged,
+                          boolean tty
 
     ) {
         this.image = image;
@@ -71,6 +73,7 @@ public abstract class DockerTemplateBase {
         this.dockerCommand = dockerCommand;
         this.lxcConfString = lxcConfString;
         this.privileged = privileged;
+        this.tty = tty;
         this.hostname = hostname;
 
         this.bindPorts    = bindPorts;
@@ -174,6 +177,7 @@ public abstract class DockerTemplateBase {
             containerConfig.withDns(dnsHosts);
         if( volumesFrom != null && !volumesFrom.isEmpty() )
             containerConfig.withVolumesFrom(VolumesFrom.parse(volumesFrom));
+        containerConfig.withTty(this.tty);
 	if(environment != null && environment.length > 0)
             containerConfig.withEnv(environment);
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
@@ -31,6 +31,7 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
     public final String environmentsString;
     public final String lxcConfString;
     public final boolean privileged;
+    public final boolean tty;
     public final String hostname;
     public final String bindPorts;
     public final boolean bindAllPorts;
@@ -46,7 +47,8 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
             String hostname,
             String bindPorts,
             boolean bindAllPorts,
-            boolean privileged) {
+            boolean privileged,
+            boolean tty) {
         super(cloudName);
         this.image = image;
 
@@ -57,6 +59,7 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
         this.volumesFrom = volumesFrom;
         this.environmentsString = environmentsString;
         this.privileged = privileged;
+        this.tty = tty;
         this.hostname = hostname;
         this.bindPorts = bindPorts;
         this.bindAllPorts = bindAllPorts;
@@ -85,7 +88,7 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
 
         DockerTemplateBase template = new DockerSimpleTemplate(xImage,
                 dnsString, xCommand,
-                volumesString, volumesFrom, environmentsString, lxcConfString, xHostname, bindPorts, bindAllPorts, privileged);
+                volumesString, volumesFrom, environmentsString, lxcConfString, xHostname, bindPorts, bindAllPorts, privileged, tty);
 
         String containerId = template.provisionNew(client).getId();
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
@@ -57,6 +57,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
     public final String bindPorts;
     public final boolean bindAllPorts;
     public final boolean privileged;
+    public final boolean tty;
     public final String hostname;
 
     @DataBoundConstructor
@@ -73,7 +74,8 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
                                               String hostname,
                                               String bindPorts,
                                               boolean bindAllPorts,
-                                              boolean privileged) {
+                                              boolean privileged,
+                                              boolean tty) {
 
         this.image = image;
         this.labelString = labelString;
@@ -96,6 +98,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
         this.bindPorts = bindPorts;
         this.bindAllPorts = bindAllPorts;
         this.privileged = privileged;
+        this.tty = tty;
         this.hostname = hostname;
     }
 
@@ -139,7 +142,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
                         prefixStartSlaveCmd,
                         suffixStartSlaveCmd, instanceCapStr,
                         dnsString, dockerCommand,
-                        volumesString, volumesFrom, environmentsString, lxcConfString, hostname, bindPorts, bindAllPorts, privileged);
+                        volumesString, volumesFrom, environmentsString, lxcConfString, hostname, bindPorts, bindAllPorts, privileged, tty);
                 ((DockerCloud) c).addTemplate(t);
             }
         }

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate/template.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate/template.jelly
@@ -50,6 +50,9 @@
             <f:checkbox/>
         </f:entry>
 
+        <f:entry title="${%Allocate a pseudo-TTY}" field="tty">
+            <f:checkbox/>
+        </f:entry>
 
         </f:advanced>
 </j:jelly>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
@@ -84,6 +84,10 @@
             <f:checkbox/>
         </f:entry>
 
+        <f:entry title="${%Allocate a pseudo-TTY}" field="tty">
+            <f:checkbox/>
+        </f:entry>
+
        <f:entry title="${%Prefix Start Slave Command}" field="prefixStartSlaveCmd">
            <f:textbox/>
        </f:entry>


### PR DESCRIPTION
Add "Allocate a pseudo-TTY" checkbox
![445e8165f59b856edb324e9558d8bf75](https://cloud.githubusercontent.com/assets/9108/6461595/aa4b6504-c1e4-11e4-86be-232d60137002.png)

and call `containerConfig.withTty(this.tty)` in `com.nirima.jenkins.plugins.docker#createContainerConfig`.

