### PR TITLE
Docker Port Binding during SSH-Connection startup

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -71,7 +71,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
             createCmd.withCmd("bash", "-c", "/usr/sbin/sshd -D -p " + sshPort);
         }
 
-        createCmd.getPortBindings().add(PortBinding.parse("0.0.0.0::" + sshPort));
+        createCmd.getPortBindings().add(PortBinding.parse( "" + sshPort));
     }
 
     @Override


### PR DESCRIPTION
Do not require the port binding for the ssh service to be on the 0.0.0.0 address.

The problem is that Windows Server 2016 docker implementation does not support "host IP addresses in NAT settings" - Removing the fixed IP solves the problem and makes no problems with *NIX based servers.
