### PR TITLE
Add caveat about workspace mapping

### DIFF
--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-remoteFsMapping.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-remoteFsMapping.html
@@ -1,5 +1,5 @@
 <div>
     Enables the ability to browse workspaces of jobs being built using docker containers. <br />
     Specify the location containing the workspace folder (e.g. /home/jenkins) on the Jenkins master where the job workspaces will be mapped from the images using volumes, network shares, etc. <br />
-    Changes to this path will be applied after the next build run.
+    Changes to this path will be applied after the next build run.  All builds must have been done on docker containers, delete any builds run on normal slaves.
 </div>


### PR DESCRIPTION
This change adds some helper text to the remote workspace mapping
configuration option that would have saved me a lot of time.  This adds
documentation about #246