### PR TITLE
Use same node name as before

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -643,7 +643,7 @@ public class DockerCloud extends Cloud {
 
     }
 
-    /* package */ boolean isSwarm() {
+    public boolean isSwarm() {
         Version remoteVersion = getClient().versionCmd().exec();
         // Cache the return.
         if( _isSwarm == null ) {

--- a/docker-plugin/src/main/java/io/jenkins/docker/DockerSlaveProvisioner.java
+++ b/docker-plugin/src/main/java/io/jenkins/docker/DockerSlaveProvisioner.java
@@ -2,10 +2,12 @@ package io.jenkins.docker;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.core.command.PullImageResultCallback;
+import com.google.common.base.Strings;
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import com.nirima.jenkins.plugins.docker.DockerImagePullStrategy;
 import com.nirima.jenkins.plugins.docker.DockerSlave;
@@ -46,6 +48,21 @@ public abstract class DockerSlaveProvisioner {
      */
     public abstract DockerSlave provision() throws IOException, Descriptor.FormException, InterruptedException;
 
+    public String getDisplayName(String containerId, InspectContainerResponse inspect) {
+        String slaveName = containerId.substring(0, 12);
+        try {
+            slaveName = cloud.getDisplayName() + "-" + slaveName;
+        } catch (Exception ex) {
+            LOGGER.warn("Error fetching cloud name");
+        }
+        if (cloud.isSwarm()) {
+            String hostName = JenkinsUtils.getHostnameFromBinding(inspect);
+            if (!Strings.isNullOrEmpty(hostName)) {
+                slaveName = slaveName + "-" + hostName;
+            }
+        }
+        return slaveName;
+    }
 
     protected String runContainer() throws IOException, InterruptedException {
         pullImage();

--- a/docker-plugin/src/main/java/io/jenkins/docker/JNLPDockerSlaveProvisioner.java
+++ b/docker-plugin/src/main/java/io/jenkins/docker/JNLPDockerSlaveProvisioner.java
@@ -63,6 +63,7 @@ public class JNLPDockerSlaveProvisioner extends DockerSlaveProvisioner {
             // FIXME report error "somewhere" visible to end user.
             LOGGER.error("Failed to launch docker JNLP agent :" + inspect.getState().getExitCode());
         }
+        slave.setNodeName(getDisplayName(id, inspect));
 
         return slave;
     }

--- a/docker-plugin/src/main/java/io/jenkins/docker/SSHDockerSlaveProvisioner.java
+++ b/docker-plugin/src/main/java/io/jenkins/docker/SSHDockerSlaveProvisioner.java
@@ -86,6 +86,7 @@ public class SSHDockerSlaveProvisioner extends DockerSlaveProvisioner {
         if (computer != null) { 
             computer.setContainerId(id);
         }
+        slave.setNodeName(getDisplayName(id, inspect));
 
         return slave;
     }


### PR DESCRIPTION
Node name is <cloud_name>-<containerId>[-<hostName>], with hostname
being added only when running on a swarm.