### PR TITLE
JENKINS-41035: fix browsing slave workspace with nested folders

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildAction.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildAction.java
@@ -22,12 +22,16 @@ public class DockerBuildAction implements Action, Serializable, Cloneable, Descr
     public final String taggedId;
 
     public final String remoteFsMapping;
+    public final String remoteFs;
+	public final String slaveWorkspace;
 
-    public DockerBuildAction(String containerHost, String containerId, String taggedId, String remoteFsMapping) {
+    public DockerBuildAction(String containerHost, String containerId, String taggedId, String remoteFsMapping, String remoteFs, String slaveWorkspace) {
         this.containerHost = containerHost;
         this.containerId = containerId;
         this.taggedId = taggedId;
         this.remoteFsMapping = remoteFsMapping;
+        this.remoteFs = remoteFs;
+        this.slaveWorkspace = slaveWorkspace;
     }
 
     public String getIconFileName() {

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
@@ -21,11 +21,14 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.AbstractBuild;

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/PathUtils.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/PathUtils.java
@@ -1,0 +1,25 @@
+package com.nirima.jenkins.plugins.docker.utils;
+
+import java.nio.file.Path;
+
+public class PathUtils {
+	/**
+	 * Translates an absolute directory, that is a child of fromRoot, to a second directory toRoot.
+	 * So basically the part of directory that is relative to fromRoot is applied to toRoot and
+	 * that absolute path is returned.
+	 * @param directory the directory to map/translate
+	 * @param fromRoot the directory that is a sub directory of fromRoot
+	 * @param toRoot the directory to which the relative part of directory shall be mapped
+	 * @return the mapped directory or <code>null</code> if directory is not a child of fromRoot
+	 */
+    public static Path mapDirectoryToOtherRoot(Path directory, Path fromRoot, Path toRoot) {
+		if (directory.startsWith(fromRoot)) {
+			Path jenkinsHomeRelativeJobPath = fromRoot.relativize(directory);
+			if (jenkinsHomeRelativeJobPath.getNameCount() > 0) {
+				Path localJobDir = toRoot.resolve(jenkinsHomeRelativeJobPath);
+				return localJobDir;
+			}
+		}
+		return null;
+    }
+}

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/ws/MappedFsWorkspaceBrowser.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/ws/MappedFsWorkspaceBrowser.java
@@ -1,18 +1,20 @@
 package com.nirima.jenkins.plugins.docker.ws;
 
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import com.nirima.jenkins.plugins.docker.action.DockerBuildAction;
+import com.nirima.jenkins.plugins.docker.utils.PathUtils;
+
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Job;
 import hudson.model.Run;
 import hudson.model.WorkspaceBrowser;
-
-import java.io.File;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static org.apache.commons.io.FileUtils.getFile;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 
 @Extension
@@ -31,8 +33,15 @@ public class MappedFsWorkspaceBrowser extends WorkspaceBrowser {
         if (lastBuild != null) {
             DockerBuildAction action = lastBuild.getAction(DockerBuildAction.class);
 
-            if (action != null && isNotBlank(action.remoteFsMapping)) {
-                return new FilePath(getFile(new File(action.remoteFsMapping), "workspace", job.getName()));
+            if (action != null && isNotBlank(action.remoteFsMapping) && isNotBlank(action.remoteFs) && isNotBlank(action.slaveWorkspace)) {
+                Path slaveWorkspaceDir = Paths.get(action.slaveWorkspace);
+                Path slaveJenkinsHomeDir = Paths.get(action.remoteFs);
+                Path masterJenkinsHomeDir = Paths.get(action.remoteFsMapping);
+
+                Path masterWorkspaceDir = PathUtils.mapDirectoryToOtherRoot(slaveWorkspaceDir, slaveJenkinsHomeDir, masterJenkinsHomeDir);
+                if (masterWorkspaceDir != null) {
+                    return new FilePath(masterWorkspaceDir.toFile());
+                }
             }
         }
 

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/utils/PathUtilsTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/utils/PathUtilsTest.java
@@ -1,0 +1,45 @@
+package com.nirima.jenkins.plugins.docker.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+public class PathUtilsTest {
+	private static final String SLAVE_HOME = "/home/slave";
+	private static final String MASTER_HOME = "/home/master";
+	private static final String RELATIVE_SIMPLE = "jobname";
+	private static final String RELATIVE_NESTED = "some/nested/jobname";
+
+	private static final String SLAVE_JOBDIR_SIMPLE = SLAVE_HOME + "/workspace/" + RELATIVE_SIMPLE;
+	private static final String SLAVE_JOBDIR_NESTED = SLAVE_HOME + "/workspace/" + RELATIVE_NESTED;
+	private static final String MASTER_JOBDIR_SIMPLE = MASTER_HOME + "/workspace/" + RELATIVE_SIMPLE;
+	private static final String MASTER_JOBDIR_NESTED = MASTER_HOME + "/workspace/" + RELATIVE_NESTED;
+
+
+	@Test
+	public void mapDirectoryToOtherRootSimple() {
+		mapDirectoryToOtherRoot(SLAVE_JOBDIR_SIMPLE, MASTER_JOBDIR_SIMPLE);
+	}
+
+	@Test
+	public void mapDirectoryToOtherRootNested() {
+		mapDirectoryToOtherRoot(SLAVE_JOBDIR_NESTED, MASTER_JOBDIR_NESTED);
+	}
+
+	private void mapDirectoryToOtherRoot(String slaveJobDir, String expectedMasterJobDir) {
+		Path slaveHome = Paths.get(SLAVE_HOME);
+		Path masterHome = Paths.get(MASTER_HOME);
+
+		Path slaveJobDirectory = Paths.get(slaveJobDir);
+		Path exectedMasterJobDirectory = Paths.get(expectedMasterJobDir);
+
+		Path masterJobDirectory = PathUtils.mapDirectoryToOtherRoot(slaveJobDirectory, slaveHome, masterHome);
+		assertNotNull("could not map slave job directory to the master", masterJobDirectory);
+		assertEquals(exectedMasterJobDirectory, masterJobDirectory);
+	}
+
+}

--- a/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/ws/MappedFsWorkspaceBrowserTest.java
+++ b/docker-plugin/src/test/java/com/nirima/jenkins/plugins/docker/ws/MappedFsWorkspaceBrowserTest.java
@@ -26,8 +26,10 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class MappedFsWorkspaceBrowserTest {
 
-    public static final String FS_MAPPING = File.pathSeparator + "mapping";
+    public static final String FS_MAPPING = File.separatorChar + "masterRoot" + File.separatorChar;
+    public static final String FS_SLAVE_ROOT = File.separatorChar + "slaveRoot";
     public static final String JOB_NAME = "job-name";
+    public static final String FS_SLAVE_WS_DIR = FS_SLAVE_ROOT + File.separatorChar + "workspace" + File.separatorChar + JOB_NAME;
 
     @Mock
     private Job job;
@@ -45,7 +47,7 @@ public class MappedFsWorkspaceBrowserTest {
                 .thenReturn(new DockerBuildAction(
                         randomAlphabetic(10),
                         randomAlphabetic(10),
-                        randomAlphabetic(10), FS_MAPPING));
+                        randomAlphabetic(10), FS_MAPPING, FS_SLAVE_ROOT, FS_SLAVE_WS_DIR));
 
         FilePath workspace = mappedFsWorkspaceBrowser.getWorkspace(job);
 
@@ -77,7 +79,7 @@ public class MappedFsWorkspaceBrowserTest {
                 .thenReturn(new DockerBuildAction(
                         randomAlphabetic(10),
                         randomAlphabetic(10),
-                        randomAlphabetic(10), ""));
+                        randomAlphabetic(10), "", "", ""));
 
         assertThat(mappedFsWorkspaceBrowser.getWorkspace(job), nullValue());
     }


### PR DESCRIPTION
(or otherwise custom workspace directories)

This maps the workspace folder from the slave path to the master path instead of assuming the path is JENKINS_HOME/workspace/job-name.