### PR TITLE
Add Windows containers support for JNLP slaves

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -13,6 +13,7 @@ import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Image;
 import com.github.dockerjava.api.model.Version;
+import com.github.dockerjava.api.model.Info;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.NameParser;
@@ -310,7 +311,7 @@ public class DockerCloud extends Cloud {
 
         // contribute launcher specific options
         if (launcher != null) {
-            launcher.appendContainerConfig(dockerTemplate, containerConfig);
+            launcher.appendContainerConfig(dockerTemplate, containerConfig, dockerClient);
         }
 
         // create
@@ -721,8 +722,9 @@ public class DockerCloud extends Cloud {
                         .build();
 
                 Version verResult = dc.versionCmd().exec();
+                Info infoResult = dc.infoCmd().exec();
 
-                return FormValidation.ok("Version = " + verResult.getVersion() + ", API Version = " + verResult.getApiVersion());
+                return FormValidation.ok("Version = " + verResult.getVersion() + ", API Version = " + verResult.getApiVersion() + ", OS type = " + infoResult.getOsType());
             } catch (Exception e) {
                 return FormValidation.error(e, e.getMessage());
             }

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher.java
@@ -19,6 +19,7 @@ import hudson.slaves.JNLPLauncher;
 import hudson.slaves.SlaveComputer;
 import hudson.util.TimeUnit2;
 import jenkins.model.Jenkins;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.accmod.Restricted;
@@ -182,9 +183,10 @@ public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
                 if (initCmd == null) {
                     throw new IllegalStateException("Resource file 'init.ps1' not found");
                 }
-                createContainerCmd.withCmd("powershell.exe", "(@\"\n" +
+                createContainerCmd.withEntrypoint("powershell.exe")
+                        .withCmd("powershell.exe", "-NoLogo", "-ExecutionPolicy", "bypass", "-Command", "{@\"\n" +
                         initCmd.replace("$", "`$") +
-                        "\n\"@ | Out-File -FilePath c:\\init.ps1) -and (c:\\init.ps1)");
+                        "\n\"@ | Out-File -FilePath c:\\init.ps1 ; if($?) {c:\\init.ps1}}");
             }
         } else {
             // default is Linux

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerLauncher.java
@@ -1,6 +1,7 @@
 package com.nirima.jenkins.plugins.docker.launcher;
 
 
+import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
@@ -36,7 +37,7 @@ public abstract class DockerComputerLauncher extends ComputerLauncher {
      * i.e. port for exposing, command to run, etc.
      */
     public abstract void appendContainerConfig(DockerTemplate dockerTemplate,
-                                               CreateContainerCmd createContainerCmd) throws IOException;
+                                               CreateContainerCmd createContainerCmd, DockerClient dockerClient) throws IOException;
 
     /**
      * Wait until slave is up and ready for connection.

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -1,5 +1,6 @@
 package com.nirima.jenkins.plugins.docker.launcher;
 
+import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ExposedPort;
@@ -60,7 +61,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
     }
 
     @Override
-    public void appendContainerConfig(DockerTemplate dockerTemplate, CreateContainerCmd createCmd) {
+    public void appendContainerConfig(DockerTemplate dockerTemplate, CreateContainerCmd createCmd, DockerClient client) {
         final int sshPort = getSshConnector().port;
 
         createCmd.withExposedPorts(new ExposedPort(sshConnector.port));

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -1,0 +1,52 @@
+$CONFIG="c:\config.ps1"
+
+while ( -not (Test-Path $CONFIG)){
+    Write-Output "No config, sleeping for 1 second"
+    sleep 1
+}
+
+
+Write-Output "Found config file"
+. "$CONFIG"
+# require:
+# $JENKINS_URL
+# $COMPUTER_URL
+# $COMPUTER_SECRET
+
+if (!$JENKINS_URL){
+ echo "JENKINS_URL is not defined! Exiting."
+ exit 1
+}
+
+if (!$COMPUTER_URL){
+ echo "COMPUTER_URL is not defined! Exiting."
+ exit 1
+}
+
+
+# Jenkins not at home - use tmp
+if (-not (Test-Path $JENKINS_HOME)){
+  New-Item -ItemType directory -Path c:\Temp
+  $JENKINS_HOME="c:\Temp"
+}
+
+Write-Output "###################################"
+Write-Output "JENKINS_URL = $JENKINS_URL         "
+Write-Output "JENKINS_USER = $JENKINS_USER       "
+Write-Output "JENKINS_HOME = $JENKINS_HOME       "
+Write-Output "COMPUTER_URL = $COMPUTER_URL       "
+Write-Output "COMPUTER_SECRET = $COMPUTER_SECRET "
+Write-Output "###################################"
+
+Get-Item Env:
+
+cd "$JENKINS_HOME"
+
+
+(New-Object System.Net.WebClient).DownloadFile("${JENKINS_URL}/jnlpJars/slave.jar", "${JENKINS_HOME}/slave.jar")
+
+$slaveName=$COMPUTER_URL -replace "computer/", "" -replace "/", ""
+$RUN_OPTS="hudson.remoting.jnlp.Main -headless -url $JENKINS_URL $COMPUTER_SECRET $slaveName "
+
+$RUN_CMD="java $CMD_OPTS -cp ${JENKINS_HOME}/slave.jar $RUN_OPTS"
+Invoke-Expression $RUN_CMD

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -48,5 +48,5 @@ cd "$JENKINS_HOME"
 $slaveName=$COMPUTER_URL -replace "computer/", "" -replace "/", ""
 $RUN_OPTS="hudson.remoting.jnlp.Main -headless -url $JENKINS_URL $COMPUTER_SECRET $slaveName "
 
-$RUN_CMD="java $CMD_OPTS -cp ${JENKINS_HOME}/slave.jar $RUN_OPTS"
+$RUN_CMD="java $env:CMD_OPTS -cp ${JENKINS_HOME}/slave.jar $RUN_OPTS"
 Invoke-Expression $RUN_CMD

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher/init.ps1
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher/init.ps1
@@ -36,6 +36,7 @@ Write-Output "JENKINS_USER = $JENKINS_USER       "
 Write-Output "JENKINS_HOME = $JENKINS_HOME       "
 Write-Output "COMPUTER_URL = $COMPUTER_URL       "
 Write-Output "COMPUTER_SECRET = $COMPUTER_SECRET "
+Write-Output "env:CMD_OPTS = $env:CMD_OPTS       "
 Write-Output "###################################"
 
 Get-Item Env:
@@ -48,5 +49,6 @@ cd "$JENKINS_HOME"
 $slaveName=$COMPUTER_URL -replace "computer/", "" -replace "/", ""
 $RUN_OPTS="hudson.remoting.jnlp.Main -headless -url $JENKINS_URL $COMPUTER_SECRET $slaveName "
 
-$RUN_CMD="java $env:CMD_OPTS -cp ${JENKINS_HOME}/slave.jar $RUN_OPTS"
+$RUN_CMD="java $env:CMD_OPTS -cp ${JENKINS_HOME}\\slave.jar $RUN_OPTS"
+Write-Output "RUN_OPTS = $RUN_CMD"
 Invoke-Expression $RUN_CMD


### PR DESCRIPTION
Add support of Windows containers as JNLP docker slaves.
Work the same way as linux part (run an init script and push config with exec command).
You can find Windows image I have used for my test [here](https://hub.docker.com/r/nanori/jenkins-windows-slave/)

Many thanks to [@Thitho007](https://github.com/Thitho007) for his precious help

Feel free to ask if you run into some issues 