### PR TITLE
add repository for docker-plugin snapshot version

### DIFF
--- a/docker-java-shaded/pom.xml
+++ b/docker-java-shaded/pom.xml
@@ -68,4 +68,14 @@
         </plugins>
     </build>
 
+    <repositories>
+        <repository>
+            <id>oss.sonatype.org</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
 </project>


### PR DESCRIPTION
- as long as we depend on a snapshot version we should add a
  repository to the pom to enable other users to at least build
  the master branch

related to #176 and [#JENKINS-26517][]

[#JENKINS-26517]: https://issues.jenkins-ci.org/browse/JENKINS-26517