### PR TITLE
Improve documentation on Retention Strategy/Availability drop down

### DIFF
--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/config.groovy
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/config.groovy
@@ -30,7 +30,7 @@ f.slave_mode(name: "mode", node: instance)
 
 f.advanced(title: _("Experimental Options"), align: "left") {
     f.dropdownList(name: "retentionStrategy", title: _("Availability"),
-            help: "/help/system-config/master-slave/availability.html") {
+            help: "/descriptor/com.nirima.jenkins.plugins.docker.DockerTemplate/help/retentionStrategy") {
         DockerFunctions.dockerRetentionStrategyDescriptors.each { sd ->
             if (sd != null) {
                 def prefix = sd.displayName.equals("Docker Once Retention Strategy") ? "" : "Experimental: "

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-retentionStrategy.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-retentionStrategy.html
@@ -1,0 +1,28 @@
+<div>
+    <p>Specify the strategy when docker containers shall be started and stopped:</p>
+    <dl>
+	    <dt><b>Docker Once Retention Strategy</b> (default)</dt>
+	    <dd>For each job in the queue, an own docker container is started. Once the job has finished, 
+	    the container is shut down.</dd>
+
+	    <dt><b>Docker Cloud Retention Strategy</b> (experimental)</dt>
+	    <dd>Based on the workload provided by the queue (load average), new docker containers are started on demand.
+	    After the job(s) have finished, the container is not shut down immediately. If no new job was 
+	    executed on this slave/container during the period of the Idle delay, the container is shut down.</dd>
+
+	    <dt><b>Keep this slave on-line as much as possible</b> (experimental)</dt>
+	    <dd>Starts as many containers as specified in the Instance Capacity (obeying the Container Cap) 
+	    and tries to keep them always running (i.e. a new container is started in case another one belonging
+	    to this template was shut down).</dd>
+	    
+	    <dt><b>Take this slave on-line according to a schedule</b> (experimental)</dt>
+	    <dd>Based on a cron-schedule slaves are brought on-line and will keep running. 
+	    Once the specified period in the schedule is over, the slaves will be shut down.</dd>
+
+	    <dt><b>Take this slave on-line when in demand and off-line when idle</b> (experimental)</dt>
+	    <dd>Containers are started if there are jobs waiting for execution in the queue. They are only started,
+	    if the jobs are waiting a certain threshold of time there (In demand delay). After the jobs have finished,
+	    the container is not shut down immediately. If no new job was 
+	    executed on this slave/container during the period of the Idle delay, the container is shut down.</dd>
+    </dl>
+</div>


### PR DESCRIPTION
The field for defining the retention strategy for a DockerTemplate
refers to the generic availability help. However, the values described
there only do have little in common with the values which the end user
can select. 
This commit provides a rough summary about the retention strategies and
tries to describe their behavior in a nutshell to the end user. The text
is newly associated to the field "Availability" in the configuration
dialog.