### PR TITLE
Correctly encode the £ in UTF-8

### DIFF
--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisherTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisherTest.java
@@ -19,7 +19,7 @@ public class DockerBuilderPublisherTest {
     private static final String INVALID1 = "MyImagei1";
     private static final String INVALID2 = "myimage%";
     private static final String INVALID3 = "1.2.3.4:abc/myimage:invalid3";
-    private static final String INVALID4 = "funnyhost£name:5000/myimage4";
+    private static final String INVALID4 = "funnyhostÂ£name:5000/myimage4";
 
     @Test
     public void verifyTagsGivenValidTagsThenPasses() {


### PR DESCRIPTION
That character has apparently been submitted using a CP-1252 encoding
(the Windows default one).

This is failing the build somehow. At least there's currently an error
during the compilation of that test class file:

```
[INFO] Compiling 8 source files to /scratch/jenkins/workspace/plugins/docker-plugin-freestyle/docker-plugin/target/test-classes
[ERROR] /scratch/jenkins/workspace/plugins/docker-plugin-freestyle/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisherTest.java:[22,54] unmappable character for encoding UTF-8
```