### PR TITLE
[FIX docker-plugin-407] Make ssh port binding configurable

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate.java
@@ -21,6 +21,7 @@ public class DockerSimpleTemplate extends DockerTemplateBase {
                                 Integer cpuShares,
                                 String bindPorts,
                                 boolean bindAllPorts,
+                                boolean bindSshPortLocalhost,
                                 boolean privileged,
                                 boolean tty,
                                 String macAddress) {
@@ -38,6 +39,7 @@ public class DockerSimpleTemplate extends DockerTemplateBase {
                 cpuShares,
                 bindPorts,
                 bindAllPorts,
+                bindSshPortLocalhost,
                 privileged,
                 tty,
                 macAddress);

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBackwardCompatibility.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBackwardCompatibility.java
@@ -120,6 +120,9 @@ public abstract class DockerTemplateBackwardCompatibility {
     private transient boolean bindAllPorts;
 
     @Deprecated
+    private transient boolean bindSshPortLocalhost;
+
+    @Deprecated
     private transient Integer memoryLimit;
     @Deprecated
     private transient Integer memorySwap;
@@ -128,6 +131,7 @@ public abstract class DockerTemplateBackwardCompatibility {
 
     @Deprecated
     private transient boolean privileged;
+
     @Deprecated
     private transient boolean tty;
 
@@ -222,6 +226,7 @@ public abstract class DockerTemplateBackwardCompatibility {
                         cpuShares,
                         bindPorts,
                         bindAllPorts,
+                        bindSshPortLocalhost,
                         privileged,
                         tty,
                         macAddress)

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -90,6 +90,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase> {
 
     public final String bindPorts;
     public final boolean bindAllPorts;
+    public final boolean bindSshPortLocalhost;
 
     public final Integer memoryLimit;
     public final Integer memorySwap;
@@ -119,6 +120,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase> {
                               Integer cpuShares,
                               String bindPorts,
                               boolean bindAllPorts,
+                              boolean bindSshPortLocalhost,
                               boolean privileged,
                               boolean tty,
                               String macAddress
@@ -132,6 +134,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase> {
 
         this.bindPorts = bindPorts;
         this.bindAllPorts = bindAllPorts;
+        this.bindSshPortLocalhost = bindSshPortLocalhost;
 
         this.memoryLimit = memoryLimit;
         this.memorySwap = memorySwap;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
@@ -52,6 +52,7 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
     public final Integer memorySwap;
     public final Integer cpuShares;
     public final boolean bindAllPorts;
+    public final boolean bindSshPortLocalhost;
     public final String macAddress;
 
     @DataBoundConstructor
@@ -71,6 +72,7 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
             Integer cpuShares,
             String bindPorts,
             boolean bindAllPorts,
+            boolean bindSshPortLocalhost,
             boolean privileged,
             boolean tty,
             String macAddress) {
@@ -92,6 +94,7 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
         this.memorySwap = memorySwap;
         this.cpuShares = cpuShares;
         this.bindAllPorts = bindAllPorts;
+        this.bindSshPortLocalhost = bindSshPortLocalhost;
         this.macAddress = macAddress;
     }
 
@@ -130,7 +133,7 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
         DockerTemplateBase template = new DockerSimpleTemplate(xImage,
                 dnsString, network, xCommand,
                 volumesString, volumesFrom, environmentsString, lxcConfString, xHostname,
-                memoryLimit, memorySwap, cpuShares, bindPorts, bindAllPorts, privileged, tty, macAddress);
+                memoryLimit, memorySwap, cpuShares, bindPorts, bindAllPorts, bindSshPortLocalhost, privileged, tty, macAddress);
 
         LOG.info("Starting container for image {}", xImage);
         llog.println("Starting container for image " + xImage);

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplate.java
@@ -62,6 +62,7 @@ public class DockerBuilderNewTemplate extends DockerBuilderNewTemplateBackwardCo
                                     String hostname,
                                     String bindPorts,
                                     boolean bindAllPorts,
+                                    boolean bindSshPortLocalhost,
                                     boolean privileged,
                                     boolean tty,
                                     String macAddress) {
@@ -89,6 +90,7 @@ public class DockerBuilderNewTemplate extends DockerBuilderNewTemplateBackwardCo
         this.lxcConfString = lxcConfString;
         this.bindPorts = bindPorts;
         this.bindAllPorts = bindAllPorts;
+        this.bindSshPortLocalhost = bindSshPortLocalhost;
         this.privileged = privileged;
         this.tty = tty;
         this.hostname = hostname;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplateBackwardCompatibility.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderNewTemplateBackwardCompatibility.java
@@ -48,7 +48,7 @@ public abstract class DockerBuilderNewTemplateBackwardCompatibility extends Buil
     protected transient Integer memoryLimit, memorySwap, cpuShares;
 
     @Deprecated
-    protected transient boolean bindAllPorts, privileged, tty;
+    protected transient boolean bindAllPorts, bindSshPortLocalhost, privileged, tty;
 
 
     public abstract void setDockerTemplate(DockerTemplate dockerTemplate);
@@ -56,7 +56,7 @@ public abstract class DockerBuilderNewTemplateBackwardCompatibility extends Buil
     protected void convert1() {
         final DockerTemplateBase dockerTemplateBase = new DockerTemplateBase(image, dnsString, network, dockerCommand,
                 volumesString, null, environmentsString, lxcConfString,
-                hostname, memoryLimit, memorySwap, cpuShares, bindPorts, bindAllPorts, privileged, tty, macAddress
+                hostname, memoryLimit, memorySwap, cpuShares, bindPorts, bindAllPorts, bindSshPortLocalhost, privileged, tty, macAddress
         );
 
         final DockerComputerSSHLauncher dockerComputerSSHLauncher = new DockerComputerSSHLauncher(

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -71,8 +71,16 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
             createCmd.withCmd("bash", "-c", "/usr/sbin/sshd -D -p " + sshPort);
         }
 
-        createCmd.getPortBindings().add(PortBinding.parse( "" + sshPort));
+        boolean bindSshPortLocalhost = dockerTemplate.getDockerTemplateBase().bindSshPortLocalhost;
+        
+        if (bindSshPortLocalhost) {
+            createCmd.getPortBindings().add(PortBinding.parse("127.0.0.1::" + sshPort));
+        }
+        else {
+            createCmd.getPortBindings().add(PortBinding.parse( "" + sshPort));
+        }
     }
+
 
     @Override
     public boolean waitUp(String cloudId, DockerTemplate dockerTemplate, InspectContainerResponse containerInspect) {

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate/config.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate/config.jelly
@@ -24,6 +24,10 @@
             <f:checkbox/>
         </f:entry>
 
+        <f:entry title="${%Bind all declared ports}" field="bindSshPortLocalhost">
+            <f:checkbox/>
+        </f:entry>
+
         <f:entry title="${%Hostname}" field="hostname">
             <f:textbox/>
         </f:entry>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.groovy
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.groovy
@@ -47,6 +47,10 @@ f.advanced(title: _("Container settings"), align: "left") {
         f.checkbox()
     }
 
+    f.entry(title: _("Bind ssh port to localhost only"), field: "bindSshPortLocalhost") {
+        f.checkbox()
+    }
+
     f.entry(title: _("Memory Limit in MB"), field: "memoryLimit") {
         f.number(name: "memoryLimit", clazz: "positive-number", min: "4", step: "1")
     }

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-bindSshPortLocalhost.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-bindSshPortLocalhost.html
@@ -1,0 +1,3 @@
+<div>
+    Tick this to bind the docker container ssh port to localhost only. By default the ssh port is bound to "0.0.0.0"
+</div>

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplate2Test.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplate2Test.java
@@ -54,6 +54,7 @@ public class DockerTemplate2Test {
         assertThat(tBase.getVolumes()[0], equalTo("/dev/log:/dev/log"));
 
         assertFalse(tBase.bindAllPorts);
+        assertTrue(tBase.bindSshPortLocalhost);
         assertTrue(tBase.privileged);
     }
 

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
@@ -32,6 +32,7 @@ public class DockerTemplateTest {
     String hostname = "hostname";
     String bindPorts = "0.0.0.0:22";
     boolean bindAllPorts = true;
+    boolean bindSshPortLocalhost = true;
     boolean privileged = false;
     boolean tty = false;
     String macAddress = "92:d0:c6:0a:29:33";
@@ -40,7 +41,7 @@ public class DockerTemplateTest {
     private DockerTemplate getDockerTemplateInstanceWithDNSHost(String dnsString) {
         final DockerTemplateBase dockerTemplateBase = new DockerTemplateBase(image, dnsString, network,
                 dockerCommand, volumesString, volumesString, environmentsString,
-                lxcConfString, hostname, memoryLimit, memorySwap, cpuShares, bindPorts, bindAllPorts, privileged, tty, macAddress);
+                lxcConfString, hostname, memoryLimit, memorySwap, cpuShares, bindPorts, bindAllPorts, bindSshPortLocalhost, privileged, tty, macAddress);
 
         return new DockerTemplate(
                 dockerTemplateBase,

--- a/docker-plugin/src/test/resources/com/nirima/jenkins/plugins/docker/DockerTemplate2Test/load080Config/config.xml
+++ b/docker-plugin/src/test/resources/com/nirima/jenkins/plugins/docker/DockerTemplate2Test/load080Config/config.xml
@@ -18,6 +18,7 @@
                     <volumesFrom></volumesFrom>
                     <bindPorts></bindPorts>
                     <bindAllPorts>false</bindAllPorts>
+                    <bindSshPortLocalhost>true</bindSshPortLocalhost>
                     <privileged>true</privileged>
                     <labelString>dockerbuild-local</labelString>
                     <credentialsId>com.nirima.jenkins.plugins.docker.DockerCloud.dockerbuild</credentialsId>
@@ -44,6 +45,7 @@
                     <volumesFrom></volumesFrom>
                     <bindPorts></bindPorts>
                     <bindAllPorts>false</bindAllPorts>
+                    <bindSshPortLocalhost>true</bindSshPortLocalhost>
                     <privileged>true</privileged>
                     <labelString>dockerbuild-vpn-local</labelString>
                     <credentialsId>com.nirima.jenkins.plugins.docker.DockerCloud.dockerbuild-vpn</credentialsId>
@@ -70,6 +72,7 @@
                     <volumesFrom></volumesFrom>
                     <bindPorts></bindPorts>
                     <bindAllPorts>false</bindAllPorts>
+                    <privileged>true</privileged>
                     <privileged>true</privileged>
                     <labelString>dockerbuild-vpn-local-fix</labelString>
                     <credentialsId>com.nirima.jenkins.plugins.docker.DockerCloud.dockerbuild-vpn</credentialsId>
@@ -98,6 +101,7 @@
                     <volumesFrom></volumesFrom>
                     <bindPorts></bindPorts>
                     <bindAllPorts>false</bindAllPorts>
+                    <bindSshPortLocalhost>true</bindSshPortLocalhost>
                     <privileged>true</privileged>
                     <labelString>dockerbuild-wlp</labelString>
                     <credentialsId>com.nirima.jenkins.plugins.docker.DockerCloud.dockerbuild</credentialsId>
@@ -124,6 +128,7 @@
                     <volumesFrom></volumesFrom>
                     <bindPorts></bindPorts>
                     <bindAllPorts>false</bindAllPorts>
+                     <bindSshPortLocalhost>true</bindSshPortLocalhost>
                     <privileged>true</privileged>
                     <labelString>dockerbuild-golang</labelString>
                     <credentialsId>com.nirima.jenkins.plugins.docker.DockerCloud.dockerbuild</credentialsId>
@@ -150,6 +155,7 @@
                     <volumesFrom></volumesFrom>
                     <bindPorts></bindPorts>
                     <bindAllPorts>false</bindAllPorts>
+                    <bindSshPortLocalhost>true</bindSshPortLocalhost>
                     <privileged>true</privileged>
                     <labelString>dockerbuild-goruby</labelString>
                     <credentialsId>com.nirima.jenkins.plugins.docker.DockerCloud.dockerbuild</credentialsId>

--- a/docker-plugin/src/test/resources/com/nirima/jenkins/plugins/docker/DockerTemplate2Test/shouldLoad090rc1Config/config.xml
+++ b/docker-plugin/src/test/resources/com/nirima/jenkins/plugins/docker/DockerTemplate2Test/shouldLoad090rc1Config/config.xml
@@ -33,6 +33,7 @@
           <environment/>
           <bindPorts></bindPorts>
           <bindAllPorts>false</bindAllPorts>
+           <bindSshPortLocalhost>true</bindSshPortLocalhost>
           <privileged>false</privileged>
           <tty>false</tty>
           <labelString>label2 label-all</labelString>

--- a/docker-plugin/src/test/resources/com/nirima/jenkins/plugins/docker/DockerTemplate2Test/shouldLoadEmptyVolumesFrom/config.xml
+++ b/docker-plugin/src/test/resources/com/nirima/jenkins/plugins/docker/DockerTemplate2Test/shouldLoadEmptyVolumesFrom/config.xml
@@ -29,6 +29,7 @@
           <environment/>
           <bindPorts></bindPorts>
           <bindAllPorts>false</bindAllPorts>
+           <bindSshPortLocalhost>true</bindSshPortLocalhost>
           <privileged>false</privileged>
           <tty>false</tty>
           <labelString>rhel65-sandbox</labelString>


### PR DESCRIPTION
- Fix issue #407  - security issue with binding all started containers with 0.0.0.0::port
- This adds an option box that controls how the ssh port is bound when starting the container. Ticking it results in `127.0.0.1:32770->22/tcp`.
Default  and current behaviour (not ticking) is `0.0.0.0:32770->22/tcp`
- related to fix for #20

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/docker-plugin/472)
<!-- Reviewable:end -->
