### PR TITLE
Make useSSHKey configuration field public final, fix #530

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -30,7 +30,7 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
     // store real UI configuration
     protected final SSHConnector sshConnector;
 
-    private final Boolean useSSHKey;
+    public final Boolean useSSHKey;
 
     @DataBoundConstructor
     public DockerComputerSSHLauncher(SSHConnector sshConnector, boolean useSSHKey) {


### PR DESCRIPTION
According to https://wiki.jenkins.io/display/JENKINS/Basic+guide+to+Jelly+usage+in+Jenkins a configuration field should either have getters/setters defined or be declared as `public final`. Since I was able to grep other `public final`s in the code, I went for this simple solution.