### PR TITLE
Per-cloud instance caps

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -102,7 +102,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         this.labelString = Util.fixNull(labelString);
         this.remoteFs = Strings.isNullOrEmpty(remoteFs) ? "/home/jenkins" : remoteFs;
 
-        if (instanceCapStr.equals("")) {
+        if (Strings.isNullOrEmpty(instanceCapStr)) {
             this.instanceCap = Integer.MAX_VALUE;
         } else {
             this.instanceCap = Integer.parseInt(instanceCapStr);

--- a/src/main/java/io/jenkins/docker/client/ListContainersCmdExec.java
+++ b/src/main/java/io/jenkins/docker/client/ListContainersCmdExec.java
@@ -1,0 +1,66 @@
+package io.jenkins.docker.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.core.DockerClientConfig;
+import com.github.dockerjava.netty.MediaType;
+import com.github.dockerjava.netty.WebTarget;
+import com.github.dockerjava.netty.exec.AbstrSyncDockerCmdExec;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Bugfixed version of docker-java's ListContainersCmdExec. This version doesn't
+ * rely on Jersey's FiltersEncoder so it works when all you've got is Netty. It
+ * also removes the logging, as Netty's WebTarget class has no useful toString()
+ * method, rendering the output largely useless.
+ */
+public class ListContainersCmdExec extends AbstrSyncDockerCmdExec<ListContainersCmd, List<Container>> implements
+        ListContainersCmd.Exec {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ListContainersCmdExec.class);
+
+    public ListContainersCmdExec(WebTarget baseResource, DockerClientConfig dockerClientConfig) {
+        super(baseResource, dockerClientConfig);
+    }
+
+    @Override
+    protected List<Container> execute(ListContainersCmd command) {
+        WebTarget webTarget = getBaseResource().path("/containers/json").queryParam("since", command.getSinceId())
+                .queryParam("before", command.getBeforeId());
+
+        webTarget = booleanQueryParam(webTarget, "all", command.hasShowAllEnabled());
+        webTarget = booleanQueryParam(webTarget, "size", command.hasShowSizeEnabled());
+
+        if (command.getLimit() != null && command.getLimit() >= 0) {
+            webTarget = webTarget.queryParam("limit", String.valueOf(command.getLimit()));
+        }
+
+        if (command.getFilters() != null && !command.getFilters().isEmpty()) {
+            // BugFix starts here
+            // Old code used FiltersEncoder.jsonEncode(command.getFilters())
+            final ObjectMapper objectMapper = new ObjectMapper();
+            final String encodedFilters;
+            try {
+                encodedFilters = objectMapper.writeValueAsString(command.getFilters());
+            } catch (JsonProcessingException ex) {
+                throw new RuntimeException(ex);
+            }
+            webTarget = webTarget.queryParam("filters", encodedFilters);
+            // End BugFix
+        }
+
+        List<Container> containers = webTarget.request().accept(MediaType.APPLICATION_JSON)
+                .get(new TypeReference<List<Container>>() {
+                });
+
+        return containers;
+    }
+
+}

--- a/src/main/java/io/jenkins/docker/client/NettyDockerCmdExecFactory.java
+++ b/src/main/java/io/jenkins/docker/client/NettyDockerCmdExecFactory.java
@@ -113,7 +113,6 @@ import com.github.dockerjava.netty.exec.InspectImageCmdExec;
 import com.github.dockerjava.netty.exec.InspectNetworkCmdExec;
 import com.github.dockerjava.netty.exec.InspectVolumeCmdExec;
 import com.github.dockerjava.netty.exec.KillContainerCmdExec;
-import com.github.dockerjava.netty.exec.ListContainersCmdExec;
 import com.github.dockerjava.netty.exec.ListImagesCmdExec;
 import com.github.dockerjava.netty.exec.ListNetworksCmdExec;
 import com.github.dockerjava.netty.exec.ListVolumesCmdExec;

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
@@ -71,4 +71,50 @@ public class DockerCloudTest {
 
         Assert.assertEquals(cloud, jenkins.getInstance().clouds.get(0));
     }
+
+    @Test
+    public void keepTrackOfContainersInProgress() {
+        final DockerTemplate i1 = new DockerTemplate(new DockerTemplateBase("image1"), null, null, null, null);
+        final DockerTemplate i2 = new DockerTemplate(new DockerTemplateBase("image2"), null, null, null, null);
+        final String uniqueId = Integer.toString(hashCode(), 36);
+        final DockerCloud c1 = new DockerCloud("cloud1." + uniqueId, null, null);
+        final DockerCloud c2 = new DockerCloud("cloud2." + uniqueId, null, null);
+
+        assertCount(c1, c2, i1, i2, 0, 0, 0, 0);
+        Assert.assertEquals("DockerCloud.CONTAINERS_IN_PROGRESS is empty to start with",
+                DockerCloud.CONTAINERS_IN_PROGRESS, Collections.EMPTY_MAP);
+
+        c1.incrementContainersInProgress(i1);
+        assertCount(c1, c2, i1, i2, 1, 0, 0, 0);
+        c1.decrementContainersInProgress(i2);
+        assertCount(c1, c2, i1, i2, 1, -1, 0, 0);
+        c2.incrementContainersInProgress(i1);
+        assertCount(c1, c2, i1, i2, 1, -1, 1, 0);
+        c2.incrementContainersInProgress(i1);
+        assertCount(c1, c2, i1, i2, 1, -1, 2, 0);
+
+        c1.decrementContainersInProgress(i1);
+        assertCount(c1, c2, i1, i2, 0, -1, 2, 0);
+        c1.incrementContainersInProgress(i2);
+        assertCount(c1, c2, i1, i2, 0, 0, 2, 0);
+        c2.decrementContainersInProgress(i1);
+        assertCount(c1, c2, i1, i2, 0, 0, 1, 0);
+        c2.decrementContainersInProgress(i1);
+        assertCount(c1, c2, i1, i2, 0, 0, 0, 0);
+        Assert.assertEquals("DockerCloud.CONTAINERS_IN_PROGRESS is empty afterwards",
+                DockerCloud.CONTAINERS_IN_PROGRESS, Collections.EMPTY_MAP);
+    }
+
+    private static void assertCount(DockerCloud c1, DockerCloud c2, DockerTemplate i1, DockerTemplate i2, int c1i1,
+            int c1i2, int c2i1, int c2i2) {
+        final int c1All = c1i1 + c1i2;
+        final int c2All = c2i1 + c2i2;
+        final String state = "when c1(" + c1i1 + "," + c1i2 + "), c2(" + c2i1 + "," + c2i2 + "), ";
+        Assert.assertEquals(state + "c1.countContainersInProgress()", c1All, c1.countContainersInProgress());
+        Assert.assertEquals(state + "c2.countContainersInProgress()", c2All, c2.countContainersInProgress());
+        Assert.assertEquals(state + "c1.countContainersInProgress(i1)", c1i1, c1.countContainersInProgress(i1));
+        Assert.assertEquals(state + "c1.countContainersInProgress(i2)", c1i2, c1.countContainersInProgress(i2));
+        Assert.assertEquals(state + "c2.countContainersInProgress(i1)", c2i1, c2.countContainersInProgress(i1));
+        Assert.assertEquals(state + "c2.countContainersInProgress(i2)", c2i2, c2.countContainersInProgress(i2));
+    }
 }


### PR DESCRIPTION
1) BugFix: if the plugin is talking to a very busy docker daemon, it can get more than 1meg of data back from the ListContainersCmd and throw an exception, which stops it from starting further containers.
This code changes the parameters we pass to ListContainers so that we only ask about containers that we started ourselves, thus excluding any other containers from the returned results.
2) BugFix: if the plugin has multiple clouds mentioning the same image, it was possible for it to get confused when counting the number of containers being constructed.  This change ensures that each cloud has its own counters so there's no longer pollution between them.
3) BugFix: the code responsible for tracking the count of containers in progress was able to loose track.  We now use try/finally code to ensure it cannot get out of step even if exceptions happen.
4) Behavioral change:  cloud-level instance caps now only count instances started by "our" Jenkins and no longer count containers running within docker that weren't started by our Jenkins.
5) Performance improvement:  If you don't set a template container instance cap, we don't ask docker to count them.  If you don't set a cloud-level container instance cap, we don't ask docker to count them.  If you don't set either cap then we don't hammer the "ListContainers" API at all, resulting in improved speed and stability of the Jenkins cloud provisioning process overall.
6) Logging changes:  DockerCloud's "Will provision ..." log messages now provide more information, showing current counts and caps, when those caps are being used.