### PR TITLE
Improved help text to be less misleading

### DIFF
--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-remoteFsMapping.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-remoteFsMapping.html
@@ -1,3 +1,5 @@
 <div>
-    Enables the ability to browse workspaces of jobs being built using docker containers. Specify the location containing the workspace folder (e.g. /home/jenkins) on the Jenkins master where the job workspaces will be mapped from the images using volumes, network shares, etc.<br />Changes to this path will be applied after the next build run.
+    Enables the ability to browse workspaces of jobs being built using docker containers. <br />
+    Specify the location containing the workspace folder (e.g. /home/jenkins) on the Jenkins master where the job workspaces will be mapped from the images using volumes, network shares, etc. <br />
+    Changes to this path will be applied after the next build run.
 </div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-remoteFsMapping.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-remoteFsMapping.html
@@ -1,3 +1,3 @@
 <div>
-    Enables the ability to browse workspaces of jobs being built using docker containers. Specify the location on the Jenkins master where the job workspaces will be mapped from the images using volumes, network shares, etc.
+    Enables the ability to browse workspaces of jobs being built using docker containers. Specify the location containing the workspace folder (e.g. /home/jenkins) on the Jenkins master where the job workspaces will be mapped from the images using volumes, network shares, etc.<br />Changes to this path will be applied after the next build run.
 </div>


### PR DESCRIPTION
The MappedFsWorkspaceBrowser class always adds the workspace folder to this path.
This is not yet being described comprehensibly, as well as the fact that changes to this path will only be applied to new build runs.