### PR TITLE
Restore multi-line control for container settings

### DIFF
--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
@@ -31,15 +31,15 @@
     </f:entry>
 
     <f:entry title="${%Volumes}" field="volumesString">
-      <f:textbox />
+      <f:expandableTextbox />
     </f:entry>
 
     <f:entry title="${%Volumes From}" field="volumesFromString">
-      <f:textbox />
+      <f:expandableTextbox />
     </f:entry>
 
     <f:entry title="${%Environment}" field="environmentsString">
-      <f:textbox />
+      <f:expandableTextbox />
     </f:entry>
 
     <f:entry title="${%Port bindings}" field="bindPorts">

--- a/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepTest.java
+++ b/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepTest.java
@@ -34,6 +34,7 @@ import hudson.slaves.EnvironmentVariablesNodeProperty;
 import hudson.tasks.Maven;
 import hudson.tools.DownloadFromUrlInstaller;
 import hudson.tools.InstallSourceProperty;
+import org.apache.commons.lang3.SystemUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -44,6 +45,8 @@ import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -59,6 +62,14 @@ import java.util.Collections;
 import java.util.Set;
 
 public class DockerNodeStepTest {
+
+//Skip this test on Windows OS family, as it have no unix sock
+    @Before
+    public void beforeTest()
+    {
+        Assume.assumeTrue(!SystemUtils.IS_OS_WINDOWS);
+    }
+
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
 


### PR DESCRIPTION
Between 1.0.4 and 1.1.0 the following multi-line control became single-line.
As a result validation for following fields were broken because they requires one value per line

Volumes
Volumes From
Environment

Disable test using unix soc on Windows OS family, to be able perform build on Windows OS

Fix for issue https://github.com/jenkinsci/docker-plugin/issues/567