### PR TITLE
chore(docker-java): update docker-java version to 2.0.2

### DIFF
--- a/docker-java-shaded/pom.xml
+++ b/docker-java-shaded/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <docker-java.version>1.4.0</docker-java.version>
+        <docker-java.version>2.0.2-SNAPSHOT</docker-java.version>
     </properties>
 
     <dependencies>

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -321,14 +321,9 @@ public class DockerCloud extends Cloud {
 
             long startTime = System.currentTimeMillis();
             //Identifier amiId = Identifier.fromCompoundString(ami);
-            try {
-                getClient().pullImageCmd(imageName).exec(new PullImageResultCallback()).awaitSuccess();
-                long pullTime = System.currentTimeMillis() - startTime;
-                LOGGER.info("Finished pulling image '{}', took {} ms", imageName, pullTime);
-            }
-            catch (DockerClientException e) {
-                LOGGER.error("Error while pulling image '{}'", imageName, e);
-            }
+            getClient().pullImageCmd(imageName).exec(new PullImageResultCallback()).awaitSuccess();
+            long pullTime = System.currentTimeMillis() - startTime;
+            LOGGER.info("Finished pulling image '{}', took {} ms", imageName, pullTime);
         }
     }
 

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -2,6 +2,7 @@ package com.nirima.jenkins.plugins.docker;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.core.command.PullImageResultCallback;
 import com.nirima.jenkins.plugins.docker.action.DockerBuildAction;
 import hudson.Extension;
 import hudson.model.*;
@@ -216,7 +217,7 @@ public class DockerSlave extends AbstractCloudSlave {
                 addJenkinsAction(tagToken);
 
                 if (getJobProperty().pushOnSuccess) {
-                    client.pushImageCmd(tagToken).exec();
+                    client.pullImageCmd(tagToken).exec(new PullImageResultCallback()).awaitSuccess();
                 }
             }
         } catch (Exception ex) {

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
@@ -89,21 +89,16 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
 
         LOGGER.info("Pulling image " + xImage);
 
-        final StringBuilder resultBuilder = new StringBuilder();
-
         PullImageResultCallback resultCallback = new PullImageResultCallback() {
             public void onNext(PullResponseItem item) {
                 if (item.getStatus() != null && item.getProgress() == null) {
-                    resultBuilder.append("\n").append(item.getId()).append(":").append(item.getStatus());
+                    LOGGER.info(item.getId() + ":" + item.getStatus());
                 }
                 super.onNext(item);
             }
         };
 
         client.pullImageCmd(xImage).exec(resultCallback).awaitSuccess();
-
-        String strResult = resultBuilder.toString();
-        LOGGER.log(Level.INFO, "Pull result = {0}", strResult);
 
         LOGGER.log(Level.INFO, "Starting container for image {0}", xImage);
 

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher.java
@@ -185,8 +185,7 @@ public class DockerBuilderPublisher extends Builder implements Serializable {
 
             if (pushOnSuccess) {
                 listener.getLogger().println("Pushing " + tagsToUse);
-                String stringResponse = pushImages();
-                listener.getLogger().println("Docker Push Response : " + stringResponse);
+                pushImages();
             }
 
             if (cleanImages) {
@@ -256,9 +255,7 @@ public class DockerBuilderPublisher extends Builder implements Serializable {
             });
         }
 
-        private String pushImages() throws IOException {
-            final StringBuilder resultBuilder = new StringBuilder();
-
+        private void pushImages() throws IOException {
             for (String tagToUse : tagsToUse) {
 
                 if (!tagToUse.toLowerCase().equals(tagToUse)) {
@@ -271,7 +268,7 @@ public class DockerBuilderPublisher extends Builder implements Serializable {
                 PushImageResultCallback resultCallback = new PushImageResultCallback() {
 
                     public void onNext(PushResponseItem item) {
-                        resultBuilder.append(item.toString());
+                        listener.getLogger().println(item.toString());
                         super.onNext(item);
                     }
 
@@ -280,7 +277,6 @@ public class DockerBuilderPublisher extends Builder implements Serializable {
                 getClient().pushImageCmd(identifier).exec(resultCallback).awaitSuccess();
             }
 
-            return resultBuilder.toString();
         }
     }
 

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPlugin.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPlugin.java
@@ -15,6 +15,7 @@ import java.util.ServiceLoader;
 public class ClientBuilderForPlugin  {
 
     private final DockerClientConfig config;
+    private Integer readTimeout;
 
     private ClientBuilderForPlugin(DockerClientConfig config) {
         this.config = config;
@@ -32,10 +33,17 @@ public class ClientBuilderForPlugin  {
         return new ClientBuilderForPlugin(dockerClientConfig.build());
     }
 
+    public ClientBuilderForPlugin withReadTimeout(Integer readTimeout) {
+        this.readTimeout = readTimeout;
+        return this;
+    }
 
     public DockerClient build() {
+        DockerCmdExecFactoryImpl dockerCmdExecFactory = new DockerCmdExecFactoryImpl();
+        dockerCmdExecFactory.withReadTimeout(readTimeout);
+
         return DockerClientBuilder.getInstance(config)
-                .withDockerCmdExecFactory(new DockerCmdExecFactoryImpl())
+                .withDockerCmdExecFactory(dockerCmdExecFactory)
                 .build();
 
     }

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPlugin.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPlugin.java
@@ -1,11 +1,12 @@
 package com.nirima.jenkins.plugins.docker.client;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.DockerCmdExecFactory;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.jaxrs.DockerCmdExecFactoryImpl;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.util.ServiceLoader;
 
@@ -15,7 +16,7 @@ import java.util.ServiceLoader;
 public class ClientBuilderForPlugin  {
 
     private final DockerClientConfig config;
-    private Integer readTimeout;
+    private int readTimeout;
 
     private ClientBuilderForPlugin(DockerClientConfig config) {
         this.config = config;
@@ -33,14 +34,18 @@ public class ClientBuilderForPlugin  {
         return new ClientBuilderForPlugin(dockerClientConfig.build());
     }
 
-    public ClientBuilderForPlugin withReadTimeout(Integer readTimeout) {
-        this.readTimeout = readTimeout;
+    public ClientBuilderForPlugin withReadTimeout(int readTimeout) {
+        if (readTimeout > 0) {
+            this.readTimeout = (int) SECONDS.toMillis(readTimeout);
+        }
         return this;
     }
 
     public DockerClient build() {
         DockerCmdExecFactoryImpl dockerCmdExecFactory = new DockerCmdExecFactoryImpl();
-        dockerCmdExecFactory.withReadTimeout(readTimeout);
+        if (readTimeout > 0) {
+            dockerCmdExecFactory.withReadTimeout(readTimeout);
+        }
 
         return DockerClientBuilder.getInstance(config)
                 .withDockerCmdExecFactory(dockerCmdExecFactory)

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientConfigBuilderForPlugin.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientConfigBuilderForPlugin.java
@@ -5,10 +5,8 @@ import com.cloudbees.plugins.credentials.common.CertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.KeystoreSSLConfig;
-import com.github.dockerjava.jaxrs.DockerCmdExecFactoryImpl;
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
@@ -34,6 +32,7 @@ public class ClientConfigBuilderForPlugin {
     private static final Logger LOGGER = Logger.getLogger(ClientConfigBuilderForPlugin.class.getName());
 
     private DockerClientConfig.DockerClientConfigBuilder config = createDefaultConfigBuilder();
+    private Integer readTimeout;
 
     private ClientConfigBuilderForPlugin() {
     }
@@ -56,7 +55,7 @@ public class ClientConfigBuilderForPlugin {
         forServer(cloud.serverUrl, cloud.version);
 
         if (cloud.readTimeout > 0) {
-            config.withReadTimeout((int) SECONDS.toMillis(cloud.readTimeout));
+            readTimeout = (int) SECONDS.toMillis(cloud.readTimeout);
         }
 
         return withCredentials(cloud.credentialsId);
@@ -104,6 +103,9 @@ public class ClientConfigBuilderForPlugin {
         return this;
     }
 
+    public Integer getReadTimeout() {
+        return readTimeout;
+    }
 
     /**
      * Build the config
@@ -122,7 +124,7 @@ public class ClientConfigBuilderForPlugin {
      * @return
      */
     public DockerClient buildClient() {
-        return ClientBuilderForPlugin.getInstance(build()).build();
+        return ClientBuilderForPlugin.getInstance(build()).withReadTimeout(readTimeout).build();
     }
 
     /**

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientConfigBuilderForPlugin.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientConfigBuilderForPlugin.java
@@ -21,7 +21,6 @@ import static com.cloudbees.plugins.credentials.CredentialsMatchers.firstOrNull;
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.withId;
 import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
 import static com.github.dockerjava.core.DockerClientConfig.createDefaultConfigBuilder;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 /**
@@ -32,7 +31,7 @@ public class ClientConfigBuilderForPlugin {
     private static final Logger LOGGER = Logger.getLogger(ClientConfigBuilderForPlugin.class.getName());
 
     private DockerClientConfig.DockerClientConfigBuilder config = createDefaultConfigBuilder();
-    private Integer readTimeout;
+    private int readTimeout;
 
     private ClientConfigBuilderForPlugin() {
     }
@@ -54,9 +53,7 @@ public class ClientConfigBuilderForPlugin {
 
         forServer(cloud.serverUrl, cloud.version);
 
-        if (cloud.readTimeout > 0) {
-            readTimeout = (int) SECONDS.toMillis(cloud.readTimeout);
-        }
+        readTimeout = cloud.readTimeout;
 
         return withCredentials(cloud.credentialsId);
     }

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
@@ -59,7 +59,7 @@ public class ClientBuilderForPluginTest {
         DockerClientConfig config = builder.config().build();
         assertThat("server", config.getUri().toString(), equalTo(HTTP_SERVER_URL));
         assertThat("version", config.getVersion(), equalTo(DOCKER_API_VER));
-        assertThat("read TO", config.getReadTimeout(), equalTo((int) SECONDS.toMillis(READ_TIMEOUT)));
+        assertThat("read TO", builder.getReadTimeout(), equalTo((int) SECONDS.toMillis(READ_TIMEOUT)));
     }
 
     @Test

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
@@ -59,7 +59,7 @@ public class ClientBuilderForPluginTest {
         DockerClientConfig config = builder.config().build();
         assertThat("server", config.getUri().toString(), equalTo(HTTP_SERVER_URL));
         assertThat("version", config.getVersion(), equalTo(DOCKER_API_VER));
-        assertThat("read TO", builder.getReadTimeout(), equalTo((int) SECONDS.toMillis(READ_TIMEOUT)));
+        assertThat("read TO", builder.getReadTimeout(), equalTo(READ_TIMEOUT));
     }
 
     @Test


### PR DESCRIPTION
- update docker-java dependency to 2.0.2
- uses async docker cmd callbacks for Pull/Push/BuildImage cmd
- read timeout was moved from `DockerClientConfig` to
  `DockerCmdExecFactoryImpl`