### PR TITLE
JENKINS-39103: Fix "Build / Publish Docker Container" Image field validation

### DIFF
--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/config.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/config.jelly
@@ -11,8 +11,7 @@
         <f:textbox />
     </f:entry>
 
-    <f:entry title="Image" field="tagsString"
-             description="Repository name (and optionally a tag)">
+    <f:entry title="Image" field="tagsString">
         <f:expandableTextbox/>
     </f:entry>
 

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-pushOnSuccess.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-pushOnSuccess.html
@@ -1,0 +1,3 @@
+<div>
+    If enabled (and the docker image builds successfully), the resulting docker image will be pushed to the registry (or registries) specified within the "Image" field.
+</div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-tagsString.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-tagsString.html
@@ -1,4 +1,6 @@
 <div>
     Repository name (and optionally a tag) to be applied to the resulting image in case of success. <br/>
-    New line separated values.
+    Multiple entries are permitted if separated by newlines. <br/>
+    Environment variable substitution is performed on the strings so you can use e.g. ${BUILD_NUMBER} as part of each entry. <br/>
+    Each entry must be of the form IMAGE[:TAG] as per the <a href="https://docs.docker.com/engine/reference/commandline/tag/">docker tag</a> command.
 </div>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help.html
@@ -1,3 +1,3 @@
 <div>
-    Build step that sends Dockerfile for building to docker host that used for this build run.
+    Build step that sends a Dockerfile for building to docker host that used for this build run.
 </div>

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisherTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisherTest.java
@@ -1,0 +1,100 @@
+package com.nirima.jenkins.plugins.docker.builder;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DockerBuilderPublisherTest {
+    private static final String VALID1 = "myimage";
+    private static final String VALID2 = "my/image-2";
+    private static final String VALID3 = "myimage_3:tag";
+    private static final String VALID4 = "myimage.4:Tag4";
+    private static final String VALID5 = "localhost/myimage";
+    private static final String VALID6 = "localhost.localdomain/myimage:My_Tag-6";
+    private static final String VALID7 = "my.repository.com:1234/myimage.7";
+    private static final String VALID8 = "my.repository.com:${PORT_NUMBER}/myimage.7";
+    private static final String VALID9 = "localhost.localdomain:5000/myimage:${JOB_NAME}-latest";
+    private static final String VALID10 = "localhost.localdomain:5000/myimage:${JOB_NAME}-${BUILD_NUMBER}";
+    private static final String INVALID1 = "MyImagei1";
+    private static final String INVALID2 = "myimage%";
+    private static final String INVALID3 = "1.2.3.4:abc/myimage:invalid3";
+    private static final String INVALID4 = "funnyhost£name:5000/myimage4";
+
+    @Test
+    public void verifyTagsGivenValidTagsThenPasses() {
+        // Given
+        final String validTags = String.join("\n", VALID1, VALID2, VALID3, VALID4, VALID5, VALID6, VALID7, VALID8,
+                VALID9, VALID10);
+
+        // When
+        DockerBuilderPublisher.verifyTags(validTags);
+
+        // Then
+        // no exception thrown
+    }
+
+    @Test
+    public void verifyTagsGivenInvalidTag1ThenThrows() {
+        // Given
+        final String invalidTag = INVALID1;
+        final String tags = String.join("\n", VALID1, invalidTag, VALID2);
+
+        // When
+        try {
+            DockerBuilderPublisher.verifyTags(tags);
+            Assert.fail("Expected exception");
+        } catch (IllegalArgumentException ex) {
+            // Then
+            Assert.assertThat(ex.getMessage(), containsString(invalidTag));
+        }
+    }
+
+    @Test
+    public void verifyTagsGivenInvalidTag2ThenThrows() {
+        // Given
+        final String invalidTag = INVALID2;
+        final String tags = String.join("\n", VALID1, invalidTag, VALID2);
+
+        // When
+        try {
+            DockerBuilderPublisher.verifyTags(tags);
+            Assert.fail("Expected exception");
+        } catch (IllegalArgumentException ex) {
+            // Then
+            Assert.assertThat(ex.getMessage(), containsString(invalidTag));
+        }
+    }
+
+    @Test
+    public void verifyTagsGivenInvalidTag3ThenThrows() {
+        // Given
+        final String invalidTag = INVALID3;
+        final String tags = String.join("\n", VALID1, invalidTag, VALID2);
+
+        // When
+        try {
+            DockerBuilderPublisher.verifyTags(tags);
+            Assert.fail("Expected exception");
+        } catch (IllegalArgumentException ex) {
+            // Then
+            Assert.assertThat(ex.getMessage(), containsString(invalidTag));
+        }
+    }
+
+    @Test
+    public void verifyTagsGivenInvalidTag4ThenThrows() {
+        // Given
+        final String invalidTag = INVALID4;
+        final String tags = String.join("\n", VALID1, invalidTag, VALID2);
+
+        // When
+        try {
+            DockerBuilderPublisher.verifyTags(tags);
+            Assert.fail("Expected exception");
+        } catch (IllegalArgumentException ex) {
+            // Then
+            Assert.assertThat(ex.getMessage(), containsString(invalidTag));
+        }
+    }
+}


### PR DESCRIPTION
Improvements to Web-UI on the "Build / Publish Docker Container" build step.
Doesn't change what the build step does when it runs - these changes are limited to the UI (and the validation code behind the UI).
