### PR TITLE
feat(DockerCloud): option to use docker hostname as slave display name

### DIFF
--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
@@ -32,6 +32,10 @@
         <f:number/>
     </f:entry>
 
+    <f:entry title="${%Display Hostname}" field="displayHostname">
+        <f:checkbox/>
+    </f:entry>
+
     <f:entry title="${%Images}" description="${%List of Images to be launched as slaves}">
         <f:repeatableHeteroProperty field="templates" hasHeader="true" addCaption="Add Docker Template"
                                     deleteCaption="Delete Docker Template"/>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-displayHostname.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-displayHostname.html
@@ -1,0 +1,6 @@
+<div>
+    Use the hostname of the docker host as display name
+    for the slave instead of the cloud name. If the hostname
+    is not resolvable the IP address is used.<br/>
+    <strong>Requirement:</strong> A port mapping is required to get the hostname of the slave.
+</div>

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
@@ -17,6 +17,7 @@ public class DockerCloudTest {
                 10, // connectTimeout,
                 10, // readTimeout,
                 null, // credentialsId,
-                null); //version
+                null, //version,
+                false); // display hostname
     }
 }

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
@@ -52,7 +52,7 @@ public class ClientBuilderForPluginTest {
                 Collections.<DockerTemplate>emptyList(),
                 HTTP_SERVER_URL,
                 EMPTY_CONTAINER_CAP,
-                CONNECT_TIMEOUT, READ_TIMEOUT, EMPTY_CREDS, DOCKER_API_VER);
+                CONNECT_TIMEOUT, READ_TIMEOUT, EMPTY_CREDS, DOCKER_API_VER, false);
         ClientConfigBuilderForPlugin builder = dockerClientConfig();
         builder.forCloud(cloud);
 


### PR DESCRIPTION
Adds an option to the docker cloud to use the hostname of the docker
host as slave display name. If the hostname cannot be resolved the IP
address is used.

This is useful for setups with docker swarm. The display name of the
slave will then contain the information on which actual docker host
the job is running.

Limitation: The docker container must have a port mapping to
get the hostname of the slave.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/docker-plugin/299)

<!-- Reviewable:end -->
