### PR TITLE
Extra container options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ work
 *.iml
 /target
 .*
+dependency-reduced-pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ work
 *.iml
 /target
 .*
-dependency-reduced-pom.xml

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerComputerLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerComputerLauncher.java
@@ -43,7 +43,6 @@ public class DockerComputerLauncher extends DelegatingComputerLauncher {
         Preconditions.checkNotNull(detail);
 
         try {
-
             ExposedPort sshPort = new ExposedPort(22);
             int port = 22;
             String host = null;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
@@ -58,6 +58,12 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
         return cleanImages;
     }
 
+    // Placeholders.
+    @Exported
+    public boolean isRemainsRunning() {
+        return false;
+    }
+
     @Extension
     public static final class DescriptorImpl extends JobPropertyDescriptor {
         public String getDisplayName() {

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
@@ -64,6 +64,11 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
         return false;
     }
 
+    @Exported
+    public String getImageAuthor() {
+        return "Jenkins";
+    }
+
     @Extension
     public static final class DescriptorImpl extends JobPropertyDescriptor {
         public String getDisplayName() {

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
@@ -12,7 +12,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
-
+import java.util.ArrayList;
 import java.util.Map;
 
 
@@ -67,6 +67,27 @@ public class DockerJobProperty extends hudson.model.JobProperty<AbstractProject<
     @Exported
     public String getImageAuthor() {
         return "Jenkins";
+    }
+
+    @Exported
+    public boolean isTagLatest() {
+        return false;
+    }
+
+    @Exported
+    public boolean isTagBuildNumber() {
+        return false;
+    }
+
+    @Exported 
+    public String getRepositoryName() {
+        return null;
+    }
+
+    @Exported 
+    public ArrayList<String> getImageTags() {
+         ArrayList<String> imageTags = new ArrayList<String>();
+         return imageTags;
     }
 
     @Extension

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -150,7 +150,7 @@ public class DockerSlave extends AbstractCloudSlave {
         String tag_image = client.commitCmd(containerId)
                     .withRepository(theRun.getParent().getDisplayName())
                     .withTag(theRun.getDisplayName())
-                    .withAuthor("Jenkins")
+                    .withAuthor(getJobProperty().getImageAuthor())
                     .exec();
 
         // Tag it with the jenkins name

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -7,6 +7,7 @@ import shaded.com.google.common.base.Strings;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.DockerException;
 import com.github.dockerjava.api.NotModifiedException;
+import com.github.dockerjava.api.NotFoundException;
 import com.nirima.jenkins.plugins.docker.action.DockerBuildAction;
 
 import hudson.Extension;
@@ -201,6 +202,18 @@ public class DockerSlave extends AbstractCloudSlave {
                 // addJenkinsAction(cleanTag);
             } catch(Exception ex) {
                 LOGGER.log(Level.SEVERE, "Could not add tag: " + cleanTag, ex);
+            }
+
+            // Push the image to the registry with all of the tags
+            if(getJobProperty().isPushOnSuccess()) {
+                try {
+                    client.pushImageCmd(repositoryName)
+                        .withTag(cleanTag)
+                        .exec();
+                } catch (NotFoundException ex) {
+                    // This should NEVER happen but just in case.
+                    LOGGER.log(Level.SEVERE, "Couldnt find " + repositoryName + ":" +cleanTag + ". Not pushing.");
+                }
             }
         }
 

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/config.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/config.jelly
@@ -1,22 +1,53 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
 
     <f:section title="Docker Container">
-        <f:entry title="${%Commit on successful build}" field="tagOnCompletion">
-            <f:checkbox default="false"/>
+
+        <f:entry title="${%Remains Running}" field="remainsRunning">
+            <f:checkbox default="true" />
         </f:entry>
 
-        <f:entry title="${%Additional tag to add}" field="additionalTag">
-            <f:textbox/>
+        <f:entry title="${%Commit on successful build}" field="tagOnCompletion">
+            <f:checkbox />
+        </f:entry>
+
+        <f:entry title="${%Repository Name}" field="repositoryName">
+            <f:textbox />
+        </f:entry>
+
+        <f:entry title="${%Tag as latest}" field="tagLatest">
+            <f:checkbox />
+        </f:entry>
+
+        <f:entry title="${%Tag with build number}" field="tagBuildNumber">
+            <f:checkbox />
+        </f:entry>
+
+        <f:entry title="${%Additional Tags}" field="imageTags">
+            <f:textbox />
         </f:entry>
 
         <f:entry title="${%Push on successful build}" field="pushOnSuccess">
             <f:checkbox/>
         </f:entry>
 
-        <f:entry title="${%Clean local images}" field="cleanImages">
-            <f:checkbox default="true"/>
+        <f:entry title="${%Image Author}" field="imageAuthor">
+            <f:textbox />
         </f:entry>
+
+        <f:entry title="${%Clean local images}" field="cleanImages">
+            <f:checkbox />
+        </f:entry>
+<!--
+        <f:entry title="${%Remove untagged images}" field="removeUntaggedImages">
+            <f:checkbox default="true" />
+        </f:entry>
+-->
+
+    </f:section>
+
+    <!-- Make an obvious divide before the other options -->
+    <f:section title="">
     </f:section>
 
 </j:jelly>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-cleanImages.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-cleanImages.html
@@ -1,0 +1,3 @@
+<div>
+    Remove local, committed image. Normally used when pushing images to a remote registry.
+</div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-imageTags.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-imageTags.html
@@ -1,0 +1,4 @@
+<div>
+    List of additional tags for committed image - delimited by commas, semi-colons or colons. e.g.
+    <p><code>tag1,tag2;tag3:tag4</code></p>
+</div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-remainsRunning.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-remainsRunning.html
@@ -1,0 +1,3 @@
+<div>
+    The docker slave instance will remain running after successful builds.
+</div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-repositoryName.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-repositoryName.html
@@ -1,0 +1,6 @@
+<div>
+    The repository name to tag the committed image with. Spaces will be replaced with underscores ('_'). Non-docker-friendly characters will be removed. 
+    <br />It should be formatted: 
+    <p><code>[REGISTRYHOST/][USERNAME/]REPOSITORY</code></p>
+    If blank, uses the job name.
+</div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-tagBuildNumber.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-tagBuildNumber.html
@@ -1,0 +1,3 @@
+<div>
+    Tag committed image with the number of the build
+</div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-tagLatest.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerJobProperty/help-tagLatest.html
@@ -1,0 +1,3 @@
+<div>
+    Tag committed image as 'latest'
+</div>


### PR DESCRIPTION
___Improvements and fixes for Job Properties___

## Enhancements ##
- Added option to keep containers running after builds
- Added 'Image Author' option to replace Jenkins
- Added 'Repository Name' option
  - Uses job name if blank
- Added option to tag image with 'latest'
- Added option to tag image with build number
  - If no tags are added, uses build number
- Added option to add multiple additional tags
  - Removes 'additionalTag', putting it into this field for backward compatibility
- Added help text for most fields
- Better logging for tagging
- Changing some catches to catch more specific exceptions

## Fixes ##
- Match valid repository and tags (docker v1.5+)
- Fix bad arguments for tagImageCmd()
- Force tag images
- Catch exception when removing containers which have already stopped
- Validates Docker Cloud URL, using String type rather than URL type