### PR TITLE
DockerComputerLauncher: don't try to connect to 0.0.0.0

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerComputerLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerComputerLauncher.java
@@ -55,7 +55,7 @@ public class DockerComputerLauncher extends DelegatingComputerLauncher {
                 host = b.getHostIp();
             }
 
-            if (host == null) {
+            if (host == null || host.equals("0.0.0.0")) {
                 URL hostUrl = new URL(template.getParent().serverUrl);
                 host = hostUrl.getHost();
             }


### PR DESCRIPTION
If a port is mapped to 0.0.0.0, we should try to connect to the IP address of
the docker host instead

Fixes issue from PR #191 