### PR TITLE
docker-plugin 1.1 does not support SSH connection to standalone swarm

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -86,11 +86,6 @@ public class DockerCloud extends Cloud {
     private int containerCap = 100;
 
     /**
-     * Is this cloud actually a swarm?
-     */
-    private transient Boolean _isSwarm;
-
-    /**
      * Is this cloud running Joyent Triton?
      */
     private transient Boolean _isTriton;
@@ -540,15 +535,6 @@ public class DockerCloud extends Cloud {
         if (templates != null ? !templates.equals(that.templates) : that.templates != null) return false;
         if (exposeDockerHost != that.exposeDockerHost)return false;
         return true;
-    }
-
-    /* package */ boolean isSwarm() {
-        Version remoteVersion = getClient().versionCmd().exec();
-        // Cache the return.
-        if( _isSwarm == null ) {
-            _isSwarm = remoteVersion.getVersion().startsWith("swarm");
-        }
-        return _isSwarm;
     }
 
     public boolean isTriton() {

--- a/src/main/java/io/jenkins/docker/client/DockerAPI.java
+++ b/src/main/java/io/jenkins/docker/client/DockerAPI.java
@@ -63,6 +63,11 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
 
     private transient DockerClient client = null;
 
+    /**
+     * Is this host actually a swarm?
+     */
+    private transient Boolean _isSwarm;
+
     @DataBoundConstructor
     public DockerAPI(DockerServerEndpoint dockerHost) {
         this.dockerHost = dockerHost;
@@ -104,6 +109,15 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
     @DataBoundSetter
     public void setHostname(String hostname) {
         this.hostname = trimToNull(hostname);
+    }
+
+    public boolean isSwarm() {
+        Version remoteVersion = getClient().versionCmd().exec();
+        // Cache the return.
+        if( _isSwarm == null ) {
+            _isSwarm = remoteVersion.getVersion().startsWith("swarm");
+        }
+        return _isSwarm;
     }
 
     public DockerClient getClient() {


### PR DESCRIPTION
When running against standalone swarm, the SSH server is not available on the same host as the docker end point: the docker endpoint starts a container on any node in the swarm, and the SSH server will only be reachable through that hosts' name/IP address.

This used to work fine, but got broken between 1.04 and 1.1.

(I reproduced the issue with docker 17.09.0-ce and swarm/1.2.8)