### PR TITLE
Enhancement: (re-)Add "Read Timeout" to DockerCloud.

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -121,7 +121,7 @@ public class DockerCloud extends Cloud {
                        int readTimeout,
                        String version,
                        String dockerHostname) {
-        this(name, new DockerAPI(dockerHost, connectTimeout, version, dockerHostname), templates);
+        this(name, new DockerAPI(dockerHost, connectTimeout, readTimeout, version, dockerHostname), templates);
     }
 
     @Deprecated
@@ -503,7 +503,7 @@ public class DockerCloud extends Cloud {
             dockerHost = new DockerServerEndpoint(serverUrl, credentialsId);
         }
         if (dockerApi == null) {
-            dockerApi = new DockerAPI(dockerHost, connectTimeout, version, dockerHostname);
+            dockerApi = new DockerAPI(dockerHost, connectTimeout, readTimeout, version, dockerHostname);
         }
 
         return this;

--- a/src/main/java/io/jenkins/docker/client/DockerAPI.java
+++ b/src/main/java/io/jenkins/docker/client/DockerAPI.java
@@ -3,12 +3,13 @@ package io.jenkins.docker.client;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.VersionCmd;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.Version;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.SSLConfig;
-import com.github.dockerjava.netty.NettyDockerCmdExecFactory;
+
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -55,7 +56,11 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
 
     private DockerServerEndpoint dockerHost;
 
+    /** Connection timeout in seconds */
     private int connectTimeout;
+
+    /** Read timeout in seconds */
+    private int readTimeout;
 
     private String apiVersion;
 
@@ -73,9 +78,10 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
         this.dockerHost = dockerHost;
     }
 
-    public DockerAPI(DockerServerEndpoint dockerHost, int connectTimeout, String apiVersion, String hostname) {
+    public DockerAPI(DockerServerEndpoint dockerHost, int connectTimeout, int readTimeout, String apiVersion, String hostname) {
         this.dockerHost = dockerHost;
         this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
         this.apiVersion = apiVersion;
         this.hostname = hostname;
     }
@@ -91,6 +97,15 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
     @DataBoundSetter
     public void setConnectTimeout(int connectTimeout) {
         this.connectTimeout = connectTimeout;
+    }
+
+    public int getReadTimeout() {
+        return readTimeout;
+    }
+
+    @DataBoundSetter
+    public void setReadTimeout(int readTimeout) {
+        this.readTimeout = readTimeout;
     }
 
     public String getApiVersion() {
@@ -122,13 +137,16 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
 
     public DockerClient getClient() {
         if (client == null) {
+            final Integer readTimeoutInMillisecondsOrNull = readTimeout > 0 ? Integer.valueOf(readTimeout * 1000) : null;
+            final Integer connectTimeoutInMillisecondsOrNull = connectTimeout > 0 ? Integer.valueOf(connectTimeout * 1000) : null;
             client = DockerClientBuilder.getInstance(
                 new DefaultDockerClientConfig.Builder()
                     .withDockerHost(dockerHost.getUri())
                     .withCustomSslConfig(toSSlConfig(dockerHost.getCredentialsId()))
                 )
                 .withDockerCmdExecFactory(new NettyDockerCmdExecFactory()
-                .withConnectTimeout(connectTimeout))
+                .withReadTimeout(readTimeoutInMillisecondsOrNull)
+                .withConnectTimeout(connectTimeoutInMillisecondsOrNull))
                 .build();
         }
         return client;
@@ -136,7 +154,7 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
 
     private static SSLConfig toSSlConfig(String credentialsId) {
         if (credentialsId == null) return null;
-        
+
         DockerServerCredentials credentials = firstOrNull(
             lookupCredentials(
                 DockerServerCredentials.class,
@@ -152,7 +170,6 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
      * Create a plain {@link Socket} to docker API endpoint
      */
     public Socket getSocket() throws IOException {
-
         try {
             final URI uri = new URI(dockerHost.getUri());
             if ("unix".equals(uri.getScheme())) {
@@ -181,6 +198,7 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
         DockerAPI dockerAPI = (DockerAPI) o;
 
         if (connectTimeout != dockerAPI.connectTimeout) return false;
+        if (readTimeout != dockerAPI.readTimeout) return false;
         if (dockerHost != null ? !dockerHost.equals(dockerAPI.dockerHost) : dockerAPI.dockerHost != null) return false;
         if (apiVersion != null ? !apiVersion.equals(dockerAPI.apiVersion) : dockerAPI.apiVersion != null) return false;
         if (hostname != null ? !hostname.equals(dockerAPI.hostname) : dockerAPI.hostname != null) return false;
@@ -191,6 +209,7 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
     public int hashCode() {
         int result = dockerHost != null ? dockerHost.hashCode() : 0;
         result = 31 * result + connectTimeout;
+        result = 31 * result + readTimeout;
         result = 31 * result + (apiVersion != null ? apiVersion.hashCode() : 0);
         result = 31 * result + (hostname != null ? hostname.hashCode() : 0);
         result = 31 * result + (client != null ? client.hashCode() : 0);
@@ -205,24 +224,35 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
             if (!ac.hasPermission(Jenkins.ADMINISTER)) {
                 return new StandardListBoxModel().includeCurrentValue(value);
             }
-
             return new StandardListBoxModel().includeAs(
                     ACL.SYSTEM, context, DockerServerCredentials.class,
                     Collections.<DomainRequirement>emptyList());
+        }
+
+        public FormValidation doCheckConnectionTimeout(@QueryParameter String value) {
+            return FormValidation.validateNonNegativeInteger(value);
+        }
+
+        public FormValidation doCheckReadTimeout(@QueryParameter String value) {
+            return FormValidation.validateNonNegativeInteger(value);
         }
 
         public FormValidation doTestConnection(
                 @QueryParameter String uri,
                 @QueryParameter String credentialsId,
                 @QueryParameter String apiVersion,
-                @QueryParameter Integer connectTimeout
-        ) throws IOException, ServletException, DockerException {
+                @QueryParameter int connectTimeout,
+                @QueryParameter int readTimeout
+        ) {
             try {
-                DockerClient dc = new DockerAPI(new DockerServerEndpoint(uri, credentialsId), connectTimeout, apiVersion, null)
-                        .getClient();
-                Version verResult = dc.versionCmd().exec();
-
-                return FormValidation.ok("Version = " + verResult.getVersion() + ", API Version = " + verResult.getApiVersion());
+                final DockerServerEndpoint dsep = new DockerServerEndpoint(uri, credentialsId);
+                final DockerAPI dapi = new DockerAPI(dsep, connectTimeout, readTimeout, apiVersion, null);
+                final DockerClient dc = dapi.getClient();
+                final VersionCmd vc = dc.versionCmd();
+                final Version v = vc.exec();
+                final String actualVersion = v.getVersion();
+                final String actualApiVersion = v.getApiVersion();
+                return FormValidation.ok("Version = " + actualVersion + ", API Version = " + actualApiVersion);
             } catch (Exception e) {
                 return FormValidation.error(e, e.getMessage());
             }

--- a/src/main/java/io/jenkins/docker/client/NettyDockerCmdExecFactory.java
+++ b/src/main/java/io/jenkins/docker/client/NettyDockerCmdExecFactory.java
@@ -1,0 +1,726 @@
+/*
+ * Enhanced version of com.github.dockerjava.netty.NettyDockerCmdExecFactory,
+ * from the docker-java project (version 3.0.14), which is distributed under
+ * the Apache 2 license.
+ * 
+ * This code is a derivative work that includes a readTimeout.
+ * The code which provides this enhanced functionality can be found between comments
+ * of the form "START/END of new readTimeout code".
+ * It was necessary to copy the entire NettyDockerCmdExecFactory class here because
+ * the design of the NettyDockerCmdExecFactory class (mostly private fields and
+ * methods) does not provide for easy extensibility.
+ * 
+ * Note: Once the official release of docker-java includes this additional
+ * functionality, the docker-plugin code should just use that and this code can
+ * (and should) be removed from the docker-plugin code.
+ */
+package io.jenkins.docker.client;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.SocketTimeoutException;
+import java.security.Security;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+
+import org.apache.commons.lang.SystemUtils;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import com.github.dockerjava.api.command.AttachContainerCmd;
+import com.github.dockerjava.api.command.AuthCmd;
+import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.command.CommitCmd;
+import com.github.dockerjava.api.command.ConnectToNetworkCmd;
+import com.github.dockerjava.api.command.ContainerDiffCmd;
+import com.github.dockerjava.api.command.CopyArchiveFromContainerCmd;
+import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
+import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateImageCmd;
+import com.github.dockerjava.api.command.CreateNetworkCmd;
+import com.github.dockerjava.api.command.CreateVolumeCmd;
+import com.github.dockerjava.api.command.DisconnectFromNetworkCmd;
+import com.github.dockerjava.api.command.DockerCmdExecFactory;
+import com.github.dockerjava.api.command.EventsCmd;
+import com.github.dockerjava.api.command.ExecCreateCmd;
+import com.github.dockerjava.api.command.ExecStartCmd;
+import com.github.dockerjava.api.command.InfoCmd;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectExecCmd;
+import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.command.InspectNetworkCmd;
+import com.github.dockerjava.api.command.InspectVolumeCmd;
+import com.github.dockerjava.api.command.KillContainerCmd;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.command.ListNetworksCmd;
+import com.github.dockerjava.api.command.ListVolumesCmd;
+import com.github.dockerjava.api.command.LoadImageCmd;
+import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.PauseContainerCmd;
+import com.github.dockerjava.api.command.PingCmd;
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.command.PushImageCmd;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.api.command.RemoveImageCmd;
+import com.github.dockerjava.api.command.RemoveNetworkCmd;
+import com.github.dockerjava.api.command.RemoveVolumeCmd;
+import com.github.dockerjava.api.command.RenameContainerCmd;
+import com.github.dockerjava.api.command.RestartContainerCmd;
+import com.github.dockerjava.api.command.SaveImageCmd;
+import com.github.dockerjava.api.command.SearchImagesCmd;
+import com.github.dockerjava.api.command.StartContainerCmd;
+import com.github.dockerjava.api.command.StatsCmd;
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.TagImageCmd;
+import com.github.dockerjava.api.command.TopContainerCmd;
+import com.github.dockerjava.api.command.UnpauseContainerCmd;
+import com.github.dockerjava.api.command.UpdateContainerCmd;
+import com.github.dockerjava.api.command.VersionCmd;
+import com.github.dockerjava.api.command.WaitContainerCmd;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.core.DockerClientImpl;
+import com.github.dockerjava.core.SSLConfig;
+import com.github.dockerjava.netty.ChannelProvider;
+import com.github.dockerjava.netty.WebTarget;
+import com.github.dockerjava.netty.exec.AttachContainerCmdExec;
+import com.github.dockerjava.netty.exec.AuthCmdExec;
+import com.github.dockerjava.netty.exec.BuildImageCmdExec;
+import com.github.dockerjava.netty.exec.CommitCmdExec;
+import com.github.dockerjava.netty.exec.ConnectToNetworkCmdExec;
+import com.github.dockerjava.netty.exec.ContainerDiffCmdExec;
+import com.github.dockerjava.netty.exec.CopyArchiveFromContainerCmdExec;
+import com.github.dockerjava.netty.exec.CopyArchiveToContainerCmdExec;
+import com.github.dockerjava.netty.exec.CopyFileFromContainerCmdExec;
+import com.github.dockerjava.netty.exec.CreateContainerCmdExec;
+import com.github.dockerjava.netty.exec.CreateImageCmdExec;
+import com.github.dockerjava.netty.exec.CreateNetworkCmdExec;
+import com.github.dockerjava.netty.exec.CreateVolumeCmdExec;
+import com.github.dockerjava.netty.exec.DisconnectFromNetworkCmdExec;
+import com.github.dockerjava.netty.exec.EventsCmdExec;
+import com.github.dockerjava.netty.exec.ExecCreateCmdExec;
+import com.github.dockerjava.netty.exec.ExecStartCmdExec;
+import com.github.dockerjava.netty.exec.InfoCmdExec;
+import com.github.dockerjava.netty.exec.InspectContainerCmdExec;
+import com.github.dockerjava.netty.exec.InspectExecCmdExec;
+import com.github.dockerjava.netty.exec.InspectImageCmdExec;
+import com.github.dockerjava.netty.exec.InspectNetworkCmdExec;
+import com.github.dockerjava.netty.exec.InspectVolumeCmdExec;
+import com.github.dockerjava.netty.exec.KillContainerCmdExec;
+import com.github.dockerjava.netty.exec.ListContainersCmdExec;
+import com.github.dockerjava.netty.exec.ListImagesCmdExec;
+import com.github.dockerjava.netty.exec.ListNetworksCmdExec;
+import com.github.dockerjava.netty.exec.ListVolumesCmdExec;
+import com.github.dockerjava.netty.exec.LoadImageCmdExec;
+import com.github.dockerjava.netty.exec.LogContainerCmdExec;
+import com.github.dockerjava.netty.exec.PauseContainerCmdExec;
+import com.github.dockerjava.netty.exec.PingCmdExec;
+import com.github.dockerjava.netty.exec.PullImageCmdExec;
+import com.github.dockerjava.netty.exec.PushImageCmdExec;
+import com.github.dockerjava.netty.exec.RemoveContainerCmdExec;
+import com.github.dockerjava.netty.exec.RemoveImageCmdExec;
+import com.github.dockerjava.netty.exec.RemoveNetworkCmdExec;
+import com.github.dockerjava.netty.exec.RemoveVolumeCmdExec;
+import com.github.dockerjava.netty.exec.RenameContainerCmdExec;
+import com.github.dockerjava.netty.exec.RestartContainerCmdExec;
+import com.github.dockerjava.netty.exec.SaveImageCmdExec;
+import com.github.dockerjava.netty.exec.SearchImagesCmdExec;
+import com.github.dockerjava.netty.exec.StartContainerCmdExec;
+import com.github.dockerjava.netty.exec.StatsCmdExec;
+import com.github.dockerjava.netty.exec.StopContainerCmdExec;
+import com.github.dockerjava.netty.exec.TagImageCmdExec;
+import com.github.dockerjava.netty.exec.TopContainerCmdExec;
+import com.github.dockerjava.netty.exec.UnpauseContainerCmdExec;
+import com.github.dockerjava.netty.exec.UpdateContainerCmdExec;
+import com.github.dockerjava.netty.exec.VersionCmdExec;
+import com.github.dockerjava.netty.exec.WaitContainerCmdExec;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelConfig;
+import io.netty.channel.ChannelFactory;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.kqueue.KQueueDomainSocketChannel;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.DuplexChannel;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.channel.unix.DomainSocketAddress;
+import io.netty.channel.unix.UnixChannel;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.logging.LoggingHandler;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+/**
+ * Experimental implementation of {@link DockerCmdExecFactory} that supports http connection hijacking that is needed to pass STDIN to the
+ * container.
+ *
+ * To use it just pass an instance via {@link DockerClientImpl#withDockerCmdExecFactory(DockerCmdExecFactory)}
+ *
+ * @see https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#attach-to-a-container
+ * @see https://docs.docker.com/engine/reference/api/docker_remote_api_v1.21/#exec-start
+ *
+ *
+ * @author Marcus Linke
+ */
+public class NettyDockerCmdExecFactory implements DockerCmdExecFactory {
+
+    private static String threadPrefix = "dockerjava-netty";
+
+    /*
+     * useful links:
+     *
+     * http://stackoverflow.com/questions/33296749/netty-connect-to-unix-domain-socket-failed
+     * http://netty.io/wiki/native-transports.html
+     * https://github.com/netty/netty/blob/master/example/src/main/java/io/netty/example/http/snoop/HttpSnoopClient.java
+     * https://github.com/slandelle/netty-request-chunking/blob/master/src/test/java/slandelle/ChunkingTest.java
+     */
+
+    private DockerClientConfig dockerClientConfig;
+
+    private Bootstrap bootstrap;
+
+    private EventLoopGroup eventLoopGroup;
+
+    private NettyInitializer nettyInitializer;
+
+    private WebTarget baseResource;
+
+    private ChannelProvider channelProvider = new ChannelProvider() {
+        @Override
+        public DuplexChannel getChannel() {
+            DuplexChannel channel = connect();
+            channel.pipeline().addLast(new LoggingHandler(getClass()));
+            return channel;
+        }
+    };
+
+    private Integer connectTimeout = null;
+
+    // START of new readTimeout code
+    private Integer readTimeout = null;
+    // END of new readTimeout code
+
+    @Override
+    public void init(DockerClientConfig dockerClientConfig) {
+        checkNotNull(dockerClientConfig, "config was not specified");
+        this.dockerClientConfig = dockerClientConfig;
+
+        bootstrap = new Bootstrap();
+
+        String scheme = dockerClientConfig.getDockerHost().getScheme();
+
+        if ("unix".equals(scheme)) {
+            nettyInitializer = new UnixDomainSocketInitializer();
+        } else if ("tcp".equals(scheme)) {
+            nettyInitializer = new InetSocketInitializer();
+        }
+
+        eventLoopGroup = nettyInitializer.init(bootstrap, dockerClientConfig);
+
+        baseResource = new WebTarget(channelProvider).path(dockerClientConfig.getApiVersion().asWebPathPart());
+    }
+
+    private DuplexChannel connect() {
+        try {
+            return connect(bootstrap);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private DuplexChannel connect(final Bootstrap bootstrap) throws InterruptedException {
+        return nettyInitializer.connect(bootstrap);
+    }
+
+    private interface NettyInitializer {
+        EventLoopGroup init(final Bootstrap bootstrap, DockerClientConfig dockerClientConfig);
+
+        DuplexChannel connect(final Bootstrap bootstrap) throws InterruptedException;
+    }
+
+    private class UnixDomainSocketInitializer implements NettyInitializer {
+        @Override
+        public EventLoopGroup init(Bootstrap bootstrap, DockerClientConfig dockerClientConfig) {
+            if (SystemUtils.IS_OS_LINUX) {
+                return epollGroup();
+            } else if (SystemUtils.IS_OS_MAC_OSX) {
+                return kqueueGroup();
+            }
+            throw new RuntimeException("Unspported OS");
+        }
+
+        public EventLoopGroup epollGroup() {
+            EventLoopGroup epollEventLoopGroup = new EpollEventLoopGroup(0, new DefaultThreadFactory(threadPrefix));
+
+            ChannelFactory<EpollDomainSocketChannel> factory = new ChannelFactory<EpollDomainSocketChannel>() {
+                @Override
+                public EpollDomainSocketChannel newChannel() {
+                    return configure(new EpollDomainSocketChannel());
+                }
+            };
+
+            bootstrap.group(epollEventLoopGroup).channelFactory(factory).handler(new ChannelInitializer<UnixChannel>() {
+                @Override
+                protected void initChannel(final UnixChannel channel) throws Exception {
+                    channel.pipeline().addLast(new HttpClientCodec());
+                }
+            });
+            return epollEventLoopGroup;
+        }
+
+        public EventLoopGroup kqueueGroup() {
+            EventLoopGroup nioEventLoopGroup = new KQueueEventLoopGroup(0, new DefaultThreadFactory(threadPrefix));
+
+            bootstrap.group(nioEventLoopGroup).channel(KQueueDomainSocketChannel.class)
+                    .handler(new ChannelInitializer<KQueueDomainSocketChannel>() {
+                        @Override
+                        protected void initChannel(final KQueueDomainSocketChannel channel) throws Exception {
+                            channel.pipeline().addLast(new LoggingHandler(getClass()));
+                            channel.pipeline().addLast(new HttpClientCodec());
+                        }
+                    });
+
+            return nioEventLoopGroup;
+        }
+
+        @Override
+        public DuplexChannel connect(Bootstrap bootstrap) throws InterruptedException {
+            return (DuplexChannel) bootstrap.connect(new DomainSocketAddress("/var/run/docker.sock")).sync().channel();
+        }
+    }
+
+    private class InetSocketInitializer implements NettyInitializer {
+        @Override
+        public EventLoopGroup init(Bootstrap bootstrap, final DockerClientConfig dockerClientConfig) {
+            EventLoopGroup nioEventLoopGroup = new NioEventLoopGroup(0, new DefaultThreadFactory(threadPrefix));
+
+            InetAddress addr = InetAddress.getLoopbackAddress();
+
+            final SocketAddress proxyAddress = new InetSocketAddress(addr, 8008);
+
+            Security.addProvider(new BouncyCastleProvider());
+
+            ChannelFactory<NioSocketChannel> factory = new ChannelFactory<NioSocketChannel>() {
+                @Override
+                public NioSocketChannel newChannel() {
+                    return configure(new NioSocketChannel());
+                }
+            };
+
+            bootstrap.group(nioEventLoopGroup).channelFactory(factory)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(final SocketChannel channel) throws Exception {
+                            // channel.pipeline().addLast(new
+                            // HttpProxyHandler(proxyAddress));
+                            channel.pipeline().addLast(new HttpClientCodec());
+                        }
+                    });
+
+            return nioEventLoopGroup;
+        }
+
+        @Override
+        public DuplexChannel connect(Bootstrap bootstrap) throws InterruptedException {
+            String host = dockerClientConfig.getDockerHost().getHost();
+            int port = dockerClientConfig.getDockerHost().getPort();
+
+            if (port == -1) {
+                throw new RuntimeException("no port configured for " + host);
+            }
+
+            DuplexChannel channel = (DuplexChannel) bootstrap.connect(host, port).sync().channel();
+
+            final SslHandler ssl = initSsl(dockerClientConfig);
+
+            if (ssl != null) {
+                channel.pipeline().addFirst(ssl);
+            }
+
+            return channel;
+        }
+
+        private SslHandler initSsl(DockerClientConfig dockerClientConfig) {
+            SslHandler ssl = null;
+
+            try {
+                String host = dockerClientConfig.getDockerHost().getHost();
+                int port = dockerClientConfig.getDockerHost().getPort();
+
+                final SSLConfig sslConfig = dockerClientConfig.getSSLConfig();
+
+                if (sslConfig != null && sslConfig.getSSLContext() != null) {
+
+                    SSLEngine engine = sslConfig.getSSLContext().createSSLEngine(host, port);
+                    engine.setUseClientMode(true);
+                    engine.setSSLParameters(enableHostNameVerification(engine.getSSLParameters()));
+
+                    // in the future we may use HostnameVerifier like here:
+                    // https://github.com/AsyncHttpClient/async-http-client/blob/1.8.x/src/main/java/com/ning/http/client/providers/netty/NettyConnectListener.java#L76
+
+                    ssl = new SslHandler(engine);
+                }
+
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            return ssl;
+        }
+    }
+
+    protected DockerClientConfig getDockerClientConfig() {
+        checkNotNull(dockerClientConfig,
+                "Factor not initialized, dockerClientConfig not set. You probably forgot to call init()!");
+        return dockerClientConfig;
+    }
+
+    public SSLParameters enableHostNameVerification(SSLParameters sslParameters) {
+        sslParameters.setEndpointIdentificationAlgorithm("HTTPS");
+        return sslParameters;
+    }
+
+    @Override
+    public CopyArchiveFromContainerCmd.Exec createCopyArchiveFromContainerCmdExec() {
+        return new CopyArchiveFromContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public CopyArchiveToContainerCmd.Exec createCopyArchiveToContainerCmdExec() {
+        return new CopyArchiveToContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public AuthCmd.Exec createAuthCmdExec() {
+        return new AuthCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public InfoCmd.Exec createInfoCmdExec() {
+        return new InfoCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public PingCmd.Exec createPingCmdExec() {
+        return new PingCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public VersionCmd.Exec createVersionCmdExec() {
+        return new VersionCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public PullImageCmd.Exec createPullImageCmdExec() {
+        return new PullImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public PushImageCmd.Exec createPushImageCmdExec() {
+        return new PushImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public SaveImageCmd.Exec createSaveImageCmdExec() {
+        return new SaveImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public CreateImageCmd.Exec createCreateImageCmdExec() {
+        return new CreateImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public LoadImageCmd.Exec createLoadImageCmdExec() {
+        return new LoadImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public SearchImagesCmd.Exec createSearchImagesCmdExec() {
+        return new SearchImagesCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public RemoveImageCmd.Exec createRemoveImageCmdExec() {
+        return new RemoveImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public ListImagesCmd.Exec createListImagesCmdExec() {
+        return new ListImagesCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public InspectImageCmd.Exec createInspectImageCmdExec() {
+        return new InspectImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public ListContainersCmd.Exec createListContainersCmdExec() {
+        return new ListContainersCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public CreateContainerCmd.Exec createCreateContainerCmdExec() {
+        return new CreateContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public StartContainerCmd.Exec createStartContainerCmdExec() {
+        return new StartContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public InspectContainerCmd.Exec createInspectContainerCmdExec() {
+        return new InspectContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public ExecCreateCmd.Exec createExecCmdExec() {
+        return new ExecCreateCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public RemoveContainerCmd.Exec createRemoveContainerCmdExec() {
+        return new RemoveContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public WaitContainerCmd.Exec createWaitContainerCmdExec() {
+        return new WaitContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public AttachContainerCmd.Exec createAttachContainerCmdExec() {
+        return new AttachContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public ExecStartCmd.Exec createExecStartCmdExec() {
+        return new ExecStartCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public InspectExecCmd.Exec createInspectExecCmdExec() {
+        return new InspectExecCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public LogContainerCmd.Exec createLogContainerCmdExec() {
+        return new LogContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public CopyFileFromContainerCmd.Exec createCopyFileFromContainerCmdExec() {
+        return new CopyFileFromContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public StopContainerCmd.Exec createStopContainerCmdExec() {
+        return new StopContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public ContainerDiffCmd.Exec createContainerDiffCmdExec() {
+        return new ContainerDiffCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public KillContainerCmd.Exec createKillContainerCmdExec() {
+        return new KillContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public UpdateContainerCmd.Exec createUpdateContainerCmdExec() {
+        return new UpdateContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public RenameContainerCmd.Exec createRenameContainerCmdExec() {
+        return new RenameContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public RestartContainerCmd.Exec createRestartContainerCmdExec() {
+        return new RestartContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public CommitCmd.Exec createCommitCmdExec() {
+        return new CommitCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public BuildImageCmd.Exec createBuildImageCmdExec() {
+        return new BuildImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public TopContainerCmd.Exec createTopContainerCmdExec() {
+        return new TopContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public TagImageCmd.Exec createTagImageCmdExec() {
+        return new TagImageCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public PauseContainerCmd.Exec createPauseContainerCmdExec() {
+        return new PauseContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public UnpauseContainerCmd.Exec createUnpauseContainerCmdExec() {
+        return new UnpauseContainerCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public EventsCmd.Exec createEventsCmdExec() {
+        return new EventsCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public StatsCmd.Exec createStatsCmdExec() {
+        return new StatsCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public CreateVolumeCmd.Exec createCreateVolumeCmdExec() {
+        return new CreateVolumeCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public InspectVolumeCmd.Exec createInspectVolumeCmdExec() {
+        return new InspectVolumeCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public RemoveVolumeCmd.Exec createRemoveVolumeCmdExec() {
+        return new RemoveVolumeCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public ListVolumesCmd.Exec createListVolumesCmdExec() {
+        return new ListVolumesCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public ListNetworksCmd.Exec createListNetworksCmdExec() {
+        return new ListNetworksCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public InspectNetworkCmd.Exec createInspectNetworkCmdExec() {
+        return new InspectNetworkCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public CreateNetworkCmd.Exec createCreateNetworkCmdExec() {
+        return new CreateNetworkCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public RemoveNetworkCmd.Exec createRemoveNetworkCmdExec() {
+        return new RemoveNetworkCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public ConnectToNetworkCmd.Exec createConnectToNetworkCmdExec() {
+        return new ConnectToNetworkCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public DisconnectFromNetworkCmd.Exec createDisconnectFromNetworkCmdExec() {
+        return new DisconnectFromNetworkCmdExec(getBaseResource(), getDockerClientConfig());
+    }
+
+    @Override
+    public void close() throws IOException {
+        checkNotNull(eventLoopGroup, "Factory not initialized. You probably forgot to call init()!");
+
+        eventLoopGroup.shutdownGracefully();
+    }
+
+    /**
+     * Configure connection timeout in milliseconds
+     */
+    public NettyDockerCmdExecFactory withConnectTimeout(Integer connectTimeout) {
+        this.connectTimeout = connectTimeout;
+        return this;
+    }
+
+    // START of new readTimeout code
+    /**
+     * Configure read timeout in milliseconds
+     */
+    public NettyDockerCmdExecFactory withReadTimeout(Integer readTimeout) {
+        this.readTimeout = readTimeout;
+        return this;
+    }
+    // END of new readTimeout code
+
+    private <T extends Channel> T configure(T channel) {
+        ChannelConfig channelConfig = channel.config();
+
+        if (connectTimeout != null) {
+            channelConfig.setConnectTimeoutMillis(connectTimeout);
+        }
+        // START of new readTimeout code
+        if (readTimeout != null) {
+            channel.pipeline().addLast("readTimeoutHandler", new ReadTimeoutHandler());
+        }
+        // END of new readTimeout code
+
+        return channel;
+    }
+
+    // START of new readTimeout code
+    private final class ReadTimeoutHandler extends IdleStateHandler {
+        private boolean alreadyTimedOut;
+
+        ReadTimeoutHandler() {
+            super(readTimeout, 0, 0, TimeUnit.MILLISECONDS);
+        }
+
+        /**
+         * Called when a read timeout was detected.
+         */
+        @Override
+        protected synchronized void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) throws Exception {
+            assert evt.state() == IdleState.READER_IDLE;
+            if (alreadyTimedOut) {
+                return;
+            }
+            final Object dockerAPIEndpoint = getDockerClientConfig().getDockerHost();
+            final String msg = "Read timed out: No data received within " + readTimeout
+                    + "ms.  Perhaps the docker API (" + dockerAPIEndpoint
+                    + ") is not responding normally, or perhaps you need to increase the readTimeout value.";
+            final Exception ex = new SocketTimeoutException(msg);
+            ctx.fireExceptionCaught(ex);
+            alreadyTimedOut = true;
+        }
+    }
+    // END of new readTimeout code
+
+    private WebTarget getBaseResource() {
+        checkNotNull(baseResource, "Factory not initialized, baseResource not set. You probably forgot to call init()!");
+        return baseResource;
+    }
+}

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-readTimeout.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-readTimeout.html
@@ -1,3 +1,0 @@
-<div>
-    Read timeout to Docker API. In seconds. 0 is infinity.
-</div>

--- a/src/main/resources/io/jenkins/docker/client/DockerAPI/config.jelly
+++ b/src/main/resources/io/jenkins/docker/client/DockerAPI/config.jelly
@@ -8,8 +8,12 @@
             <f:textbox/>
         </f:entry>
 
-        <f:entry title="${%Connection Timeout (seconds)}" field="connectTimeout">
-            <f:textbox default="60"/>
+        <f:entry title="${%Connection Timeout}" field="connectTimeout">
+            <f:textbox clazz="required number" default="60"/>
+        </f:entry>
+
+        <f:entry title="${%Read Timeout}" field="readTimeout">
+            <f:textbox clazz="required number" default="60"/>
         </f:entry>
 
         <f:entry title="${%Docker Hostname or IP address}" field="hostname">
@@ -19,6 +23,6 @@
 
     <!-- we can't pass dockerhost here, need to "flatmap" it's attributes -->
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection"
-                      with="uri,credentialsId,apiVersion,connectTimeout"/>
+                      with="uri,credentialsId,apiVersion,connectTimeout,readTimeout"/>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/docker/client/DockerAPI/help-connectTimeout.html
+++ b/src/main/resources/io/jenkins/docker/client/DockerAPI/help-connectTimeout.html
@@ -1,3 +1,4 @@
 <div>
-    Timeout for opening connection to Docker API. 0 is infinity.
+    Timeout, in seconds, for opening connection to Docker API.
+    0 means no time limit.
 </div>

--- a/src/main/resources/io/jenkins/docker/client/DockerAPI/help-readTimeout.html
+++ b/src/main/resources/io/jenkins/docker/client/DockerAPI/help-readTimeout.html
@@ -1,0 +1,4 @@
+<div>
+    Timeout, in seconds, to apply when expecting data from the Docker API.
+    0 means no time limit, but this is not recommended (if your docker API locks up, some aspects of Jenkins can also lock up).
+</div>


### PR DESCRIPTION
It's possible for a docker API endpoint to seize up, accepting incoming connections but never replying.  This causes docker-plugin's calls to the docker API to hang, causing Jenkins' call to the docker-plugin to hang, causing Jenkins' cloud functionality to hang, crippling Jenkins.
To handle this, the docker-plugin must timeout so that it won't wait forever for the docker-api to return, and treat a timeout as a failure.  This will help mitigate #594.
This code change re-introduces the functionality as follows:
 - Re-add readTimeout to the docker cloud configuration
 - Re-add readTimeout to the docker API
 - Enhance docker-java code to support readTimeout.
 - Improve help text for both connectTimeout and readTimeout.

Note: This functionality was present in older versions of the plugin but was lost due to later versions of the docker-java library missing this functionality.  There's a separate issue to put that back again.  Once the official docker-java release is enhanced to support readTimeout, this plugin can remove its own enhanced NettyDockerCmdFactory and go back to using the docker-java version directly.
