### PR TITLE
More info in DockerComputerSSHConnector

### DIFF
--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/config.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/config.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" >
 
     <f:block>
-        <span class="info">Prerequisites:</span> Docker image must have <a href="https://www.openssh.com/">sshd</a> installed.
+        <span class="info">Prerequisites:</span> Docker image must have <a href="https://www.openssh.com/">sshd</a> and a JDK installed.
     </f:block>
 
     <f:dropdownDescriptorSelector  title="SSH key" field="sshKeyStrategy" />


### PR DESCRIPTION
Display more information in the Prerequisites section of
DockerComputerSSHConnector.

Only sshd is shown as mandatory but JDK is also mandatory

Note that this info is available on the plugin page
https://plugins.jenkins.io/docker-plugin
(Section "Creating a docker image">"Launch via SSH")