### PR TITLE
Give high priority to Docker Hostname definition

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -139,11 +139,12 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
         //get address, if docker on localhost, then use local?
         if (host == null || host.equals("0.0.0.0")) {
             String url = DockerCloud.getCloudByName(cloudId).getServerUrl();
-            if( url.startsWith("unix") ) {
+            host = getDockerHostFromCloud(cloudId);
+
+            if( url.startsWith("unix") && (host == null || host.trim().isEmpty()) ) {
                 // Communicating with local sockets.
                 host = "0.0.0.0";
             } else {
-                host = getDockerHostFromCloud(cloudId);
 
             /* Don't use IP from DOCKER_HOST because it is invalid or we are
              * connecting to a system that supports a single host abstraction


### PR DESCRIPTION
When the Docker Hostname is defined at Cloud level, it should be used
as preferential setting over the other automatisms.