### PR TITLE
[fix] running JNLP with user jenkins breaks the init command with a q…

### DIFF
--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher/init.sh
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher/init.sh
@@ -51,7 +51,7 @@ fi
 
 RUN_CMD="java -jar ${JENKINS_HOME}/slave.jar $RUN_OPTS"
 if [ ! -z "$JENKINS_USER" ] && [ x"$JENKINS_USER" != "xroot" ] && [ "$JENKINS_USER" != "null" ]; then
- RUN_CMD="su - $JENKINS_USER -c '$RUN_CMD'"
+  su - $JENKINS_USER -c "$RUN_CMD"
+else
+  $RUN_CMD
 fi
-
-$RUN_CMD


### PR DESCRIPTION
…uote (see docker logs on the container)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jenkinsci/docker-plugin/367)
<!-- Reviewable:end -->
