### PR TITLE
[FIX JENKINS-39689] don't embed an old version of tiger_types

### DIFF
--- a/docker-java-shaded/pom.xml
+++ b/docker-java-shaded/pom.xml
@@ -257,6 +257,15 @@
                             <include>com.google.guava:*</include>
                         </includes>
                     </artifactSet>
+                    <filters>
+                      <filter>
+                          <!-- JENKINS-39689: never embed tiger_types to not conflict with the one pulled by Stapler -->
+                          <artifact>*:*</artifact>
+                          <excludes>
+                            <exclude>org/jvnet/tiger_types/*</exclude>
+                          </excludes>
+                      </filter>
+                    </filters>
                     <relocations>
                         <relocation>
                             <pattern>org.apache.http</pattern>

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisherTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisherTest.java
@@ -19,7 +19,7 @@ public class DockerBuilderPublisherTest {
     private static final String INVALID1 = "MyImagei1";
     private static final String INVALID2 = "myimage%";
     private static final String INVALID3 = "1.2.3.4:abc/myimage:invalid3";
-    private static final String INVALID4 = "funnyhost£name:5000/myimage4";
+    private static final String INVALID4 = "funnyhostÂ£name:5000/myimage4";
 
     @Test
     public void verifyTagsGivenValidTagsThenPasses() {


### PR DESCRIPTION
Which in turn is used by Stapler