### PR TITLE
JENKINS-30200: Nullpointer exception while connecting to a docker

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -59,7 +59,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
     public void appendContainerConfig(DockerTemplate dockerTemplate, CreateContainerCmd createCmd) {
         final int sshPort = getSshConnector().port;
 
-        createCmd.withPortSpecs(sshPort + "/tcp");
+        createCmd.withExposedPorts(new ExposedPort(sshConnector.port));
 
         String[] cmd = dockerTemplate.getDockerTemplateBase().getDockerCommandArray();
         if (cmd.length == 0) {


### PR DESCRIPTION
container

Looks like due to Docker API changes between `v1.19` and `v1.20`
create container call should contain `ExposedPorts` instead of
`PortSpecs`. Change was tested with Docker `1.8.2` and `1.7.1`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/docker-plugin/320)
<!-- Reviewable:end -->
