### PR TITLE
Guard against null image tags during pull logic

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -334,7 +334,11 @@ public class DockerCloud extends Cloud {
         boolean imageExists = Iterables.any(images, new Predicate<Image>() {
             @Override
             public boolean apply(Image image) {
-                return Arrays.asList(image.getRepoTags()).contains(fullImageName);
+                if (image == null || image.getRepoTags() == null) {
+                    return false;
+                } else {
+                    return Arrays.asList(image.getRepoTags()).contains(fullImageName);
+                }
             }
         });
 


### PR DESCRIPTION
For issue #415 

  - In the case where there happens to be a badly stored image on the
    target host it is possible that the image.getRepoTags() call will
    return null. This causes an exception to be thrown during processing
    which can only be recovered by cleaning up the Docker host. In the
    case where you either use a host/swarm managed by someone else, or
    share the resources with other teams, you cannot always guarantee
    all hosts will be clean, so it is important to include this check