### PR TITLE
Added DataBoundConstructor

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -43,7 +43,6 @@ public class DockerSlave extends AbstractCloudSlave {
 
     private transient Run theRun;
 
-    @DataBoundConstructor
     public DockerSlave(DockerTemplate dockerTemplate, String containerId,
                        String name, String nodeDescription,
                        String remoteFS, int numExecutors, Mode mode,

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -43,6 +43,7 @@ public class DockerSlave extends AbstractCloudSlave {
 
     private transient Run theRun;
 
+    @DataBoundConstructor
     public DockerSlave(DockerTemplate dockerTemplate, String containerId,
                        String name, String nodeDescription,
                        String remoteFS, int numExecutors, Mode mode,
@@ -58,6 +59,7 @@ public class DockerSlave extends AbstractCloudSlave {
         this.containerId = containerId;
     }
 
+    @DataBoundConstructor
     public DockerSlave(String slaveName, String nodeDescription, ComputerLauncher launcher, String containerId,
                        DockerTemplate dockerTemplate, String cloudId)
             throws IOException, Descriptor.FormException {


### PR DESCRIPTION
I ran into a error message with Jenkins 2.1 and the newest version of
the Docker Slave plugin where it was throwing an error needing
@DataBoundConstructor

Error ended in this:
Caused by: org.kohsuke.stapler.NoStaplerConstructorException: There's no @DataBoundConstructor on any constructor of class com.nirima.jenkins.plugins.docker.DockerSlave 
at org.kohsuke.stapler.ClassDescriptor.loadConstructorParamNames(ClassDescriptor.java:177) 
at org.kohsuke.stapler.RequestImpl.instantiate(RequestImpl.java:756) 
at org.kohsuke.stapler.RequestImpl.access$200(RequestImpl.java:81) 
at org.kohsuke.stapler.RequestImpl$TypePair.convertJSON(RequestImpl.java:672) 