### PR TITLE
DockerComputerLauncher: get host IP from binding

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerComputerLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerComputerLauncher.java
@@ -46,15 +46,19 @@ public class DockerComputerLauncher extends DelegatingComputerLauncher {
 
             ExposedPort sshPort = new ExposedPort(22);
             int port = 22;
+            String host = null;
 
             Ports.Binding[] bindings = detail.getNetworkSettings().getPorts().getBindings().get(sshPort);
 
             for(Ports.Binding b : bindings) {
                 port = b.getHostPort();
+                host = b.getHostIp();
             }
 
-            URL hostUrl = new URL(template.getParent().serverUrl);
-            String host = hostUrl.getHost();
+            if (host == null) {
+                URL hostUrl = new URL(template.getParent().serverUrl);
+                host = hostUrl.getHost();
+            }
 
             LOGGER.log(Level.INFO, "Creating slave SSH launcher for " + host + ":" + port);
             


### PR DESCRIPTION
The IP address of the binding may not be the same as the IP of the
docker host.  The port may be bound to only one interface, or we could
be connecting through a Docker Swarm, in which case the container is
actually running on a different machine altogether.

Fixes issue #190 