### PR TITLE
Option format for SSHD changed.

### DIFF
--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -164,8 +164,8 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
             if (sshKeyStrategy.getInjectedKey() != null) {
                 cmd.withCmd("/usr/sbin/sshd", "-D", "-p", String.valueOf(port),
                         // override sshd_config to force retrieval of InstanceIdentity public for as authentication
-                        "-o", "AuthorizedKeysCommand /root/authorized_key",
-                        "-o", "AuthorizedKeysCommandUser root"
+                        "-o", "AuthorizedKeysCommand=/root/authorized_key",
+                        "-o", "AuthorizedKeysCommandUser=root"
                 );
             } else {
                 cmd.withCmd("/usr/sbin/sshd", "-D", "-p", String.valueOf(port));


### PR DESCRIPTION
Whilst trying to make the Docker plugin work with a recent Docker image based on Alpine, I came across an issue with the way the plugin injects options to SSHD.

The original method only works with some versions of SSHD - by adding the equal sign it should work reliably with all versions of SSHD. At least it works with all the images I've tried.

It can be tested without rebuilding the plugin by replacing the "Docker command" under "Container settings" to

`/usr/sbin/sshd -D -p 22 -o AuthorizedKeysCommand=/root/authorized_key -o AuthorizedKeysCommandUser=root
`

Regards,
Lars