### PR TITLE
JENKINS-36080 enable to specify docker api version

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -64,12 +64,7 @@ public class DockerCloud extends Cloud {
     public final String serverUrl;
     private int connectTimeout;
     public final int readTimeout;
-    /**
-     * TODO remove
-     * @deprecated Confuses users and no real use cases.
-     */
-    @Deprecated
-    public String version;
+    public final String version;
     public final String credentialsId;
 
     private transient DockerClient connection;
@@ -136,7 +131,7 @@ public class DockerCloud extends Cloud {
                        String version) {
         super(name);
         Preconditions.checkNotNull(serverUrl);
-        this.version = null;
+        this.version = version;
         this.credentialsId = credentialsId;
         this.serverUrl = serverUrl;
         this.connectTimeout = connectTimeout;
@@ -549,9 +544,7 @@ public class DockerCloud extends Cloud {
         for (DockerTemplate template : getTemplates()) {
             template.readResolve();
         }
-        if (version != null) {
-            version = null;
-        }
+
         return this;
     }
 
@@ -633,7 +626,7 @@ public class DockerCloud extends Cloud {
 
                 Version verResult = dc.versionCmd().exec();
 
-                return FormValidation.ok("Version = " + verResult.getVersion());
+                return FormValidation.ok("Version = " + verResult.getVersion() + ", API Version = " + verResult.getApiVersion());
             } catch (Exception e) {
                 return FormValidation.error(e, e.getMessage());
             }

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
@@ -9,9 +9,9 @@
         <f:textbox/>
     </f:entry>
 
-    <!--<f:entry title="${%Docker Version}" field="version">-->
-        <!--<f:textbox/>-->
-    <!--</f:entry>-->
+    <f:entry title="${%Docker API Version}" field="version">
+        <f:textbox/>
+    </f:entry>
 
     <f:entry title="${%Credentials}" field="credentialsId">
         <c:select/>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-serverUrl.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-serverUrl.html
@@ -1,3 +1,3 @@
 <div>
-    The URL to use to access your Docker server API (e.g: http://172.16.42.43:4243 or unix:///var/run/docker.sock).
+    The URL to use to access your Docker server API (e.g: tcp://172.16.42.43:4243 or unix:///var/run/docker.sock).
 </div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-version.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-version.html
@@ -1,5 +1,6 @@
 <div>
     API version. Appends path in format "/v${VERSION}" to api url for connector,
     where ${VERSION} is entered string. For details see <a href="https://docs.docker.com/reference/api/docker_remote_api/">docker_remote_api</a>
+    By default the latest version from the Docker server is used.
 </div>
 

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.equalTo;
  */
 public class ClientBuilderForPluginTest {
 
-    public static final String HTTP_SERVER_URL = "http://server.url/";
+    public static final String HTTP_SERVER_URL = "tcp://server.url/";
     public static final RemoteApiVersion DOCKER_API_VER = RemoteApiVersion.VERSION_1_19;
     public static final String CLOUD_NAME = "cloud-name";
     public static final int READ_TIMEOUT = 10;


### PR DESCRIPTION
Revert "Hide API version from users and nullify for existed installations."
This reverts commit 59abe7c1916c02247228b537be41d4ebd0478049.

Since our dependency docker-java is not yet docker api v1.24 compatible
we need a way to specify the docker api version to use. This was
functionality was removed a while ago. It is back now, as a more or less
workaround.