### PR TITLE
DockerCloud: Accompany "Bad template" message with actual stacktrace.

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -225,7 +225,7 @@ public class DockerCloud extends Cloud {
                     }
                 } catch (Exception e) {
                     LOGGER.warn("Bad template '{}' in cloud '{}': '{}'. Trying next template...",
-                            t.getDockerTemplateBase().getImage(), getDisplayName(), e.getMessage());
+                            t.getDockerTemplateBase().getImage(), getDisplayName(), e.getMessage(), e);
                     templates.remove(t);
                     continue;
                 }


### PR DESCRIPTION
That message is confusing, and oftentimes, wrong - the problem may be not
with Docker template, but with something else, and it may be not even on
Docker side, but on plugin side. So, just let people to see what really
happens and where, to have better chance to diagnose it.

Implementation uses SLF4J feature available since 1.6:
http://www.slf4j.org/faq.html#paramException (Jenkins uses 1.7)

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/docker-plugin/352)
<!-- Reviewable:end -->
