### PR TITLE
DockerCloud now removes containers it created if provisioning failed.

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -328,10 +328,11 @@ public class DockerCloud extends Cloud {
                 final Runnable taskToCreateNewSlave = new Runnable() {
                     @Override
                     public void run() {
+                        DockerTransientNode slave = null;
                         try {
                             // TODO where can we log provisioning progress ?
                             final DockerAPI api = DockerCloud.this.getDockerApi();
-                            final DockerTransientNode slave = t.provisionNode(api, TaskListener.NULL);
+                            slave = t.provisionNode(api, TaskListener.NULL);
                             slave.setCloudId(DockerCloud.this.name);
                             plannedNode.complete(slave);
 
@@ -342,6 +343,9 @@ public class DockerCloud extends Cloud {
                             LOGGER.error("Error in provisioning; template='{}' for cloud='{}'",
                                     t, getDisplayName(), ex);
                             plannedNode.completeExceptionally(ex);
+                            if (slave != null) {
+                                slave.terminate(LOGGER);
+                            }
                             throw Throwables.propagate(ex);
                         } finally {
                             decrementContainersInProgress(t);

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerOfflineCause.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerOfflineCause.java
@@ -8,6 +8,6 @@ import hudson.slaves.OfflineCause;
 public class DockerOfflineCause extends OfflineCause {
     @Override
     public String toString() {
-        return "Shutting down Docker";
+        return "Shutting down Docker container";
     }
 }


### PR DESCRIPTION
If the docker container gets successfully created, but Jenkins then fails to take on the new slave, we used to forget about it and just leak containers.
We now remove the container if we failed to complete the provisioning process after we'd created it, and log the termination progress.