### PR TITLE
Allow to use unix sockets as URL (#206, JENKINS-23301)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ work
 *.iml
 /target
 .*
+*~

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerBuildVariableContributor.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerBuildVariableContributor.java
@@ -31,9 +31,11 @@ public class DockerBuildVariableContributor extends BuildVariableContributor {
             variables.put("JENKINS_CLOUD_ID", dockerComputer.getCloudId());
             try {
                 //replace http:// and https:// from docker-java to tcp://
-                final String dockerHost = new URIBuilder(dockerComputer.getCloud().serverUrl)
-                        .setScheme("tcp")
-                        .toString();
+                final URIBuilder uriBuilder = new URIBuilder(dockerComputer.getCloud().serverUrl);
+                if (uriBuilder.getScheme() != "unix") {
+                    uriBuilder.setScheme("tcp");
+                }
+                final String dockerHost = uriBuilder.toString();
                 variables.put("DOCKER_HOST", dockerHost);
             } catch (URISyntaxException e) {
                 LOG.error("Can't build 'DOCKER_HOST' var: {}", e.getMessage());

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -123,6 +123,11 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
         //get address, if docker on localhost, then use local?
         if (host == null || host.equals("0.0.0.0")) {
             host = URI.create(DockerCloud.getCloudByName(cloudId).serverUrl).getHost();
+            if (host == null || host.equals("0.0.0.0")) {
+                // Try to connect to the container directly (without going through the host)
+                host = networkSettings.getIpAddress();
+                port = sshConnector.port;
+            }
         }
 
         return PortUtils.canConnect(host, port);

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-serverUrl.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-serverUrl.html
@@ -1,3 +1,3 @@
 <div>
-    The URL to use to access your Docker server API (e.g: http://172.16.42.43:4243). Only http:// supported.
+    The URL to use to access your Docker server API (e.g: http://172.16.42.43:4243 or unix:///var/run/docker.sock).
 </div>


### PR DESCRIPTION
- allow to directly connect to the container without going through
  the mapped port on the host

This is useful if Jenkins itself runs as a container with the host's
Docker socket mapped[1]. To use the docker plugin in this case simply
set the Docker URL to "unix:///var/run/docker.sock".

[1] https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/docker-plugin/344)
<!-- Reviewable:end -->
