### PR TITLE
fix switched parameter names in log message

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -483,7 +483,7 @@ public class DockerCloud extends Cloud {
             estimatedAmiSlaves += currentProvisioning;
 
             if (estimatedTotalSlaves >= getContainerCap()) {
-                LOGGER.info("Not Provisioning '{}'; Server '{}' full with '{}' container(s)", ami, getContainerCap(), name);
+                LOGGER.info("Not Provisioning '{}'; Server '{}' full with '{}' container(s)", ami, name, getContainerCap());
                 return false;      // maxed out
             }
 


### PR DESCRIPTION
In https://github.com/jenkinsci/docker-plugin/commit/cd52419e0fdfa74c2f52c262d02f4c8ab1c6fea8#diff-bccfbf21349af601aaa58e3583b6f8f7R428 the parameter order of a logging statement was switched, so you now see:

```
INFO: Not Provisioning 'fusion-builder:oracle-jdk-7'; Server '0' full with 'docker-n2' container(s)
```

This change puts them back in the correct order. Untested.