### PR TITLE
Bumping docker-java.version to 3.0.6

### DIFF
--- a/docker-java-shaded/pom.xml
+++ b/docker-java-shaded/pom.xml
@@ -33,7 +33,7 @@
              submodule. But for now it's probably better to allow CI to work
             as it will at least build on the CI. -->
 
-        <docker-java.version>3.0.6-jenkins</docker-java.version>
+        <docker-java.version>3.0.6</docker-java.version>
 
         <jersey.version>2.23.1</jersey.version>
         <jackson-jaxrs.version>2.6.4</jackson-jaxrs.version>


### PR DESCRIPTION
Version 3.0.6-jenkins of java-docker apprently is no longer available for CI builds. That is why pull-requests are currently failing with their builds (thus, making everyone blind to real errors which need to be fixed).

This change bumps the docker-java version to the final version of 3.0.6 which is currently in place (needs to be checked, if this version is also ok from a delivery perspective).