### PR TITLE
Handle exception inspecting newly created container.

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -123,7 +123,7 @@ public abstract class DockerTemplateBase {
 
     public Integer getCpuShares() { return cpuShares; }
 
-    public InspectContainerResponse provisionNew(DockerClient dockerClient) throws DockerException {
+    public String provisionNew(DockerClient dockerClient) throws DockerException {
 
         CreateContainerCmd containerConfig = dockerClient.createContainerCmd(image);
 
@@ -138,9 +138,7 @@ public abstract class DockerTemplateBase {
 
         startCommand.exec();
 
-        return dockerClient.inspectContainerCmd(containerId).exec();
-
-
+        return containerId;
     }
 
     public String[] getDockerCommandArray() {

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionProvisionAndStart.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionProvisionAndStart.java
@@ -29,7 +29,7 @@ public class DockerBuilderControlOptionProvisionAndStart extends DockerBuilderCo
 
         DockerTemplate template = getCloud(build).getTemplate(templateId);
 
-        String containerId = template.provisionNew().getId();
+        String containerId = template.provisionNew();
 
         LOGGER.info("Starting container " + containerId);
         DockerClient client = getClient(build);

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
@@ -96,7 +96,7 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
                 dnsString, xCommand,
                 volumesString, volumesFrom, environmentsString, lxcConfString, xHostname,  memoryLimit, cpuShares, bindPorts, bindAllPorts, privileged, tty);
 
-        String containerId = template.provisionNew(client).getId();
+        String containerId = template.provisionNew(client);
 
         LOGGER.info("Started container " + containerId);
         getLaunchAction(build).started(client, containerId);


### PR DESCRIPTION
PR to address #188 

It's entirely possible that the container can be salvaged at this point; the root cause of this is usually a SocketTimeoutException. There's usually nothing wrong with the container itself at this point; it will be up and running and I can ssh into it and poke around, but there's no slave.jar because Jenkins already gave up on it.

This adds essentially one more layer of protection in terms of managing the containers. In testing, I've also seen the same SocketTimeoutException trigger on the `RemoveContainerCmd.exec()` call here, but after checking docker it seemed that it did at least manage to do the job and remove the container in that instance.