### PR TITLE
Exclude jersey-apache-connector from docker-java-shaded to fix "org.apache.http.conn.UnsupportedSchemeException: unix protocol is not supported"

### DIFF
--- a/docker-plugin/pom.xml
+++ b/docker-plugin/pom.xml
@@ -55,6 +55,10 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcpkix-jdk15on</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.connectors</groupId>
+                    <artifactId>jersey-apache-connector</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
      <!--   <dependency>


### PR DESCRIPTION
`org.glassfish.jersey.apache.connector.ApacheConnector` could be loaded from either jersey-apache-connector.jar or docker-java-shaded.jar. As docker-java-shaded includes all the classes in the org.glassfish package, it should be guaranteed to be loaded from the shaded jar, not the original jersey jar. I excluded it from docker-java-shaded.