### PR TITLE
Fix reading of network settings from docker.

### DIFF
--- a/docker-java-shaded/pom.xml
+++ b/docker-java-shaded/pom.xml
@@ -33,7 +33,7 @@
              submodule. But for now it's probably better to allow CI to work
             as it will at least build on the CI. -->
 
-        <docker-java.version>3.0.6-jenkins</docker-java.version>
+        <docker-java.version>3.0.6</docker-java.version>
 
         <jersey.version>2.23.1</jersey.version>
         <jackson-jaxrs.version>2.6.4</jackson-jaxrs.version>

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -72,6 +72,7 @@ public class DockerCloud extends Cloud {
     public final int readTimeout;
     public final String version;
     public final String credentialsId;
+    public final String dockerHostname;
 
     private transient DockerClient connection;
 
@@ -104,7 +105,8 @@ public class DockerCloud extends Cloud {
                        int connectTimeout,
                        int readTimeout,
                        String credentialsId,
-                       String version) {
+                       String version,
+                       String dockerHostname) {
         super(name);
         Preconditions.checkNotNull(serverUrl);
         this.version = version;
@@ -112,6 +114,7 @@ public class DockerCloud extends Cloud {
         this.serverUrl = sanitizeUrl(serverUrl);
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
+        this.dockerHostname = dockerHostname;
 
         if (templates != null) {
             this.templates = new ArrayList<>(templates);
@@ -134,7 +137,8 @@ public class DockerCloud extends Cloud {
                        int connectTimeout,
                        int readTimeout,
                        String credentialsId,
-                       String version) {
+                       String version,
+                       String dockerHostname) {
         super(name);
         Preconditions.checkNotNull(serverUrl);
         this.version = version;
@@ -142,6 +146,7 @@ public class DockerCloud extends Cloud {
         this.serverUrl = sanitizeUrl(serverUrl);
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
+        this.dockerHostname = dockerHostname;
 
         if (templates != null) {
             this.templates = new ArrayList<>(templates);
@@ -158,6 +163,10 @@ public class DockerCloud extends Cloud {
 
     public String getServerUrl() {
         return serverUrl;
+    }
+
+    public String getDockerHostname() {
+        return dockerHostname;
     }
 
     /**

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -139,11 +139,12 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
         //get address, if docker on localhost, then use local?
         if (host == null || host.equals("0.0.0.0")) {
             String url = DockerCloud.getCloudByName(cloudId).getServerUrl();
-            if( url.startsWith("unix") ) {
+            host = getDockerHostFromCloud(cloudId);
+
+            if( url.startsWith("unix") && (host == null || host.trim().isEmpty()) ) {
                 // Communicating with local sockets.
                 host = "0.0.0.0";
             } else {
-                host = getDockerHostFromCloud(cloudId);
 
             /* Don't use IP from DOCKER_HOST because it is invalid or we are
              * connecting to a system that supports a single host abstraction

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -143,7 +143,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
                 // Communicating with local sockets.
                 host = "0.0.0.0";
             } else {
-                host = URI.create(url).getHost();
+                host = getDockerHostFromCloud(cloudId);
 
             /* Don't use IP from DOCKER_HOST because it is invalid or we are
              * connecting to a system that supports a single host abstraction
@@ -157,6 +157,19 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
         }
 
         return new InetSocketAddress(host, port);
+    }
+
+    private String getDockerHostFromCloud(String cloudId) {
+        String url;
+        String host;
+        DockerCloud cloud = DockerCloud.getCloudByName(cloudId);
+        url = cloud.getServerUrl();
+        String dockerHostname = cloud.getDockerHostname();
+        if (dockerHostname != null && !dockerHostname.trim().isEmpty()) {
+            return dockerHostname;
+        } else {
+            return URI.create(url).getHost();
+        }
     }
 
     @Override

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -79,7 +79,8 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
         super.waitUp(cloudId, dockerTemplate, containerInspect);
 
         final PortUtils.ConnectionCheck connectionCheck =
-                PortUtils.connectionCheck(getAddressForSSHD(cloudId, containerInspect))
+                PortUtils.connectionCheck(
+                        getAddressForSSHD(cloudId, containerInspect, dockerTemplate.getDockerTemplateBase().network))
                          .withRetries(60)
                          .withEveryRetryWaitFor(2, TimeUnit.SECONDS);
 
@@ -91,7 +92,9 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
         Preconditions.checkNotNull(inspect);
 
         try {
-            final InetSocketAddress address = getAddressForSSHD(cloudId, inspect);
+            final InetSocketAddress address = getAddressForSSHD(
+                    cloudId, inspect, template.getDockerTemplateBase().network
+            );
             LOGGER.log(Level.INFO, "Creating slave SSH launcher for " + address);
             return new SSHLauncher(address.getHostString(), address.getPort(), sshConnector.getCredentials(),
                     sshConnector.jvmOptions,
@@ -112,7 +115,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
      * a direct connection.
      *
      */
-    protected InetSocketAddress getAddressForSSHD(String cloudId, InspectContainerResponse ir) {
+    protected InetSocketAddress getAddressForSSHD(String cloudId, InspectContainerResponse ir, String network) {
         // get exposed port
         ExposedPort sshPort = new ExposedPort(sshConnector.port);
         String host = null;
@@ -151,7 +154,11 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
              * like Joyent's Triton. */
                 if (host == null || host.equals("0.0.0.0") || usesSingleHostAbstraction(ir)) {
                     // Try to connect to the container directly (without going through the host)
-                    host = networkSettings.getIpAddress();
+                    if (network != null && network.length() > 0) {
+                        host = networkSettings.getNetworks().get(network).getIpAddress();
+                    } else {
+                        host = networkSettings.getIpAddress();
+                    }
                     port = sshConnector.port;
                 }
             }

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
@@ -9,6 +9,10 @@
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%Docker Hostname}" field="dockerHostname">
+        <f:textbox/>
+    </f:entry>
+
     <f:entry title="${%Docker API Version}" field="version">
         <f:textbox/>
     </f:entry>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-dockerHostname.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-dockerHostname.html
@@ -1,0 +1,4 @@
+<div>
+    The Docker Hostname (or IP) to use to access your Docker Host from the internal or external network.
+    Required when using unix-domain sockets otherwise automatically set as the host part of Server URL.
+</div>

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
@@ -17,6 +17,7 @@ public class DockerCloudTest {
                 10, // connectTimeout,
                 10, // readTimeout,
                 null, // credentialsId,
-                null); //version
+                null, //version
+                null); // dockerHostname
     }
 }

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
@@ -53,7 +53,7 @@ public class ClientBuilderForPluginTest {
                 Collections.<DockerTemplate>emptyList(),
                 HTTP_SERVER_URL,
                 EMPTY_CONTAINER_CAP,
-                CONNECT_TIMEOUT, READ_TIMEOUT, EMPTY_CREDS, "1.19");
+                CONNECT_TIMEOUT, READ_TIMEOUT, EMPTY_CREDS, "1.19", "");
         ClientConfigBuilderForPlugin builder = dockerClientConfig();
         builder.forCloud(cloud);
 


### PR DESCRIPTION
This pull request fixes https://issues.jenkins-ci.org/browse/JENKINS-38135 by reading the container's IP address from the `network` map of the container settings instead of using the deprecated top-level `IPAddress` field in case a custom network is defined for the docker template.
