### PR TITLE
fix volume support

### DIFF
--- a/docker-plugin/pom.xml
+++ b/docker-plugin/pom.xml
@@ -42,6 +42,12 @@
             <artifactId>durable-task</artifactId>
             <version>0.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -211,7 +211,7 @@ public class DockerTemplate extends DockerTemplateBase implements Describable<Do
     }
 
     public String getVolumesString() {
-	return Joiner.on(" ").join(volumes);
+        return volumesString;
     }
 
     public String getVolumesFrom() {

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-volumesString.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-volumesString.html
@@ -1,3 +1,10 @@
 <div>
-    A space separated list of host volume mounts, e.g. /host/path:/container/path:ro
+    A space separated list of host volume mounts : &lt;host/path&gt;[&lt;container/path&gt;[&lt;:mode&gt;]]
+    <ul>
+        <li>container/path create empty  volume container/path</li>
+        <li>host/path:container/path will mount host/path from host to container's container/path, read/write</li>
+        <li>host/path:container/path:rw will mount host/path from host to container's container/path, read/write</li>
+        <li>host/path:container/path:ro will mount host/path from host to container's container/path, read-only</li>
+    </ul>
+    Note: when provided, an invalid mode will mount the volume in read-only
 </div>

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
@@ -1,12 +1,25 @@
 package com.nirima.jenkins.plugins.docker;
 
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.*;
 import com.nirima.jenkins.plugins.docker.strategy.DockerOnceRetentionStrategy;
 import hudson.slaves.RetentionStrategy;
+import com.github.dockerjava.api.command.StartContainerCmd;
+
 import static org.junit.Assert.*;
+
+import org.junit.Before;
 import org.junit.Test;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
+
+import org.mockito.Matchers;
+import org.mockito.Mockito;
 
 public class DockerTemplateTest {
 
+    CreateContainerCmd createContainerCmd;
+    StartContainerCmd startContainerCmd;
 
     String image = "image";
     String labelString;
@@ -22,6 +35,8 @@ public class DockerTemplateTest {
     String prefixStartSlaveCmd = "prefixStartSlaveCmd";
     String suffixStartSlaveCmd = " suffixStartSlaveCmd";
     String instanceCapStr = "";
+
+    String dnsString = "0.0.0.0";
 
     String dockerCommand = "dockerCommand";
     String volumesString = "volumes";
@@ -58,6 +73,52 @@ public class DockerTemplateTest {
               
         return instance;
     }
+    private DockerTemplate getDockerTemplateInstanceWithVolumesString(String volumesString) {
+        DockerTemplate instance = new DockerTemplate(image, labelString,
+                remoteFs,
+                remoteFsMapping,
+                credentialsId, idleTerminationMinutes,
+                sshLaunchTimeoutMinutes,
+                jvmOptions, javaPath,
+                memoryLimit, cpuShares,
+                prefixStartSlaveCmd, suffixStartSlaveCmd,
+                instanceCapStr, dnsString,
+                dockerCommand,
+                volumesString, volumesFrom,
+                environmentsString,
+                lxcConfString,
+                hostname,
+                bindPorts,
+                bindAllPorts,
+                privileged,
+                tty);
+
+
+        return instance;
+    }
+
+    @Before
+    public void beforeEach(){
+
+        createContainerCmd = Mockito.mock(CreateContainerCmd.class);
+        when(createContainerCmd.withBinds(Matchers.<Bind>anyVararg())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withVolumes(Matchers.<Volume>anyVararg())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withPortBindings(Matchers.<PortBinding>anyVararg())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withPublishAllPorts(Matchers.anyBoolean())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withPrivileged(Matchers.anyBoolean())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withDns(Matchers.<String>anyVararg())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withLxcConf(Matchers.<LxcConf>anyVararg())).thenReturn(createContainerCmd);
+        when(createContainerCmd.withVolumesFrom(Matchers.<VolumesFrom>anyVararg())).thenReturn(createContainerCmd);
+        
+        startContainerCmd = Mockito.mock(StartContainerCmd.class);
+        when(startContainerCmd.withBinds(Matchers.<Bind>anyVararg())).thenReturn(startContainerCmd);
+        when(startContainerCmd.withPortBindings(Matchers.<PortBinding>anyVararg())).thenReturn(startContainerCmd);
+        when(startContainerCmd.withPublishAllPorts(Matchers.anyBoolean())).thenReturn(startContainerCmd);
+        when(startContainerCmd.withPrivileged(Matchers.anyBoolean())).thenReturn(startContainerCmd);
+        when(startContainerCmd.withDns(Matchers.<String>anyVararg())).thenReturn(startContainerCmd);
+        when(startContainerCmd.withLxcConf(Matchers.<LxcConf>anyVararg())).thenReturn(startContainerCmd);
+        when(startContainerCmd.withVolumesFrom(any(String.class))).thenReturn(startContainerCmd);
+    }
 
     @Test
     public void testDnsHosts() {
@@ -84,4 +145,102 @@ public class DockerTemplateTest {
         assertTrue("Error, wrong cpuShares", 1000 == instance.cpuShares);
     }
 
+    @Test
+    public void testCreateContainerWithNoVolume() throws Exception {
+        DockerTemplate instance;
+
+        CreateContainerCmd createContainerCmd = Mockito.mock(CreateContainerCmd.class);
+
+        instance = getDockerTemplateInstanceWithVolumesString("");
+        instance.createContainerConfig(createContainerCmd);
+        verify(createContainerCmd,times(0)).withBinds(any(Bind.class));
+        verify(createContainerCmd,times(0)).withVolumes(any(Volume.class));
+    }
+
+    @Test
+    public void testCreateContainerWith1Volume() throws Exception{
+        DockerTemplate instance;
+
+        instance = getDockerTemplateInstanceWithVolumesString("volume");
+        instance.createContainerConfig(createContainerCmd);
+        verify(createContainerCmd,times(0)).withBinds(any(Bind.class));
+        verify(createContainerCmd,times(1)).withVolumes(any(Volume.class));
+    }
+
+    @Test
+    public void testCreateContainerWith2Volumes() throws Exception{
+        DockerTemplate instance;
+
+        instance = getDockerTemplateInstanceWithVolumesString("volume0 volume1");
+        instance.createContainerConfig(createContainerCmd);
+        verify(createContainerCmd,times(0)).withBinds(any(Bind.class));
+        verify(createContainerCmd,times(2)).withVolumes(any(Volume.class));
+    }
+
+    @Test
+    public void testCreateContainerWithHostVolume() throws Exception{
+        DockerTemplate instance;
+
+        instance = getDockerTemplateInstanceWithVolumesString("host/path:container/path");
+        instance.createContainerConfig(createContainerCmd);
+        verify(createContainerCmd,times(1)).withBinds(any(Bind.class));
+        verify(createContainerCmd,times(0)).withVolumes(any(Volume.class));
+    }
+
+    @Test
+    public void testCreateContainerWithHostVolumeRo() throws Exception{
+        DockerTemplate instance;
+
+        instance = getDockerTemplateInstanceWithVolumesString("host/path:container/path:ro");
+        instance.createContainerConfig(createContainerCmd);
+        verify(createContainerCmd,times(1)).withBinds(any(Bind.class));
+        verify(createContainerCmd,times(0)).withVolumes(any(Volume.class));
+    }
+
+    @Test
+    public void testCreateContainerWith2HostVolumes() throws Exception{
+        DockerTemplate instance;
+
+        instance = getDockerTemplateInstanceWithVolumesString("host/path:container/path:ro host/path2:container/path2:rw");
+        instance.createContainerConfig(createContainerCmd);
+        verify(createContainerCmd,times(2)).withBinds(any(Bind.class));
+        verify(createContainerCmd,times(0)).withVolumes(any(Volume.class));
+    }
+
+    @Test
+    public void testStartContainerWithNoVolume() throws Exception {
+        DockerTemplate instance;
+
+        instance = getDockerTemplateInstanceWithVolumesString("");
+        instance.createHostConfig(startContainerCmd);
+        verify(startContainerCmd,times(0)).withBinds(any(Bind.class));
+    }
+
+
+    @Test
+    public void testStartContainerWithHostVolume() throws Exception{
+        DockerTemplate instance;
+
+        instance = getDockerTemplateInstanceWithVolumesString("host/path:container/path");
+        instance.createHostConfig(startContainerCmd);
+        verify(startContainerCmd,times(1)).withBinds(any(Bind.class));
+    }
+
+    @Test
+    public void testStartContainerWithHostVolumeRo() throws Exception{
+        DockerTemplate instance;
+
+        instance = getDockerTemplateInstanceWithVolumesString("host/path:container/path:ro");
+        instance.createHostConfig(startContainerCmd);
+        verify(startContainerCmd,times(1)).withBinds(any(Bind.class));
+    }
+
+    @Test
+    public void testStartContainerWith2HostVolumes() throws Exception{
+        DockerTemplate instance;
+
+        instance = getDockerTemplateInstanceWithVolumesString("host/path:container/path:ro host/path2:container/path2:rw");
+        instance.createHostConfig(startContainerCmd);
+        verify(startContainerCmd,times(2)).withBinds(any(Bind.class));
+    }
 }


### PR DESCRIPTION
Setting the 'Volumes' advanced option inside a cloud with a value of "/tmp/docker-jenkins:/tmp/docker-test-volume" does not bind container /tmp/docker-test-volume to host /tmp/docker-jenkins any longer.

It can be reproduced cloning "https://github.com/tjamet/jenkins-docker-master.git" branch " test/docker-volume" and launching a build on docker-volume after having updating the docker plugin
