### PR TITLE
JENKINS-39100 - Fix NPE in makeAuthConfig

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
@@ -169,8 +169,10 @@ public class JenkinsUtils {
             return null;
 
         Credentials credentials = lookupSystemCredentials(registry.credentialsId);
-
-        return makeAuthConfig(credentials).withRegistryAddress(registry.registry);
+        final AuthConfig authConfig = makeAuthConfig(credentials);
+        if( authConfig == null )
+            return null;
+        return authConfig.withRegistryAddress(registry.registry);
     }
 
     protected static AuthConfig makeAuthConfig(Credentials credentials) {


### PR DESCRIPTION
Prevents NPE during JenkinsUtils.makeAuthConfig when dealing with registries that have no username/password defined.
