### PR TITLE
Add the possibility to choose the image repository and tag when commited

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
@@ -22,6 +22,8 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
      * Tag on completion (commit).
      */
     public final boolean tagOnCompletion;
+    public final String imageRepository;
+    public final String commitTag;
     public final String additionalTag;
     public final boolean pushOnSuccess;
     public final boolean cleanImages;
@@ -29,10 +31,14 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
     @DataBoundConstructor
     public DockerJobProperty(
             boolean tagOnCompletion,
+            String imageRepository,
+            String commitTag,
             String additionalTag,
             boolean pushOnSuccess, boolean cleanImages)
     {
         this.tagOnCompletion = tagOnCompletion;
+        this.imageRepository = imageRepository;
+        this.commitTag = commitTag;
         this.additionalTag = additionalTag;
         this.pushOnSuccess = pushOnSuccess;
         this.cleanImages = cleanImages;
@@ -41,6 +47,16 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
     @Exported
     public String getAdditionalTag() {
         return additionalTag;
+    }
+
+    @Exported
+    public String getImageRepository() {
+        return imageRepository;
+    }
+
+    @Exported
+    public String getCommitTag() {
+        return commitTag;
     }
 
     @Exported
@@ -73,6 +89,8 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
         public DockerJobProperty newInstance(StaplerRequest sr, JSONObject formData) throws hudson.model.Descriptor.FormException {
             return new DockerJobProperty(
                     (Boolean)formData.get("tagOnCompletion"),
+                    (String)formData.get("imageRepository"),
+                    (String)formData.get("commitTag"),
                     (String)formData.get("additionalTag"),
                     (Boolean)formData.get("pushOnSuccess"),
                     (Boolean)formData.get("cleanImages"));

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -17,7 +17,6 @@ import hudson.slaves.ComputerLauncher;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
 import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -224,8 +223,7 @@ public class DockerSlave extends AbstractCloudSlave {
         return tagToken;
     }
 
-    private String expandString(TaskListener listener, String tagToken)
-            throws MacroEvaluationException, IOException, InterruptedException {
+    private String expandString(TaskListener listener, String tagToken) throws Exception {
         /* Check if TokenMacro plugin is installed and enabled */
         Plugin plugin = Jenkins.getInstance().getPlugin("token-macro");
         if (plugin != null && plugin.getWrapper().isEnabled()) {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -95,7 +95,6 @@ public class DockerSlave extends AbstractCloudSlave {
     @Override
     protected void _terminate(TaskListener listener) throws IOException, InterruptedException {
 
-	LOGGER.log(Level.FINE, "Terminating container " + containerId);
         try {
             toComputer().disconnect(null);
 

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/config.jelly
@@ -1,8 +1,17 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:section title="Docker Container">
         <f:entry title="${%Commit on successful build}" field="tagOnCompletion">
             <f:checkbox default="false"/>
+        </f:entry>
+
+        <f:entry title="${%Image repository name}" field="imageRepository">
+            <f:textbox/>
+        </f:entry>
+
+        <f:entry title="${%Commit tag}" field="commitTag">
+            <f:textbox/>
         </f:entry>
 
         <f:entry title="${%Additional tag to add}" field="additionalTag">

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-commitTag.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-commitTag.html
@@ -1,0 +1,3 @@
+<div>
+    The name of the tag used for the commited image. When this field is left empty, the build name is used.
+</div>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-imageRepository.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-imageRepository.html
@@ -1,0 +1,3 @@
+<div>
+    The name of the repository used for the commited image. When this field is left empty, the job name is used.
+</div>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-tagOnCompletion.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-tagOnCompletion.html
@@ -1,3 +1,3 @@
 <div>
-    When a job completes, the docker slave instance is committed with repository based on the job name and build number as tag
+    When a job completes, the docker slave instance is committed with the provided repository and tag
 </div>


### PR DESCRIPTION
This patch adds 2 fields to customize the repository and tag when the docker image is commited. When these fields are left empty the default values are used (i.e. the job name for the repository and the build name for the tag).
