### PR TITLE
New Option for JNLP: Pass Slave Connection Arguments to Entrypoint

### DIFF
--- a/src/main/java/io/jenkins/docker/DockerTransientNode.java
+++ b/src/main/java/io/jenkins/docker/DockerTransientNode.java
@@ -7,7 +7,6 @@ import com.nirima.jenkins.plugins.docker.DockerOfflineCause;
 import com.nirima.jenkins.plugins.docker.strategy.DockerOnceRetentionStrategy;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
-import hudson.model.Queue;
 import hudson.model.Slave;
 import hudson.model.TaskListener;
 import hudson.slaves.Cloud;
@@ -15,10 +14,8 @@ import hudson.slaves.ComputerLauncher;
 import io.jenkins.docker.client.DockerAPI;
 import jenkins.model.Jenkins;
 
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.io.Serializable;
 
 /**
  * A {@link Slave} node designed to be used only once for a build.
@@ -26,25 +23,34 @@ import java.io.Serializable;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class DockerTransientNode extends Slave {
-    
-    private final String containerId;
-    
+
+    //Keeping real containerId information, but using containerUniqueName as containerId
+    private String containerId;
+
+    private String containerUniqueName;
+
     private DockerAPI dockerAPI;
 
     private boolean removeVolumes;
 
     private String cloudId;
 
-    public DockerTransientNode(@Nonnull String containerId, String remoteFS, ComputerLauncher launcher) throws Descriptor.FormException, IOException {
-        super("docker-" + containerId.substring(0,12), remoteFS, launcher);
+
+    public DockerTransientNode(@Nonnull String uniqueName, String workdir, ComputerLauncher launcher) throws Descriptor.FormException, IOException {
+        super("docker-" + uniqueName, workdir, launcher);
+        this.containerUniqueName = uniqueName;
         setNumExecutors(1);
         setMode(Mode.EXCLUSIVE);
         setRetentionStrategy(new DockerOnceRetentionStrategy(10));
+    }
+
+    public void setRealContainerId(String containerId){
         this.containerId = containerId;
     }
 
-    public String getContainerId() {
-        return containerId;
+    public String getContainerId(){
+        // For old sake. If the containerUniqueName was not introduced yet, use the containerId
+        return containerUniqueName == null ? containerId : containerUniqueName;
     }
 
     public void setDockerAPI(DockerAPI dockerAPI) {
@@ -92,7 +98,7 @@ public class DockerTransientNode extends Slave {
         }
 
         Computer.threadPoolForRemoting.submit(() -> {
-
+            final String containerId = getContainerId();
             DockerClient client = dockerAPI.getClient();
 
             try {

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
@@ -5,6 +5,7 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.ExecCreateCmd;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.nirima.jenkins.plugins.docker.DockerTemplate;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
@@ -18,7 +19,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -52,6 +52,7 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
         this.user = user;
     }
 
+
     @Override
     public void beforeContainerCreated(DockerAPI api, String workdir, CreateContainerCmd cmd) throws IOException, InterruptedException {
         ensureWaiting(cmd);
@@ -64,7 +65,9 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
     }
 
     @Override
-    protected ComputerLauncher createLauncher(DockerAPI api, String workdir, InspectContainerResponse inspect, TaskListener listener) throws IOException, InterruptedException {
+    protected ComputerLauncher createLauncher(DockerAPI api, String workdir, DockerTemplate.ContainerCommandCreator containerCommandCreator, TaskListener listener) throws IOException, InterruptedException {
+        CreateContainerCmd cmd = containerCommandCreator.createContainerCmd(api);
+        InspectContainerResponse inspect = executeContainer(api, listener, cmd, workdir);
         return new DockerAttachLauncher(api, inspect.getId(), user, workdir);
     }
 

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
@@ -3,6 +3,7 @@ package io.jenkins.docker.connector;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.nirima.jenkins.plugins.docker.DockerSlave;
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
@@ -15,6 +16,7 @@ import hudson.remoting.Which;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.DelegatingComputerLauncher;
 import hudson.slaves.SlaveComputer;
+import io.jenkins.docker.DockerComputer;
 import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import org.slf4j.Logger;
@@ -23,6 +25,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
+import java.io.Serializable;
 
 /**
  * Create a {@link DockerSlave} based on a template. Container is created in detached mode so it can survive
@@ -89,31 +92,51 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
         return workdir + '/' + remoting.getName();
     }
 
-    public final ComputerLauncher createLauncher(final DockerAPI api, @Nonnull final String containerId, String workdir, TaskListener listener) throws IOException, InterruptedException {
+    protected final InspectContainerResponse executeContainer(DockerAPI dockerAPI, TaskListener listener, CreateContainerCmd cmd, String workdir) throws IOException, InterruptedException{
 
-        final InspectContainerResponse inspect = api.getClient().inspectContainerCmd(containerId).exec();
+        beforeContainerCreated(dockerAPI, workdir, cmd);
+        final String containerId = cmd.exec().getId();
+
+        try {
+            beforeContainerStarted(dockerAPI, workdir, containerId);
+
+            dockerAPI.getClient().startContainerCmd(containerId).exec();
+
+            afterContainerStarted(dockerAPI, workdir, containerId);
+        } catch (DockerException e) {
+            // if something went wrong, cleanup aborted container
+            dockerAPI.getClient().removeContainerCmd(containerId).withForce(true).exec();
+            throw e;
+        }
+        final InspectContainerResponse inspect = dockerAPI.getClient().inspectContainerCmd(containerId).exec();
         final Boolean running = inspect.getState().getRunning();
         if (Boolean.FALSE.equals(running)) {
             listener.error("Container {} is not running. {}", containerId, inspect.getState().getStatus());
             throw new IOException("Container is not running.");
         }
 
-        final ComputerLauncher launcher = createLauncher(api, workdir, inspect, listener);
+        return inspect;
+    }
+
+    public final ComputerLauncher createLauncher(final DockerAPI api, DockerTemplate.ContainerCommandCreator containerCommandCreator, String workdir, TaskListener listener) throws IOException, InterruptedException {
+
+        final ComputerLauncher launcher = createLauncher(api, workdir, containerCommandCreator, listener);
         return new DelegatingComputerLauncher(launcher) {
 
             @Override
             public void launch(SlaveComputer computer, TaskListener listener) throws IOException, InterruptedException {
                 try {
-                    api.getClient().inspectContainerCmd(containerId).exec();
+                    super.launch(computer, listener);
+                    final String containerUniqueName = ((DockerComputer)computer).getNode().getContainerId();
+                    InspectContainerResponse response = api.getClient().inspectContainerCmd(containerUniqueName).exec();
+                    ((DockerComputer)computer).getNode().setRealContainerId(response.getId());
                 } catch (NotFoundException e) {
                     // Container has been removed
                     Queue.withLock( () -> {
                         DockerTransientNode node = (DockerTransientNode) computer.getNode();
                         node.terminate(listener);
                     });
-                    return;
                 }
-                super.launch(computer, listener);
             }
         };
     }
@@ -122,6 +145,7 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
      * Create a Launcher to create an Agent with this container. Can assume container has been created by this
      * DockerAgentConnector so adequate setup did take place.
      */
-    protected abstract ComputerLauncher createLauncher(DockerAPI api, String workdir, InspectContainerResponse inspect, TaskListener listener) throws IOException, InterruptedException;
+    protected abstract ComputerLauncher createLauncher(DockerAPI api, String workdir, DockerTemplate.ContainerCommandCreator containerCommandCreator, TaskListener listener) throws IOException, InterruptedException;
+
 
 }

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/config.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
 
     <f:block>
-        <span class="info">Prerequisites:</span> Docker image must have <a href="https://go.java">Java</a> installed.
+        <span class="info">Prerequisites:</span> Docker image must have <a href="https://go.java">Java</a> installed. Also entrypoint must be able to accept jenkins slave connection parameters. <a href="https://github.com/jenkinsci/docker-jnlp-slave">See jenkins/docker-jnlp-slave as an example</a>
     </f:block>
 
     <f:entry title="${%User}" field="user">

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerJNLPConnector/config.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerJNLPConnector/config.jelly
@@ -10,5 +10,9 @@
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="${%Jenkins URL}" field="jenkinsUrl">
+        <f:textbox/>
+    </f:entry>
+
     <f:property field="jnlpLauncher"/>
 </j:jelly>

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerJNLPConnector/help-jenkinsUrl.html
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerJNLPConnector/help-jenkinsUrl.html
@@ -1,0 +1,3 @@
+<div>
+    If needed, the Jenkins URL can be overwritten with this property (e.g. to support other HTTP(S) endpoints due to reverse proxies or firewalling). By default the URL from the global Jenkins configuration is used.
+</div>

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
@@ -1,10 +1,8 @@
 package io.jenkins.docker.connector;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
 import com.nirima.jenkins.plugins.docker.DockerTemplateBase;
 import hudson.slaves.JNLPLauncher;
-import io.jenkins.docker.client.DockerAPI;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
@@ -31,8 +29,8 @@ public class DockerComputerJNLPConnectorTest extends DockerComputerConnectorTest
 
         final DockerTemplate template = new DockerTemplate(
                 new DockerTemplateBase("jenkins/jnlp-slave"),
-                new DockerComputerJNLPConnector(new JNLPLauncher(null, null)).user("jenkins")
-                        .jenkinsUrl(uri.toString()),
+                new DockerComputerJNLPConnector(new JNLPLauncher(null, null)).withUser("jenkins")
+                        .withJenkinsUrl(uri.toString()),
                 "docker-agent", "/home/jenkins/agent", "10"
         );
 
@@ -42,6 +40,4 @@ public class DockerComputerJNLPConnectorTest extends DockerComputerConnectorTest
 
         should_connect_agent(template);
     }
-
-
 }


### PR DESCRIPTION
Hi,

I am using the docker jnlp slave to to build docker images by attaching the /var/run/docker.sock to the slave container. 
In order for it to work, I created an [image](https://github.com/odavid/jenkins-jnlp-slave) derived from [jenkins/jnlp-slave](https://github.com/jenkinsci/docker-jnlp-slave). 

Basically the user that runs the entrypoint is 'root' and during startup, it checks for the GID that owns the /var/run/docker.sock on the host. Then, it changes the 'jenkins' user to be member of that group.  

```bash
# To enable docker cloud based on docker socket,
# we need to add jenkins user to the docker group
if [ -S /var/run/docker.sock ]; then
  DOCKER_SOCKET_OWNER_GROUP_ID=$(stat -c %g /var/run/docker.sock)
  groupadd -for -g ${DOCKER_SOCKET_OWNER_GROUP_ID} docker
  id jenkins -G -n | grep docker || usermod -aG docker jenkins
fi
```    

At the end, the entrypoint replaces the user to be 'jenkins' and passes the arguments it got back to the original entrypoint
```bash
...
exec gosu jenkins "jenkins-slave" "$@"
``` 

It works very well with [kubernetes-plugin](https://github.com/jenkinsci/kubernetes-plugin/) and [amazon-ecs-plugin](https://github.com/jenkinsci/amazon-ecs-plugin/), however, with docker-plugin it does not work in lot of situations.

After investigation, I noticed that the problem is the way the docker-plugin runs the entrypoint with /bin/sh in detached mode and then exec the slave.jar. 
Although I understand the reasoning behind that - (i.e to be able to inject the slave.jar), it causes the 'jenkins' user to start the java process before it was a member of the docker group.

Pseudo Example:
```bash
docker run -t -d -v /var/run/docker.sock:/var/run/docker.sock --name my-jenkins-slave odavid/jenkins-jnlp-slave /bin/sh
docker exec -t -u jenkins my-jenkins-slave bash -c id

# can result (depends on how fast it ran...)
# uid=10000(jenkins) gid=10000(jenkins) groups=10000(jenkins)

docker run -t -d --name my-jenkins-slave -v /var/run/docker.sock:/var/run/docker.sock odavid/jenkins-jnlp-slave bash -c id
# will always result
# uid=10000(jenkins) gid=10000(jenkins) groups=50(docker),10000(jenkins)

```


In order to solve that, I wanted to have an additional option (while keeping the current behaviour as the default one): 
* __Pass Slave Connection Arguments to Entrypoint__  - When this option is enabled, the plugin will only run the container without any "docker exec" processes and pass the slave.jar arguments to the entrypoint. Using this way can help people do some initial preparation within the entrypoint ___before___ running the slave.jar. This also simplifies the execution and make it aligned with with [kubernetes-plugin](https://github.com/jenkinsci/kubernetes-plugin/) and [amazon-ecs-plugin](https://github.com/jenkinsci/amazon-ecs-plugin/).

In order to implement this feature, I had to re-factor the code in the following steps:
* Make the ability for the Launcher to start a container and not just get a container Id
* Move the beforeContainerCreated(), beforeContainerStarted(), afterContainerStarted() to a dedicated DockerContainerLifecycleHandler class, so it will be used as a callback
* Move the docker container start to a dedicated class: i.e. DockerContainerExecuter
* Enable the CreateContainerCmd to be manipulated with a reference to the SlaveComputer ___before___ the container starts, so I can pass the computer.JnlpMac and computer.name to the entrypoint
* In order to keep everything work with Serialization, I needed also to pass the template to the createLauncher and use DockerTemplate.createContainerCmd within the launcher.launch()
* Since the containerId is not available during the laucher object creation, I had to change the unique slave name to a different unique

I will be very happy if I can this PR approved, since currently I have only 2 options:
* Use root user instead of jenkins - this makes it hard with cache volumes. Also I don't really like root to be the process owner.
* Use jenkins-swarm or other static slaves (There are several places I work who do not have kubernetes or ECS) 

I would really appericiate if you can approve this PR.

Best,
Ohad
