### PR TITLE
Should not hide root cause of the exception

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -590,7 +590,7 @@ public class DockerCloud extends Cloud {
 
                 return FormValidation.ok("Version = " + verResult.getVersion());
             } catch (Exception e) {
-                return FormValidation.error(e.getMessage());
+                return FormValidation.error(e, e.getMessage());
             }
         }
 


### PR DESCRIPTION
When testing the connection to the docker host, it might be a good thing to see the underlying exception rather that just having the `shaded.org.apache.http.client.ClientProtocolException` (example).

@reviewbybees

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/docker-plugin/345)
<!-- Reviewable:end -->
