### PR TITLE
According to remoting.jar documentation -tunnel option should be used…

### DIFF
--- a/docker-plugin/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
+++ b/docker-plugin/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
@@ -119,7 +119,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
                 "-cp", template.remoteFs + "/" + remoting.getName(),
                 "hudson.remoting.jnlp.Main", "-headless"));
         if (StringUtils.isNotBlank(jnlpLauncher.tunnel)) {
-            args.addAll(Arrays.asList("--tunnel", jnlpLauncher.tunnel));
+            args.addAll(Arrays.asList("-tunnel", jnlpLauncher.tunnel));
         }
 
         args.addAll(Arrays.asList(


### PR DESCRIPTION
According to remoting.jar documentation `-tunnel` option should be used instead of `--tunnel`

Fix for issue https://github.com/jenkinsci/docker-plugin/issues/550