### PR TITLE
Upgrade to docker-java 3.x

### DIFF
--- a/docker-java-shaded/pom.xml
+++ b/docker-java-shaded/pom.xml
@@ -24,7 +24,7 @@
         <!-- private fork. If you don't care about wildcard SSL certificates,
         you can bump this down to 2.2.3 -->
 
-        <docker-java.version>2.2.4-jenkins</docker-java.version>
+        <docker-java.version>3.0.1</docker-java.version>
     </properties>
 
     <repositories>

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -6,7 +6,7 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.*;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.command.*;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Image;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -1,8 +1,8 @@
 package com.nirima.jenkins.plugins.docker;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.DockerClientException;
-import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.exception.DockerClientException;
+import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.command.PushImageCmd;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.Identifier;
@@ -264,7 +264,7 @@ public class DockerSlave extends AbstractCloudSlave {
         if (getJobProperty().cleanImages) {
 
             client.removeImageCmd(tag_image)
-                    .withForce()
+                    .withForce(true)
                     .exec();
         }
 

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -363,7 +363,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase> {
 
         if (memoryLimit != null && memoryLimit > 0) {
             Long memoryInByte = (long) memoryLimit * 1024 * 1024;
-            containerConfig.withMemoryLimit(memoryInByte);
+            containerConfig.withMemory(memoryInByte);
         }
         
         if (memorySwap != null) {
@@ -371,7 +371,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase> {
       		  Long memorySwapInByte = (long) memorySwap * 1024 * 1024;
               containerConfig.withMemorySwap(memorySwapInByte);
       	  } else {
-      		  containerConfig.withMemorySwap(memorySwap);
+      		  containerConfig.withMemorySwap(memorySwap.longValue());
       	  }
         }
 

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOption.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOption.java
@@ -1,6 +1,6 @@
 package com.nirima.jenkins.plugins.docker.builder;
 
-import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.exception.DockerException;
 import com.nirima.jenkins.plugins.docker.action.DockerLaunchAction;
 import hudson.Launcher;
 import hudson.model.*;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionProvisionAndStart.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionProvisionAndStart.java
@@ -2,7 +2,7 @@ package com.nirima.jenkins.plugins.docker.builder;
 
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.exception.DockerException;
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
 import hudson.Extension;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
@@ -1,7 +1,7 @@
 package com.nirima.jenkins.plugins.docker.builder;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.PullResponseItem;
 import com.github.dockerjava.core.command.PullImageResultCallback;
 import com.nirima.jenkins.plugins.docker.DockerCloud;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStart.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStart.java
@@ -1,7 +1,7 @@
 package com.nirima.jenkins.plugins.docker.builder;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.exception.DockerException;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStop.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStop.java
@@ -1,8 +1,8 @@
 package com.nirima.jenkins.plugins.docker.builder;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.DockerException;
-import com.github.dockerjava.api.NotModifiedException;
+import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.exception.NotModifiedException;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.Run;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStopAll.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStopAll.java
@@ -1,6 +1,6 @@
 package com.nirima.jenkins.plugins.docker.builder;
 
-import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.exception.DockerException;
 import com.nirima.jenkins.plugins.docker.action.DockerLaunchAction;
 import hudson.Extension;
 import hudson.Launcher;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher.java
@@ -4,7 +4,7 @@ import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.common.CertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.DockerClientException;
+import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.command.PushImageCmd;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.BuildResponseItem;
@@ -262,7 +262,7 @@ public class DockerBuilderPublisher extends Builder implements Serializable, Sim
 
         private void cleanImages(String id) {
             getClient().removeImageCmd(id)
-                    .withForce()
+                    .withForce(true)
                     .exec();
         }
 

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientConfigBuilderForPlugin.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/client/ClientConfigBuilderForPlugin.java
@@ -5,6 +5,7 @@ import com.cloudbees.plugins.credentials.common.CertificateCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.KeystoreSSLConfig;
 import com.github.dockerjava.core.LocalDirectorySSLConfig;
@@ -22,7 +23,7 @@ import java.util.logging.Logger;
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.firstOrNull;
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.withId;
 import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
-import static com.github.dockerjava.core.DockerClientConfig.createDefaultConfigBuilder;
+import static com.github.dockerjava.core.DefaultDockerClientConfig.createDefaultConfigBuilder;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 /**
@@ -32,7 +33,7 @@ public class ClientConfigBuilderForPlugin {
 
     private static final Logger LOGGER = Logger.getLogger(ClientConfigBuilderForPlugin.class.getName());
 
-    private DockerClientConfig.DockerClientConfigBuilder config = createDefaultConfigBuilder();
+    private DefaultDockerClientConfig.Builder config = createDefaultConfigBuilder();
 
     private ClientConfigBuilderForPlugin() {
     }
@@ -66,8 +67,8 @@ public class ClientConfigBuilderForPlugin {
      * @return this builder
      */
     public ClientConfigBuilderForPlugin forServer(String uri, @Nullable String version) {
-        config.withUri(URI.create(uri).toString())
-                .withVersion(version);
+        config.withDockerHost(URI.create(uri).toString())
+                .withApiVersion(version);
         return this;
     }
 
@@ -84,21 +85,21 @@ public class ClientConfigBuilderForPlugin {
 
             if (credentials instanceof CertificateCredentials) {
                 CertificateCredentials certificateCredentials = (CertificateCredentials) credentials;
-                config.withSSLConfig(new KeystoreSSLConfig(
+                config.withCustomSslConfig(new KeystoreSSLConfig(
                         certificateCredentials.getKeyStore(),
                         certificateCredentials.getPassword().getPlainText()
                 ));
             }
             else if( credentials instanceof DockerDirectoryCredentials) {
                 DockerDirectoryCredentials ddc = (DockerDirectoryCredentials)credentials;
-                config.withSSLConfig( new LocalDirectorySSLConfig(ddc.getPath()));
+                config.withCustomSslConfig( new LocalDirectorySSLConfig(ddc.getPath()));
 
             } else if (credentials instanceof StandardUsernamePasswordCredentials) {
                 StandardUsernamePasswordCredentials usernamePasswordCredentials =
                         ((StandardUsernamePasswordCredentials) credentials);
 
-                config.withUsername(usernamePasswordCredentials.getUsername());
-                config.withPassword(usernamePasswordCredentials.getPassword().getPlainText());
+                config.withRegistryUsername(usernamePasswordCredentials.getUsername());
+                config.withRegistryPassword(usernamePasswordCredentials.getPassword().getPlainText());
             }
         }
         return this;
@@ -128,7 +129,7 @@ public class ClientConfigBuilderForPlugin {
      *
      * @return docker config builder
      */
-    /* package */ DockerClientConfig.DockerClientConfigBuilder config() {
+    /* package */ DefaultDockerClientConfig.Builder config() {
         return config;
     }
 

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher.java
@@ -1,7 +1,7 @@
 package com.nirima.jenkins.plugins.docker.launcher;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.NotFoundException;
+import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
@@ -110,10 +110,10 @@ public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
 //            logger.println("Creating jnlp connection command '" + Arrays.toString(connectCmd) + "' for '" + containerId + "'");
 
             final ExecCreateCmdResponse response = connect.execCreateCmd(containerId)
-                    .withTty()
-                    .withAttachStdin()
-                    .withAttachStderr()
-                    .withAttachStdout()
+                    .withTty(true)
+                    .withAttachStdin(true)
+                    .withAttachStderr(true)
+                    .withAttachStdout(true)
 //                    .withCmd(connectCmd)
                     .withCmd("/bin/bash", "-cxe", startCmd.replace("$", "\\$"))
                     .exec();
@@ -124,8 +124,8 @@ public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
 
             try {
                 connect.execStartCmd(response.getId())
-                        .withDetach()
-                        .withTty()
+                        .withDetach(true)
+                        .withTty(true)
                         .exec( new ExecStartResultCallback(null,null));
             } catch (NotFoundException ex) {
                 listener.error("Can't execute command: " + ex.getMessage());

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerLauncher.java
@@ -42,7 +42,7 @@ public abstract class DockerComputerLauncher extends ComputerLauncher {
      * Wait until slave is up and ready for connection.
      */
     public boolean waitUp(String cloudId, DockerTemplate dockerTemplate, InspectContainerResponse containerInspect) {
-        if (!containerInspect.getState().isRunning()) {
+        if (!containerInspect.getState().getRunning()) {
             throw new IllegalStateException("Container '" + containerInspect.getId() + "' is not running!");
         }
 

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -3,6 +3,7 @@ package com.nirima.jenkins.plugins.docker.launcher;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.NetworkSettings;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.Ports;
 import com.nirima.jenkins.plugins.docker.DockerCloud;
@@ -115,7 +116,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
         String host = null;
         Integer port = 22;
 
-        final InspectContainerResponse.NetworkSettings networkSettings = ir.getNetworkSettings();
+        final NetworkSettings networkSettings = ir.getNetworkSettings();
         final Ports ports = networkSettings.getPorts();
         final Map<ExposedPort, Ports.Binding[]> bindings = ports.getBindings();
 
@@ -124,7 +125,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
 
         // Find where it's mapped to
         for (Ports.Binding b : sshBindings) {
-            port = b.getHostPort();
+            port = Integer.valueOf(b.getHostPortSpec());
             host = b.getHostIp();
         }
 

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/publisher/DockerPublisherControl.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/publisher/DockerPublisherControl.java
@@ -1,6 +1,6 @@
 package com.nirima.jenkins.plugins.docker.publisher;
 
-import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.exception.DockerException;
 import com.nirima.jenkins.plugins.docker.builder.DockerBuilderControlOptionStopAll;
 import hudson.Extension;
 import hudson.Launcher;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
@@ -144,9 +144,9 @@ public class JenkinsUtils {
             StandardUsernamePasswordCredentials usernamePasswordCredentials =
                     ((StandardUsernamePasswordCredentials) credentials);
 
-            AuthConfig ac = new AuthConfig();
-            ac.setUsername( usernamePasswordCredentials.getUsername() );
-            ac.setPassword( usernamePasswordCredentials.getPassword().getPlainText() );
+            AuthConfig ac = new AuthConfig()
+            		.withUsername( usernamePasswordCredentials.getUsername() )
+            		.withPassword( usernamePasswordCredentials.getPassword().getPlainText() );
 
             return ac;
         }

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-serverUrl.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-serverUrl.html
@@ -1,3 +1,3 @@
 <div>
-    The URL to use to access your Docker server API (e.g: http://172.16.42.43:4243 or unix:///var/run/docker.sock).
+    The URL to use to access your Docker server API (e.g: tcp://172.16.42.43:4243 or unix:///var/run/docker.sock).
 </div>

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class ClientBuilderForPluginTest {
 
-    public static final String HTTP_SERVER_URL = "http://server.url/";
+    public static final String HTTP_SERVER_URL = "tcp://server.url/";
     public static final RemoteApiVersion DOCKER_API_VER = RemoteApiVersion.VERSION_1_19;
     public static final String CLOUD_NAME = "cloud-name";
     public static final int READ_TIMEOUT = 10;
@@ -58,8 +58,8 @@ public class ClientBuilderForPluginTest {
         builder.forCloud(cloud);
 
         DockerClientConfig config = builder.config().build();
-        assertThat("server", config.getUri().toString(), equalTo(HTTP_SERVER_URL));
-        assertThat("version", config.getVersion(), equalTo(DOCKER_API_VER));
+        assertThat("server", config.getDockerHost().toString(), equalTo(HTTP_SERVER_URL));
+        assertThat("version", config.getApiVersion(), equalTo(DOCKER_API_VER));
 //        assertThat("read TO", config.getReadTimeout(), equalTo((int) SECONDS.toMillis(READ_TIMEOUT)));
     }
 
@@ -69,8 +69,8 @@ public class ClientBuilderForPluginTest {
         builder.forServer(HTTP_SERVER_URL, "1.19").withCredentials(ID_OF_CREDS);
 
         DockerClientConfig config = builder.config().build();
-        assertThat("login", config.getUsername(), equalTo(USERNAME));
-        assertThat("pwd", config.getPassword(), equalTo(PASSWORD));
+        assertThat("login", config.getRegistryUsername(), equalTo(USERNAME));
+        assertThat("pwd", config.getRegistryPassword(), equalTo(PASSWORD));
     }
 
 


### PR DESCRIPTION
Docker-java 3.x allows the use of the ':Z' option for volumes. I don't know what's in your private fork (for wildcard SSL?), so this is based off the public release.

I haven't created an issue for this, what I wanted to do was specify this in a Docker template:

    Volumes: /tmp/fortify/:/home/jenkins/.fortify/:Z

Version 2.x of docker-java threw a parse error with volumes configured like this. Version 3.x supports it.