### PR TITLE
Fix name of slave on swarm.

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
@@ -121,17 +121,23 @@ public class JenkinsUtils {
         });
     }
 
-    public static String getHostnameFromBinding(InspectContainerResponse inspectContainerResponse) {
-        Map<ExposedPort, Ports.Binding[]> bindings = inspectContainerResponse.getHostConfig().getPortBindings().getBindings();
+    private static String getHostnameFromBinding(Map<ExposedPort, Ports.Binding[]> bindings) {
         if (bindings != null && !bindings.isEmpty())  {
             Ports.Binding[] binding = bindings.values().iterator().next();
             if (binding != null && binding.length > 0) {
                 String hostIp = binding[0].getHostIp();
-                return getHostnameForIp(hostIp);
+                if (!"0.0.0.0".equals(hostIp))
+                    return getHostnameForIp(hostIp);
             }
         }
-
         return null;
+    }
+
+    public static String getHostnameFromBinding(InspectContainerResponse inspectContainerResponse) {
+        String hostname = getHostnameFromBinding(inspectContainerResponse.getHostConfig().getPortBindings().getBindings());
+        if (hostname != null)
+            return hostname;
+        return getHostnameFromBinding(inspectContainerResponse.getNetworkSettings().getPorts().getBindings());
     }
 
     private static String getHostnameForIp(String hospIp) {


### PR DESCRIPTION
When using recent versions of Swarm, hostIP does not seem to be
available in the PortBindings section of HostConfig, but in the ports
section of NetworkSettings. docker inspect response looks something like
this:

   [...]
   "HostConfig": {
       "Binds": null,
       "ContainerIDFile": "",
       "LogConfig": { ... },
       "NetworkMode": "default",
       "PortBindings": {
           "22/tcp": [
               {
                   "HostIp": "0.0.0.0",
                   "HostPort": ""
               }
           ]
       },
       ...
   }
   "NetworkSettings": {
       "Bridge": "",
       "SandboxID": "e73dee6dcda0985515a2b21c8ffa9690db633278b033409658a809149ddf0f41",
       "HairpinMode": false,
       "LinkLocalIPv6Address": "",
       "LinkLocalIPv6PrefixLen": 0,
       "Ports": {
           "22/tcp": [
               {
                   "HostIp": "172.20.182.49",
                   "HostPort": "37032"
               }
           ]
       },
       ...
   }
   [...]

To handle both situations, now try to get host hostip from
NetworkSettings.Ports if we only get 0.0.0.0 from HostConfig.portBindings.