### PR TITLE
Prefix and Suffix have been reversed.

### DIFF
--- a/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/docker-plugin/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -25,8 +25,8 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
         connector.setJvmOptions(sshConnector.jvmOptions);
         connector.setLaunchTimeoutSeconds(sshConnector.launchTimeoutSeconds);
         connector.setPort(sshConnector.port);
-        connector.setPrefixStartSlaveCmd(sshConnector.suffixStartSlaveCmd);
-        connector.setSuffixStartSlaveCmd(sshConnector.prefixStartSlaveCmd);
+        connector.setPrefixStartSlaveCmd(sshConnector.prefixStartSlaveCmd);
+        connector.setSuffixStartSlaveCmd(sshConnector.suffixStartSlaveCmd);
 
         return connector;
     }


### PR DESCRIPTION
The old DockerComputerSSHLauncher is just a wrapper now, but the API usage has been mixed up leading to a wrong setup.