### PR TITLE
Configurable number of executors #81

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
@@ -38,6 +38,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
 
     public final String image;
     public final String labelString;
+    public final int numExecutors;
     public final String remoteFsMapping;
     public final String remoteFs;
     public final String credentialsId;
@@ -63,7 +64,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
     public final String hostname;
 
     @DataBoundConstructor
-    public DockerBuilderNewTemplate(String image, String labelString, String remoteFs, String remoteFsMapping,
+    public DockerBuilderNewTemplate(String image, String labelString, int numExecutors, String remoteFs, String remoteFsMapping,
                                               String credentialsId, String idleTerminationMinutes,
                                               String sshLaunchTimeoutMinutes,
                                               String jvmOptions, String javaPath,
@@ -82,6 +83,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
 
         this.image = image;
         this.labelString = labelString;
+        this.numExecutors = numExecutors;
         this.remoteFs = remoteFs;
         this.remoteFsMapping = remoteFsMapping;
         this.credentialsId = credentialsId;
@@ -140,7 +142,7 @@ public class DockerBuilderNewTemplate extends Builder implements Serializable {
         for (Cloud c : Jenkins.getInstance().clouds) {
             if (c instanceof DockerCloud && ((DockerCloud) c).getTemplate(image) == null) {
                 LOGGER.log(Level.INFO, "Adding new template « "+image+" » to cloud " + ((DockerCloud) c).name);
-                DockerTemplate t = new DockerTemplate(image, labelString, remoteFs, remoteFsMapping, 
+                DockerTemplate t = new DockerTemplate(image, labelString, numExecutors, remoteFs, remoteFsMapping, 
                         credentialsId, idleTerminationMinutes,
                         sshLaunchTimeoutMinutes,
                         jvmOptions, javaPath,

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/template.jelly
@@ -11,6 +11,10 @@
             <f:textbox/>
         </f:entry>
 
+        <f:entry title="${%Num Executors}" field="numExecutors">
+           <f:number name="numExecutors" clazz="positive-number" min="1" step="1"/>
+        </f:entry>
+
         <f:entry title="${%Credentials}" field="credentialsId">
             <c:select/>
         </f:entry>

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
@@ -9,6 +9,7 @@ public class DockerTemplateTest {
 
     String image = "image";
     String labelString;
+    int numExecutors = 1;
     String remoteFs = "remoteFs";
     String remoteFsMapping = "remoteFsMapping";
     String credentialsId = "credentialsId";
@@ -36,6 +37,7 @@ public class DockerTemplateTest {
 
     private DockerTemplate getDockerTemplateInstanceWithDNSHost(String dnsString) {
         DockerTemplate instance = new DockerTemplate(image, labelString,
+                numExecutors,
                 remoteFs,
                 remoteFsMapping,
                 credentialsId, idleTerminationMinutes,


### PR DESCRIPTION
Adds `numExecutors` to the DockerTemplate class; any slave created with this template will have that many executors. Switched the retention strategy from `OnceRetentionStrategy` to `CloudRetentionStrategy` so that, if multiple jobs are spawned on a slave, it doesn't go down when the first job finishes.