### PR TITLE
make DOCKER_HOST optional

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerBuildVariableContributor.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerBuildVariableContributor.java
@@ -29,16 +29,20 @@ public class DockerBuildVariableContributor extends BuildVariableContributor {
             final DockerComputer dockerComputer = (DockerComputer) executor.getOwner();
             variables.put("DOCKER_CONTAINER_ID", dockerComputer.getContainerId());
             variables.put("JENKINS_CLOUD_ID", dockerComputer.getCloudId());
-            try {
-                //replace http:// and https:// from docker-java to tcp://
-                final URIBuilder uriBuilder = new URIBuilder(dockerComputer.getCloud().getServerUrl());
-                if (!uriBuilder.getScheme().equals("unix")) {
-                    uriBuilder.setScheme("tcp");
+
+            final DockerCloud cloud = dockerComputer.getCloud();
+            if (cloud.isExposeDockerHost()) {
+                try {
+                    //replace http:// and https:// from docker-java to tcp://
+                    final URIBuilder uriBuilder = new URIBuilder(cloud.getServerUrl());
+                    if (!uriBuilder.getScheme().equals("unix")) {
+                        uriBuilder.setScheme("tcp");
+                    }
+                    final String dockerHost = uriBuilder.toString();
+                    variables.put("DOCKER_HOST", dockerHost);
+                } catch (URISyntaxException e) {
+                    LOG.error("Can't build 'DOCKER_HOST' var: {}", e.getMessage());
                 }
-                final String dockerHost = uriBuilder.toString();
-                variables.put("DOCKER_HOST", dockerHost);
-            } catch (URISyntaxException e) {
-                LOG.error("Can't build 'DOCKER_HOST' var: {}", e.getMessage());
             }
         }
     }

--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -37,6 +37,7 @@ import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -96,6 +97,11 @@ public class DockerCloud extends Cloud {
      * provisioned, but not necessarily reported yet by docker.
      */
     private static final HashMap<String, Integer> provisionedImages = new HashMap<>();
+
+    /**
+     * Indicate if docker host used to run container is exposed inside container as DOCKER_HOST environment variable
+     */
+    private Boolean exposeDockerHost;
 
     @Deprecated
     public DockerCloud(String name,
@@ -671,6 +677,16 @@ public class DockerCloud extends Cloud {
             _isTriton = remoteVersion.getOperatingSystem().equals("solaris");
         }
         return _isTriton;
+    }
+
+    public boolean isExposeDockerHost() {
+        // if null (i.e migration from previous installation) consider true for backward compatibility
+        return exposeDockerHost != null ? exposeDockerHost : true;
+    }
+
+    @DataBoundSetter
+    public void setExposeDockerHost(boolean exposeDockerHost) {
+        this.exposeDockerHost = exposeDockerHost;
     }
 
 

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
@@ -32,6 +32,10 @@
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection"
                       with="serverUrl,credentialsId,version"/>
 
+    <f:entry title="${%Expose DOCKER_HOST}" field="exposeDockerHost">
+        <f:checkbox/>
+    </f:entry>
+
     <f:entry title="${%Container Cap}" field="containerCap">
         <f:number default="100"/>
     </f:entry>

--- a/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-exposeDockerHost.html
+++ b/docker-plugin/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-exposeDockerHost.html
@@ -1,0 +1,3 @@
+Expose docker host URL as environment variable <code>DOCKER_HOST</code> inside container.
+This assumes the docker host IP/hostname is visible from container and doesn't require authentication <em>or</em>
+adequate TLS keys are injected inside container by another mechanism.


### PR DESCRIPTION
seems the initial intent was to let container access it's containing host, but actually this prevent a build to rely on /var/run/docker.sock bind mount. Also, there's no guarantee the hostname/ip as declared in jenkins for connectivity from master is relevant from container.