### PR TITLE
Improve documentation on Container Cap and Instance Capacity

### DIFF
--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-containerCap.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-containerCap.html
@@ -1,0 +1,5 @@
+<div>
+    <p>The maximum number of <b>containers</b> that this provider is allowed to run in total (value is independent of the template/image).</p>
+    <p>Note that also containers, which have <b>not</b> been created by Jenkins, are counted as well.</p>
+    <p>Defaults to blank which disables this limit.</p>
+</div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-containerCapStr.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-containerCapStr.html
@@ -1,3 +1,0 @@
-<div>
-    The maximum number of containers that this provider is allowed to run. Defaults to blank which disables the limit
-</div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-instanceCapStr.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-instanceCapStr.html
@@ -1,3 +1,4 @@
 <div>
-    Max number of instances of this image to run, or empty for unlimited
+    <p>Maximal number of instances of this <b>image</b> to run, or empty for unlimited.</p>
+    <p>Note that also those containers (using the same image) are counted which have <b>not</b> been started by Jenkins.</p>
 </div>


### PR DESCRIPTION
Based on the discussion at https://issues.jenkins-ci.org/browse/JENKINS-36919 and https://issues.jenkins-ci.org/browse/JENKINS-36920, I was unsatisfied with the documentation provided for the parameters Container Cap and Instance Capacity:
* The help page of Container Cap is not reachable for the end user
* Both help pages do not make clear what is being counted.
Both issues are fixed with this change.