### PR TITLE
Configure Docker hostname when using unix socks

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -72,6 +72,7 @@ public class DockerCloud extends Cloud {
     public final int readTimeout;
     public final String version;
     public final String credentialsId;
+    public final String dockerHostname;
 
     private transient DockerClient connection;
 
@@ -104,7 +105,8 @@ public class DockerCloud extends Cloud {
                        int connectTimeout,
                        int readTimeout,
                        String credentialsId,
-                       String version) {
+                       String version,
+                       String dockerHostname) {
         super(name);
         Preconditions.checkNotNull(serverUrl);
         this.version = version;
@@ -112,6 +114,7 @@ public class DockerCloud extends Cloud {
         this.serverUrl = sanitizeUrl(serverUrl);
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
+        this.dockerHostname = dockerHostname;
 
         if (templates != null) {
             this.templates = new ArrayList<>(templates);
@@ -134,7 +137,8 @@ public class DockerCloud extends Cloud {
                        int connectTimeout,
                        int readTimeout,
                        String credentialsId,
-                       String version) {
+                       String version,
+                       String dockerHostname) {
         super(name);
         Preconditions.checkNotNull(serverUrl);
         this.version = version;
@@ -142,6 +146,7 @@ public class DockerCloud extends Cloud {
         this.serverUrl = sanitizeUrl(serverUrl);
         this.connectTimeout = connectTimeout;
         this.readTimeout = readTimeout;
+        this.dockerHostname = dockerHostname;
 
         if (templates != null) {
             this.templates = new ArrayList<>(templates);
@@ -158,6 +163,10 @@ public class DockerCloud extends Cloud {
 
     public String getServerUrl() {
         return serverUrl;
+    }
+
+    public String getDockerHostname() {
+        return dockerHostname;
     }
 
     /**

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -143,7 +143,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
                 // Communicating with local sockets.
                 host = "0.0.0.0";
             } else {
-                host = URI.create(url).getHost();
+                host = getDockerHostFromCloud(cloudId);
 
             /* Don't use IP from DOCKER_HOST because it is invalid or we are
              * connecting to a system that supports a single host abstraction
@@ -157,6 +157,18 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
         }
 
         return new InetSocketAddress(host, port);
+    }
+
+    private String getDockerHostFromCloud(String cloudId) {
+        String url;
+        String host;DockerCloud cloud = DockerCloud.getCloudByName(cloudId);
+        url = cloud.getServerUrl();
+        String dockerHostname = cloud.getDockerHostname();
+        if (dockerHostname != null && !dockerHostname.trim().isEmpty()) {
+            return dockerHostname;
+        } else {
+            return URI.create(url).getHost();
+        }
     }
 
     @Override

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -161,7 +161,8 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
 
     private String getDockerHostFromCloud(String cloudId) {
         String url;
-        String host;DockerCloud cloud = DockerCloud.getCloudByName(cloudId);
+        String host;
+        DockerCloud cloud = DockerCloud.getCloudByName(cloudId);
         url = cloud.getServerUrl();
         String dockerHostname = cloud.getDockerHostname();
         if (dockerHostname != null && !dockerHostname.trim().isEmpty()) {

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
@@ -9,6 +9,10 @@
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%Docker Hostname}" field="dockerHostname">
+        <f:textbox/>
+    </f:entry>
+
     <f:entry title="${%Docker API Version}" field="version">
         <f:textbox/>
     </f:entry>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-dockerHostname.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-dockerHostname.html
@@ -1,0 +1,4 @@
+<div>
+    The Docker Hostname (or IP) to use to access your Docker Host from the internal or external network.
+    Required when using unix-domain sockets otherwise automatically set as the host part of Server URL.
+</div>

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
@@ -17,6 +17,7 @@ public class DockerCloudTest {
                 10, // connectTimeout,
                 10, // readTimeout,
                 null, // credentialsId,
-                null); //version
+                null, //version
+                null); // dockerHostname
     }
 }

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/client/ClientBuilderForPluginTest.java
@@ -53,7 +53,7 @@ public class ClientBuilderForPluginTest {
                 Collections.<DockerTemplate>emptyList(),
                 HTTP_SERVER_URL,
                 EMPTY_CONTAINER_CAP,
-                CONNECT_TIMEOUT, READ_TIMEOUT, EMPTY_CREDS, "1.19");
+                CONNECT_TIMEOUT, READ_TIMEOUT, EMPTY_CREDS, "1.19", "");
         ClientConfigBuilderForPlugin builder = dockerClientConfig();
         builder.forCloud(cloud);
 


### PR DESCRIPTION
When using Docker URL with unix-domains sockets we cannot access the
docker hostname from the host part of the URL. Even using the docker
inspection of the machine created dynamically would not expose the
right value accessible from the outside.

Allow to explicitly define the Docker hostname you want to use when
Jenkins master needs to connect to slave instances created.