### PR TITLE
Revert missing waitFor for sshd

### DIFF
--- a/docker-plugin/src/main/java/io/jenkins/docker/SSHDockerSlaveProvisioner.java
+++ b/docker-plugin/src/main/java/io/jenkins/docker/SSHDockerSlaveProvisioner.java
@@ -72,6 +72,9 @@ public class SSHDockerSlaveProvisioner extends DockerSlaveProvisioner {
         }
         LOGGER.debug("container created {}", inspect);
 
+        // Make sure, the ssh daemon is up and running
+        template.getLauncher().waitUp(template.getDisplayName(), template, inspect);
+
         StandardUsernameCredentials pk = getPrivateKeyAsCredentials();
 
         final InetSocketAddress address = launcher.getAddressForSSHD(cloud, inspect);


### PR DESCRIPTION
Revert the missing (regression) waitFor function to make sure that the daemon is actually running.

This functionality got lost during the restructuring. See #533.