### PR TITLE
[REVIEW REQUESTED] Improve readtimeout functionality

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
@@ -17,6 +17,7 @@ import hudson.model.BuildListener;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import io.jenkins.docker.DockerTransientNode;
+import io.jenkins.docker.client.DockerAPI;
 import jenkins.model.Jenkins;
 import jenkins.model.OptionalJobProperty;
 import org.apache.commons.lang.StringUtils;
@@ -97,8 +98,17 @@ public class DockerJobProperty extends OptionalJobProperty<AbstractProject<?, ?>
         DockerTransientNode dockerNode = (DockerTransientNode) node;
 
         final String containerId = dockerNode.getContainerId();
-        final DockerClient client = dockerNode.getDockerAPI().getClient();
-        final String dockerHost = dockerNode.getDockerAPI().getDockerHost().getUri();
+        final DockerAPI dockerAPI = dockerNode.getDockerAPI();
+        final DockerClient client = dockerAPI.takeClient();
+        try {
+            return perform(build, listener, containerId, dockerAPI, client);
+        } finally {
+            dockerAPI.releaseClient(client);
+        }
+    }
+
+    private boolean perform(AbstractBuild<?, ?> build, BuildListener listener, String containerId, DockerAPI dockerAPI, DockerClient client) throws IOException {
+        final String dockerHost = dockerAPI.getDockerHost().getUri();
 
         // Commit
         String tag_image = client.commitCmd(containerId)

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerJobProperty.java
@@ -99,11 +99,8 @@ public class DockerJobProperty extends OptionalJobProperty<AbstractProject<?, ?>
 
         final String containerId = dockerNode.getContainerId();
         final DockerAPI dockerAPI = dockerNode.getDockerAPI();
-        final DockerClient client = dockerAPI.takeClient();
-        try {
+        try(final DockerClient client = dockerAPI.getClient()) {
             return perform(build, listener, containerId, dockerAPI, client);
-        } finally {
-            dockerAPI.releaseClient(client);
         }
     }
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagement.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagement.java
@@ -107,12 +107,9 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
             public String getActiveHosts() {
                 try {
                     final DockerAPI dockerApi = cloud.getDockerApi();
-                    final DockerClient client = dockerApi.takeClient();
                     final List<?> containers;
-                    try {
+                    try(final DockerClient client = dockerApi.getClient()) {
                         containers = client.listContainersCmd().exec();
-                    } finally {
-                        dockerApi.releaseClient(client);
                     }
                     return "(" + containers.size() + ")";
                 } catch(Exception ex) {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagement.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagement.java
@@ -1,6 +1,6 @@
 package com.nirima.jenkins.plugins.docker;
 
-import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.DockerClient;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.nirima.jenkins.plugins.docker.utils.JenkinsUtils;
@@ -9,10 +9,9 @@ import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.model.ManagementLink;
 import hudson.model.Saveable;
+import io.jenkins.docker.client.DockerAPI;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.StaplerProxy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -28,8 +27,6 @@ import java.util.List;
 @Extension
 public class DockerManagement extends ManagementLink implements StaplerProxy, Describable<DockerManagement>, Saveable {
 
-    private static final Logger logger = LoggerFactory.getLogger(DockerManagement.class);
-
     @Override
     public String getIconFileName() {
         return com.nirima.jenkins.plugins.docker.utils.Consts.PLUGIN_IMAGES_URL + "/48x48/docker.png";
@@ -40,6 +37,7 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
         return "docker-plugin";
     }
 
+    @Override
     public String getDisplayName() {
         return Messages.DisplayName();
     }
@@ -54,10 +52,12 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
     }
 
 
+    @Override
     public DescriptorImpl getDescriptor() {
         return Jenkins.getInstance().getDescriptorByType(DescriptorImpl.class);
     }
 
+    @Override
     public void save() throws IOException {
 
     }
@@ -78,6 +78,7 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
             return new DockerManagementServer(serverName);
         }
 
+        @Override
         public Object getTarget() {
             Jenkins.getInstance().checkPermission(Jenkins.ADMINISTER);
             return this;
@@ -85,6 +86,7 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
 
         public Collection<String> getServerNames() {
             return Collections2.transform(JenkinsUtils.getServers(), new Function<DockerCloud, String>() {
+                @Override
                 public String apply(@Nullable DockerCloud input) {
                     return input.getDisplayName();
                 }
@@ -104,7 +106,14 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
 
             public String getActiveHosts() {
                 try {
-                    List<Container> containers = cloud.getClient().listContainersCmd().exec();
+                    final DockerAPI dockerApi = cloud.getDockerApi();
+                    final DockerClient client = dockerApi.takeClient();
+                    final List<?> containers;
+                    try {
+                        containers = client.listContainersCmd().exec();
+                    } finally {
+                        dockerApi.releaseClient(client);
+                    }
                     return "(" + containers.size() + ")";
                 } catch(Exception ex) {
                     return "Error";
@@ -115,6 +124,7 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
 
         public Collection<ServerDetail> getServers() {
             return Collections2.transform(JenkinsUtils.getServers(), new Function<DockerCloud, ServerDetail>() {
+                @Override
                 public ServerDetail apply(@Nullable DockerCloud input) {
                     return new ServerDetail(input);
                 }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagementServer.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagementServer.java
@@ -39,21 +39,19 @@ public class DockerManagementServer  implements Describable<DockerManagementServ
 
     public Collection getImages(){
         final DockerAPI dockerApi = theCloud.getDockerApi();
-        final DockerClient client = dockerApi.takeClient();
-        try {
+        try(final DockerClient client = dockerApi.getClient()) {
             return client.listImagesCmd().exec();
-        } finally {
-            dockerApi.releaseClient(client);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
         }
     }
 
     public Collection getProcesses() {
         final DockerAPI dockerApi = theCloud.getDockerApi();
-        final DockerClient client = dockerApi.takeClient();
-        try {
+        try(final DockerClient client = dockerApi.getClient()) {
             return client.listContainersCmd().exec();
-        } finally {
-            dockerApi.releaseClient(client);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
         }
     }
 
@@ -73,11 +71,8 @@ public class DockerManagementServer  implements Describable<DockerManagementServ
             IOException,
             InterruptedException {
         final DockerAPI dockerApi = theCloud.getDockerApi();
-        final DockerClient client = dockerApi.takeClient();
-        try {
+        try(final DockerClient client = dockerApi.getClient()) {
             client.stopContainerCmd(stopId).exec();
-        } finally {
-            dockerApi.releaseClient(client);
         }
         rsp.sendRedirect(".");
     }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagementServer.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagementServer.java
@@ -1,10 +1,12 @@
 package com.nirima.jenkins.plugins.docker;
 
+import com.github.dockerjava.api.DockerClient;
 import com.nirima.jenkins.plugins.docker.utils.Consts;
 import com.nirima.jenkins.plugins.docker.utils.JenkinsUtils;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import io.jenkins.docker.client.DockerAPI;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
@@ -36,19 +38,29 @@ public class DockerManagementServer  implements Describable<DockerManagementServ
     }
 
     public Collection getImages(){
-        return theCloud.getClient().listImagesCmd().exec();
+        final DockerAPI dockerApi = theCloud.getDockerApi();
+        final DockerClient client = dockerApi.takeClient();
+        try {
+            return client.listImagesCmd().exec();
+        } finally {
+            dockerApi.releaseClient(client);
+        }
     }
 
     public Collection getProcesses() {
-        return theCloud.getClient().listContainersCmd().exec();
+        final DockerAPI dockerApi = theCloud.getDockerApi();
+        final DockerClient client = dockerApi.takeClient();
+        try {
+            return client.listContainersCmd().exec();
+        } finally {
+            dockerApi.releaseClient(client);
+        }
     }
 
     public String asTime(Long time) {
         if( time == null )
             return "";
-
         long when = System.currentTimeMillis() - time;
-
         Date dt = new Date(when);
         return dt.toString();
     }
@@ -60,21 +72,21 @@ public class DockerManagementServer  implements Describable<DockerManagementServ
     public void doControlSubmit(@QueryParameter("stopId") String stopId, StaplerRequest req, StaplerResponse rsp) throws ServletException,
             IOException,
             InterruptedException {
-
-        theCloud.getClient()
-            .stopContainerCmd(stopId).exec();
-
+        final DockerAPI dockerApi = theCloud.getDockerApi();
+        final DockerClient client = dockerApi.takeClient();
+        try {
+            client.stopContainerCmd(stopId).exec();
+        } finally {
+            dockerApi.releaseClient(client);
+        }
         rsp.sendRedirect(".");
     }
 
     @Extension
     public static final class DescriptorImpl extends Descriptor<DockerManagementServer> {
-
         @Override
         public String getDisplayName() {
             return "server ";
         }
-
-
     }
 }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildAction.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildAction.java
@@ -1,6 +1,5 @@
 package com.nirima.jenkins.plugins.docker.action;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.dockerjava.api.DockerClient;
@@ -14,6 +13,7 @@ import io.jenkins.docker.client.DockerAPI;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.export.ExportedBean;
 
+import java.io.IOException;
 import java.io.Serializable;
 
 /**
@@ -42,16 +42,13 @@ public class DockerBuildAction implements Action, Serializable, Cloneable, Descr
         this.cloudId = node.getCloudId();
         try {
             final InspectContainerResponse containerDetails;
-            final DockerClient client = dockerAPI.takeClient();
-            try {
+            try(final DockerClient client = dockerAPI.getClient()) {
                 containerDetails = client.inspectContainerCmd(containerId).exec();
-            } finally {
-                dockerAPI.releaseClient(client);
             }
             this.inspect = new ObjectMapper()
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .writeValueAsString(containerDetails);
-        } catch (JsonProcessingException e) {
+        } catch (IOException e) {
             this.inspect = "Failed to capture container inspection data: "+e.getMessage();
         }
     }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionProvisionAndStart.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionProvisionAndStart.java
@@ -1,6 +1,5 @@
 package com.nirima.jenkins.plugins.docker.builder;
 
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.DockerException;
 import com.nirima.jenkins.plugins.docker.DockerCloud;
@@ -14,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.PrintStream;
 
 /**
@@ -44,11 +44,10 @@ public class DockerBuilderControlOptionProvisionAndStart extends DockerBuilderCo
         final DockerCloud cloud = getCloud(build, launcher);
         final DockerTemplate template = cloud.getTemplate(templateId);
         final DockerAPI dockerApi = cloud.getDockerApi();
-        final DockerClient client = dockerApi.takeClient();
-        try {
+        try(final DockerClient client = dockerApi.getClient()) {
             executeOnDocker(build, llog, cloud, template, client);
-        } finally {
-            dockerApi.releaseClient(client);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
         }
     }
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
@@ -16,6 +16,7 @@ import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import io.jenkins.docker.client.DockerAPI;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -104,7 +105,8 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
             throws DockerException, IOException {
         final PrintStream llog = listener.getLogger();
 
-        DockerClient client = getCloud(build,launcher).getClient();
+        final DockerCloud cloud = getCloud(build,launcher);
+        final DockerAPI dockerApi = cloud.getDockerApi();
 
         String xImage = expand(build, image);
         String xCommand = expand(build, dockerCommand);
@@ -113,8 +115,25 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
         LOG.info("Pulling image {}", xImage);
         llog.println("Pulling image " + xImage);
 
+        // need a client that will tolerate lengthy pauses for a docker pull
+        final DockerClient clientWithoutReadTimeout = dockerApi.takeClient(0);
+        try {
+            executePullOnDocker(build, llog, xImage, clientWithoutReadTimeout);
+        } finally {
+            dockerApi.releaseClient(clientWithoutReadTimeout);
+        }
+        final DockerClient clientForQuickOperations = dockerApi.takeClient();
+        try {
+            executeOnDocker(build, llog, xImage, xCommand, xHostname, clientForQuickOperations);
+        } finally {
+            dockerApi.releaseClient(clientForQuickOperations);
+        }
+    }
 
+    private void executePullOnDocker(Run<?, ?> build, PrintStream llog, String xImage, DockerClient client)
+            throws DockerException, IOException {
         PullImageResultCallback resultCallback = new PullImageResultCallback() {
+            @Override
             public void onNext(PullResponseItem item) {
                 if (item.getStatus() != null && item.getProgress() == null) {
                     llog.print(item.getId() + ":" + item.getStatus());
@@ -131,12 +150,15 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
         } catch (InterruptedException e) {
             throw new DockerClientException("Interrupted while pulling image", e);
         }
+    }
+
+    private void executeOnDocker(Run<?, ?> build, PrintStream llog, String xImage, String xCommand, String xHostname, DockerClient client)
+            throws DockerException {
         try {
             client.inspectImageCmd(xImage).exec();
         } catch (NotFoundException e) {
             throw new DockerClientException("Failed to pull image: " + image, e);
         }
-
 
         DockerTemplateBase template = new DockerSimpleTemplate(xImage, pullCredentialsId,
                 dnsString, network, xCommand,

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStart.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStart.java
@@ -8,6 +8,7 @@ import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import io.jenkins.docker.client.DockerAPI;
+import java.io.IOException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,11 +34,10 @@ public class DockerBuilderControlOptionStart extends DockerBuilderControlOptionS
 
         final DockerCloud cloud = getCloud(build,launcher);
         final DockerAPI dockerApi = cloud.getDockerApi();
-        final DockerClient client = dockerApi.takeClient();
-        try {
+        try(final DockerClient client = dockerApi.getClient()) {
             executeOnDocker(build, client);
-        } finally {
-            dockerApi.releaseClient(client);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
         }
     }
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStart.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStart.java
@@ -2,10 +2,12 @@ package com.nirima.jenkins.plugins.docker.builder;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.DockerException;
+import com.nirima.jenkins.plugins.docker.DockerCloud;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import io.jenkins.docker.client.DockerAPI;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +31,17 @@ public class DockerBuilderControlOptionStart extends DockerBuilderControlOptionS
         LOG.info("Starting container {}", containerId);
         listener.getLogger().println("Starting container " + containerId);
 
-        DockerClient client = getCloud(build,launcher).getClient();
+        final DockerCloud cloud = getCloud(build,launcher);
+        final DockerAPI dockerApi = cloud.getDockerApi();
+        final DockerClient client = dockerApi.takeClient();
+        try {
+            executeOnDocker(build, client);
+        } finally {
+            dockerApi.releaseClient(client);
+        }
+    }
+
+    private void executeOnDocker(Run<?, ?> build, DockerClient client) {
         client.startContainerCmd(containerId).exec();
 
         getLaunchAction(build).started(client, containerId);

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStop.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStop.java
@@ -3,10 +3,12 @@ package com.nirima.jenkins.plugins.docker.builder;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotModifiedException;
+import com.nirima.jenkins.plugins.docker.DockerCloud;
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import io.jenkins.docker.client.DockerAPI;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +38,18 @@ public class DockerBuilderControlOptionStop extends DockerBuilderControlOptionSt
         LOG.info("Stopping container " + containerId);
         llog.println("Stopping container " + containerId);
 
-        DockerClient client = getCloud(build, launcher).getClient();
+        final DockerCloud cloud = getCloud(build, launcher);
+        final DockerAPI dockerApi = cloud.getDockerApi();
+        final DockerClient client = dockerApi.takeClient();
+        try {
+            executeOnDocker(build, llog, client);
+        } finally {
+            dockerApi.releaseClient(client);
+        }
+    }
+
+    private void executeOnDocker(Run<?, ?> build, PrintStream llog, DockerClient client)
+            throws DockerException {
         try {
             client.stopContainerCmd(containerId).exec();
         } catch (NotModifiedException ex) {
@@ -59,6 +72,5 @@ public class DockerBuilderControlOptionStop extends DockerBuilderControlOptionSt
         public String getDisplayName() {
             return "Stop Container";
         }
-
     }
 }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStop.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionStop.java
@@ -13,6 +13,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.io.PrintStream;
 
 /**
@@ -40,11 +41,10 @@ public class DockerBuilderControlOptionStop extends DockerBuilderControlOptionSt
 
         final DockerCloud cloud = getCloud(build, launcher);
         final DockerAPI dockerApi = cloud.getDockerApi();
-        final DockerClient client = dockerApi.takeClient();
-        try {
+        try(final DockerClient client = dockerApi.getClient()) {
             executeOnDocker(build, llog, client);
-        } finally {
-            dockerApi.releaseClient(client);
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
         }
     }
 

--- a/src/main/java/io/jenkins/docker/client/DelegatingDockerClient.java
+++ b/src/main/java/io/jenkins/docker/client/DelegatingDockerClient.java
@@ -1,0 +1,359 @@
+package io.jenkins.docker.client;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.AttachContainerCmd;
+import com.github.dockerjava.api.command.AuthCmd;
+import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.command.CommitCmd;
+import com.github.dockerjava.api.command.ConnectToNetworkCmd;
+import com.github.dockerjava.api.command.ContainerDiffCmd;
+import com.github.dockerjava.api.command.CopyArchiveFromContainerCmd;
+import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
+import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateImageCmd;
+import com.github.dockerjava.api.command.CreateNetworkCmd;
+import com.github.dockerjava.api.command.CreateVolumeCmd;
+import com.github.dockerjava.api.command.DisconnectFromNetworkCmd;
+import com.github.dockerjava.api.command.EventsCmd;
+import com.github.dockerjava.api.command.ExecCreateCmd;
+import com.github.dockerjava.api.command.ExecStartCmd;
+import com.github.dockerjava.api.command.InfoCmd;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectExecCmd;
+import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.command.InspectNetworkCmd;
+import com.github.dockerjava.api.command.InspectVolumeCmd;
+import com.github.dockerjava.api.command.KillContainerCmd;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.command.ListNetworksCmd;
+import com.github.dockerjava.api.command.ListVolumesCmd;
+import com.github.dockerjava.api.command.LoadImageCmd;
+import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.command.PauseContainerCmd;
+import com.github.dockerjava.api.command.PingCmd;
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.command.PushImageCmd;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.api.command.RemoveImageCmd;
+import com.github.dockerjava.api.command.RemoveNetworkCmd;
+import com.github.dockerjava.api.command.RemoveVolumeCmd;
+import com.github.dockerjava.api.command.RenameContainerCmd;
+import com.github.dockerjava.api.command.RestartContainerCmd;
+import com.github.dockerjava.api.command.SaveImageCmd;
+import com.github.dockerjava.api.command.SearchImagesCmd;
+import com.github.dockerjava.api.command.StartContainerCmd;
+import com.github.dockerjava.api.command.StatsCmd;
+import com.github.dockerjava.api.command.StopContainerCmd;
+import com.github.dockerjava.api.command.TagImageCmd;
+import com.github.dockerjava.api.command.TopContainerCmd;
+import com.github.dockerjava.api.command.UnpauseContainerCmd;
+import com.github.dockerjava.api.command.UpdateContainerCmd;
+import com.github.dockerjava.api.command.VersionCmd;
+import com.github.dockerjava.api.command.WaitContainerCmd;
+import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.Identifier;
+
+/**
+ * Simple delegate class for the {@link DockerClient} interface. This makes it
+ * easy for other classes to override specific methods without having to
+ * implement all of them.
+ */
+public class DelegatingDockerClient implements DockerClient {
+
+    private final DockerClient delegate;
+
+    public DelegatingDockerClient(final DockerClient delegate) {
+        this.delegate = delegate;
+    }
+
+    protected DockerClient getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public AttachContainerCmd attachContainerCmd(String arg0) {
+        return getDelegate().attachContainerCmd(arg0);
+    }
+
+    @Override
+    public AuthCmd authCmd() {
+        return getDelegate().authCmd();
+    }
+
+    @Override
+    public AuthConfig authConfig() throws DockerException {
+        return getDelegate().authConfig();
+    }
+
+    @Override
+    public BuildImageCmd buildImageCmd() {
+        return getDelegate().buildImageCmd();
+    }
+
+    @Override
+    public BuildImageCmd buildImageCmd(File arg0) {
+        return getDelegate().buildImageCmd(arg0);
+    }
+
+    @Override
+    public BuildImageCmd buildImageCmd(InputStream arg0) {
+        return getDelegate().buildImageCmd(arg0);
+    }
+
+    @Override
+    public void close() throws IOException {
+        getDelegate().close();
+    }
+
+    @Override
+    public CommitCmd commitCmd(String arg0) {
+        return getDelegate().commitCmd(arg0);
+    }
+
+    @Override
+    public ConnectToNetworkCmd connectToNetworkCmd() {
+        return getDelegate().connectToNetworkCmd();
+    }
+
+    @Override
+    public ContainerDiffCmd containerDiffCmd(String arg0) {
+        return getDelegate().containerDiffCmd(arg0);
+    }
+
+    @Override
+    public CopyArchiveFromContainerCmd copyArchiveFromContainerCmd(String arg0, String arg1) {
+        return getDelegate().copyArchiveFromContainerCmd(arg0, arg1);
+    }
+
+    @Override
+    public CopyArchiveToContainerCmd copyArchiveToContainerCmd(String arg0) {
+        return getDelegate().copyArchiveToContainerCmd(arg0);
+    }
+
+    @Override
+    public CopyFileFromContainerCmd copyFileFromContainerCmd(String arg0, String arg1) {
+        return getDelegate().copyFileFromContainerCmd(arg0, arg1);
+    }
+
+    @Override
+    public CreateContainerCmd createContainerCmd(String arg0) {
+        return getDelegate().createContainerCmd(arg0);
+    }
+
+    @Override
+    public CreateImageCmd createImageCmd(String arg0, InputStream arg1) {
+        return getDelegate().createImageCmd(arg0, arg1);
+    }
+
+    @Override
+    public CreateNetworkCmd createNetworkCmd() {
+        return getDelegate().createNetworkCmd();
+    }
+
+    @Override
+    public CreateVolumeCmd createVolumeCmd() {
+        return getDelegate().createVolumeCmd();
+    }
+
+    @Override
+    public DisconnectFromNetworkCmd disconnectFromNetworkCmd() {
+        return getDelegate().disconnectFromNetworkCmd();
+    }
+
+    @Override
+    public EventsCmd eventsCmd() {
+        return getDelegate().eventsCmd();
+    }
+
+    @Override
+    public ExecCreateCmd execCreateCmd(String arg0) {
+        return getDelegate().execCreateCmd(arg0);
+    }
+
+    @Override
+    public ExecStartCmd execStartCmd(String arg0) {
+        return getDelegate().execStartCmd(arg0);
+    }
+
+    @Override
+    public InfoCmd infoCmd() {
+        return getDelegate().infoCmd();
+    }
+
+    @Override
+    public InspectContainerCmd inspectContainerCmd(String arg0) {
+        return getDelegate().inspectContainerCmd(arg0);
+    }
+
+    @Override
+    public InspectExecCmd inspectExecCmd(String arg0) {
+        return getDelegate().inspectExecCmd(arg0);
+    }
+
+    @Override
+    public InspectImageCmd inspectImageCmd(String arg0) {
+        return getDelegate().inspectImageCmd(arg0);
+    }
+
+    @Override
+    public InspectNetworkCmd inspectNetworkCmd() {
+        return getDelegate().inspectNetworkCmd();
+    }
+
+    @Override
+    public InspectVolumeCmd inspectVolumeCmd(String arg0) {
+        return getDelegate().inspectVolumeCmd(arg0);
+    }
+
+    @Override
+    public KillContainerCmd killContainerCmd(String arg0) {
+        return getDelegate().killContainerCmd(arg0);
+    }
+
+    @Override
+    public ListContainersCmd listContainersCmd() {
+        return getDelegate().listContainersCmd();
+    }
+
+    @Override
+    public ListImagesCmd listImagesCmd() {
+        return getDelegate().listImagesCmd();
+    }
+
+    @Override
+    public ListNetworksCmd listNetworksCmd() {
+        return getDelegate().listNetworksCmd();
+    }
+
+    @Override
+    public ListVolumesCmd listVolumesCmd() {
+        return getDelegate().listVolumesCmd();
+    }
+
+    @Override
+    public LoadImageCmd loadImageCmd(InputStream arg0) {
+        return getDelegate().loadImageCmd(arg0);
+    }
+
+    @Override
+    public LogContainerCmd logContainerCmd(String arg0) {
+        return getDelegate().logContainerCmd(arg0);
+    }
+
+    @Override
+    public PauseContainerCmd pauseContainerCmd(String arg0) {
+        return getDelegate().pauseContainerCmd(arg0);
+    }
+
+    @Override
+    public PingCmd pingCmd() {
+        return getDelegate().pingCmd();
+    }
+
+    @Override
+    public PullImageCmd pullImageCmd(String arg0) {
+        return getDelegate().pullImageCmd(arg0);
+    }
+
+    @Override
+    public PushImageCmd pushImageCmd(String arg0) {
+        return getDelegate().pushImageCmd(arg0);
+    }
+
+    @Override
+    public PushImageCmd pushImageCmd(Identifier arg0) {
+        return getDelegate().pushImageCmd(arg0);
+    }
+
+    @Override
+    public RemoveContainerCmd removeContainerCmd(String arg0) {
+        return getDelegate().removeContainerCmd(arg0);
+    }
+
+    @Override
+    public RemoveImageCmd removeImageCmd(String arg0) {
+        return getDelegate().removeImageCmd(arg0);
+    }
+
+    @Override
+    public RemoveNetworkCmd removeNetworkCmd(String arg0) {
+        return getDelegate().removeNetworkCmd(arg0);
+    }
+
+    @Override
+    public RemoveVolumeCmd removeVolumeCmd(String arg0) {
+        return getDelegate().removeVolumeCmd(arg0);
+    }
+
+    @Override
+    public RenameContainerCmd renameContainerCmd(String arg0) {
+        return getDelegate().renameContainerCmd(arg0);
+    }
+
+    @Override
+    public RestartContainerCmd restartContainerCmd(String arg0) {
+        return getDelegate().restartContainerCmd(arg0);
+    }
+
+    @Override
+    public SaveImageCmd saveImageCmd(String arg0) {
+        return getDelegate().saveImageCmd(arg0);
+    }
+
+    @Override
+    public SearchImagesCmd searchImagesCmd(String arg0) {
+        return getDelegate().searchImagesCmd(arg0);
+    }
+
+    @Override
+    public StartContainerCmd startContainerCmd(String arg0) {
+        return getDelegate().startContainerCmd(arg0);
+    }
+
+    @Override
+    public StatsCmd statsCmd(String arg0) {
+        return getDelegate().statsCmd(arg0);
+    }
+
+    @Override
+    public StopContainerCmd stopContainerCmd(String arg0) {
+        return getDelegate().stopContainerCmd(arg0);
+    }
+
+    @Override
+    public TagImageCmd tagImageCmd(String arg0, String arg1, String arg2) {
+        return getDelegate().tagImageCmd(arg0, arg1, arg2);
+    }
+
+    @Override
+    public TopContainerCmd topContainerCmd(String arg0) {
+        return getDelegate().topContainerCmd(arg0);
+    }
+
+    @Override
+    public UnpauseContainerCmd unpauseContainerCmd(String arg0) {
+        return getDelegate().unpauseContainerCmd(arg0);
+    }
+
+    @Override
+    public UpdateContainerCmd updateContainerCmd(String arg0) {
+        return getDelegate().updateContainerCmd(arg0);
+    }
+
+    @Override
+    public VersionCmd versionCmd() {
+        return getDelegate().versionCmd();
+    }
+
+    @Override
+    public WaitContainerCmd waitContainerCmd(String arg0) {
+        return getDelegate().waitContainerCmd(arg0);
+    }
+}

--- a/src/main/java/io/jenkins/docker/client/DockerAPI.java
+++ b/src/main/java/io/jenkins/docker/client/DockerAPI.java
@@ -26,14 +26,16 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.newsclub.net.unix.AFUNIXSocket;
 import org.newsclub.net.unix.AFUNIXSocketAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.Socket;
 import java.net.URI;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import static com.cloudbees.plugins.credentials.CredentialsMatchers.*;
 import static com.cloudbees.plugins.credentials.CredentialsProvider.lookupCredentials;
@@ -42,7 +44,8 @@ import static org.apache.commons.lang.StringUtils.trimToNull;
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Serializable, Closeable {
+public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Serializable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DockerAPI.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -58,8 +61,6 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
     private String apiVersion;
 
     private String hostname;
-
-    private transient DockerClient client = null;
 
     /**
      * Is this host actually a swarm?
@@ -120,37 +121,122 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
     }
 
     public boolean isSwarm() {
-        Version remoteVersion = getClient().versionCmd().exec();
-        // Cache the return.
-        if( _isSwarm == null ) {
-            _isSwarm = remoteVersion.getVersion().startsWith("swarm");
+        if (_isSwarm == null) {
+            final DockerClient client = takeClient();
+            try {
+                Version remoteVersion = client.versionCmd().exec();
+                // Cache the return.
+                _isSwarm = remoteVersion.getVersion().startsWith("swarm");
+            } finally {
+                releaseClient(client);
+            }
         }
         return _isSwarm;
     }
 
-    public DockerClient getClient() {
-        if (client == null) {
-            final Integer readTimeoutInMillisecondsOrNull = readTimeout > 0 ? Integer.valueOf(readTimeout * 1000) : null;
-            final Integer connectTimeoutInMillisecondsOrNull = connectTimeout > 0 ? Integer.valueOf(connectTimeout * 1000) : null;
-            client = DockerClientBuilder.getInstance(
-                new DefaultDockerClientConfig.Builder()
-                    .withDockerHost(dockerHost.getUri())
-                    .withCustomSslConfig(toSSlConfig(dockerHost.getCredentialsId()))
-                )
-                .withDockerCmdExecFactory(new NettyDockerCmdExecFactory()
-                .withReadTimeout(readTimeoutInMillisecondsOrNull)
-                .withConnectTimeout(connectTimeoutInMillisecondsOrNull))
-                .build();
-        }
-        return client;
+    /**
+     * Obtains a raw {@link DockerClient} pointing at our docker service
+     * endpoint. You <em>MUST</em> ensure that you call
+     * {@link #releaseClient(DockerClient)} after you are finished with the
+     * {@link DockerClient}, otherwise we will leak resources.
+     * <p>
+     * Note: {@link DockerClient}s are cached and shared between threads, so
+     * taking and releasing is relatively cheap.
+     * </p>
+     * 
+     * @return A raw {@link DockerClient} pointing at our docker service
+     *         endpoint.
+     */
+    public DockerClient takeClient() {
+        return takeClient(readTimeout);
     }
 
-    @Override
-    public void close() throws IOException {
-        if (client != null) {
-            client.close();
-            client = null;
+    /**
+     * As {@link #takeClient()}, but overriding the default
+     * <code>readTimeout</code>. This is typically used when running
+     * long-duration activities that can "go quiet" for a long period of time,
+     * e.g. pulling a docker image from a registry or building a docker image.
+     * Most users should just call {@link #takeClient()} instead.
+     * 
+     * @param activityTimeoutInSeconds
+     *            The activity timeout, in seconds. A value less than one means
+     *            no timeout.
+     * @return A raw {@link DockerClient} pointing at our docker service
+     *         endpoint.
+     */
+    public DockerClient takeClient(int activityTimeoutInSeconds) {
+        return getOrMakeClient(dockerHost.getUri(), dockerHost.getCredentialsId(), activityTimeoutInSeconds,
+                connectTimeout);
+    }
+
+    /**
+     * Returns the {@link DockerClient} to the resource pool. This <em>MUST</em>
+     * be called once for every call to {@link #takeClient()} or
+     * {@link #takeClient(int)}, otherwise we will leak resources.
+     * 
+     * @param client
+     *            The value previously returned by {@link #takeClient()} or
+     *            {@link #takeClient(int)}.
+     */
+    public void releaseClient(DockerClient client) {
+        ungetClient(client);
+    }
+
+    /** Caches connections until they've been unused for 5 minutes */
+    private static final UsageTrackingCache<DockerClientParameters, DockerClient> CLIENT_CACHE;
+    static {
+        final UsageTrackingCache.ExpiryHandler<DockerClientParameters, DockerClient> expiryHandler;
+        expiryHandler = new UsageTrackingCache.ExpiryHandler<DockerClientParameters, DockerClient>() {
+            @Override
+            public void entryDroppedFromCache(DockerClientParameters cacheKey, DockerClient client) {
+                try {
+                    client.close();
+                    LOGGER.info("Dropped connection {} to {}", client, cacheKey);
+                } catch (IOException ex) {
+                    LOGGER.error("Dropped connection " + client + " to " + cacheKey + " but failed to close it:", ex);
+                }
+            }
+        };
+        CLIENT_CACHE = new UsageTrackingCache(5, TimeUnit.MINUTES, expiryHandler);
+    }
+
+    /** Obtains a {@link DockerClient} from the cache, or makes one and puts it in the cache, implicitly telling the cache we need it. */
+    private static DockerClient getOrMakeClient(final String dockerUri, final String credentialsId,
+            final int readTimeout, final int connectTimeout) {
+        final Integer readTimeoutInMillisecondsOrNull = readTimeout > 0 ? Integer.valueOf(readTimeout * 1000) : null;
+        final Integer connectTimeoutInMillisecondsOrNull = connectTimeout > 0 ? Integer.valueOf(connectTimeout * 1000) : null;
+        final DockerClientParameters cacheKey = new DockerClientParameters(dockerUri, credentialsId, readTimeoutInMillisecondsOrNull, connectTimeoutInMillisecondsOrNull);
+        synchronized(CLIENT_CACHE) {
+            DockerClient client = CLIENT_CACHE.getAndIncrementUsage(cacheKey);
+            if ( client==null ) {
+                client = makeClient(dockerUri, credentialsId, readTimeoutInMillisecondsOrNull,
+                        connectTimeoutInMillisecondsOrNull);
+                LOGGER.info("Cached connection {} to {}", client, cacheKey);
+                CLIENT_CACHE.cacheAndIncrementUsage(cacheKey, client);
+            }
+            return client;
         }
+    }
+
+    /** Tell the cache we no longer need the {@link DockerClient} and it can be thrown away if it remains unused. */
+    private static void ungetClient(DockerClient client) {
+        synchronized (CLIENT_CACHE) {
+            CLIENT_CACHE.decrementUsage(client);
+        }
+    }
+
+    /** Creates a new {@link DockerClient} */
+    private static DockerClient makeClient(final String dockerUri, final String credentialsId,
+            final Integer readTimeoutInMillisecondsOrNull, final Integer connectTimeoutInMillisecondsOrNull) {
+        return DockerClientBuilder.getInstance(
+            new DefaultDockerClientConfig.Builder()
+                .withDockerHost(dockerUri)
+                .withCustomSslConfig(toSSlConfig(credentialsId))
+            )
+            .withDockerCmdExecFactory(new NettyDockerCmdExecFactory()
+            .withReadTimeout(readTimeoutInMillisecondsOrNull)
+            .withConnectTimeout(connectTimeoutInMillisecondsOrNull))
+            .build();
     }
 
     private static SSLConfig toSSlConfig(String credentialsId) {
@@ -203,7 +289,7 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
         if (dockerHost != null ? !dockerHost.equals(dockerAPI.dockerHost) : dockerAPI.dockerHost != null) return false;
         if (apiVersion != null ? !apiVersion.equals(dockerAPI.apiVersion) : dockerAPI.apiVersion != null) return false;
         if (hostname != null ? !hostname.equals(dockerAPI.hostname) : dockerAPI.hostname != null) return false;
-        return client != null ? client.equals(dockerAPI.client) : dockerAPI.client == null;
+        return true;
     }
 
     @Override
@@ -213,7 +299,6 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
         result = 31 * result + readTimeout;
         result = 31 * result + (apiVersion != null ? apiVersion.hashCode() : 0);
         result = 31 * result + (hostname != null ? hostname.hashCode() : 0);
-        result = 31 * result + (client != null ? client.hashCode() : 0);
         return result;
     }
 
@@ -248,8 +333,8 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
             try {
                 final DockerServerEndpoint dsep = new DockerServerEndpoint(uri, credentialsId);
                 final DockerAPI dapi = new DockerAPI(dsep, connectTimeout, readTimeout, apiVersion, null);
+                final DockerClient dc = dapi.takeClient();
                 try {
-                    final DockerClient dc = dapi.getClient();
                     final VersionCmd vc = dc.versionCmd();
                     final Version v = vc.exec();
                     final String actualVersion = v.getVersion();
@@ -257,10 +342,7 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> implements Ser
                     return FormValidation.ok("Version = " + actualVersion + ", API Version = " + actualApiVersion);
                 } finally {
                     // nobody else can see this DockerAPI instance, we must close it
-                    try {
-                        dapi.close();
-                    } catch (IOException ignored) {
-                    }
+                    dapi.releaseClient(dc);
                 }
             } catch (Exception e) {
                 return FormValidation.error(e, e.getMessage());

--- a/src/main/java/io/jenkins/docker/client/DockerClientParameters.java
+++ b/src/main/java/io/jenkins/docker/client/DockerClientParameters.java
@@ -1,0 +1,60 @@
+package io.jenkins.docker.client;
+
+import com.google.common.base.Objects;
+
+class DockerClientParameters {
+    final String dockerUri;
+    final String credentialsId;
+    final Integer readTimeoutInMsOrNull;
+    final Integer connectTimeoutInMsOrNull;
+
+    DockerClientParameters(String dockerUri, String credentialsId, Integer readTimeoutInMsOrNull,
+            Integer connectTimeoutInMsOrNull) {
+        this.dockerUri = dockerUri;
+        this.credentialsId = credentialsId;
+        this.readTimeoutInMsOrNull = readTimeoutInMsOrNull;
+        this.connectTimeoutInMsOrNull = connectTimeoutInMsOrNull;
+    }
+
+    public String getDockerUri() {
+        return dockerUri;
+    }
+
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    public Integer getReadTimeoutInMsOrNull() {
+        return readTimeoutInMsOrNull;
+    }
+
+    public Integer getConnectTimeoutInMsOrNull() {
+        return connectTimeoutInMsOrNull;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(dockerUri, credentialsId, connectTimeoutInMsOrNull, readTimeoutInMsOrNull);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final DockerClientParameters other = (DockerClientParameters) obj;
+        return Objects.equal(dockerUri, other.dockerUri) && Objects.equal(credentialsId, other.credentialsId)
+                && Objects.equal(readTimeoutInMsOrNull, other.readTimeoutInMsOrNull)
+                && Objects.equal(connectTimeoutInMsOrNull, other.connectTimeoutInMsOrNull);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this).add("dockerUri", dockerUri).add("credentialsId", credentialsId)
+                .add("readTimeoutInMsOrNull", readTimeoutInMsOrNull)
+                .add("connectTimeoutInMsOrNull", connectTimeoutInMsOrNull).toString();
+    }
+}

--- a/src/main/java/io/jenkins/docker/client/UsageTrackingCache.java
+++ b/src/main/java/io/jenkins/docker/client/UsageTrackingCache.java
@@ -1,0 +1,206 @@
+package io.jenkins.docker.client;
+
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+
+/**
+ * A cache that keep things until they haven't been used for a given duration.
+ * Things will be kept in the cache until they have been inactive for too long.
+ * Things will not be dropped from the cache while they are active, no matter
+ * how long that is.
+ *
+ * @param <K>
+ *            The type of key by which cache entries can be indexed. This must
+ *            implement {@link #hashCode()} and {@link #equals(Object)}.
+ * @param <V>
+ *            The type of entry being cached.
+ */
+public class UsageTrackingCache<K, V> {
+
+    /**
+     * Callback API to handle things that are no longer in use when they
+     * eventually fall out of the cache.
+     *
+     * @param <K>
+     *            The type of key used by the cache.
+     * @param <V>
+     *            The type of value stored by the cache.
+     */
+    public interface ExpiryHandler<K, V> {
+        void entryDroppedFromCache(K key, V value);
+    }
+
+    /** Holds all active records, indexed by key */
+    private final Map<K, CacheEntry<K, V>> activeCacheByKey;
+    /** Holds all active records, indexed by value */
+    private final Map<V, CacheEntry<K, V>> activeCacheByValue;
+    /** Holds all inactive records for a period, indexed by key */
+    private final Cache<K, CacheEntry<K, V>> durationCache;
+
+    /**
+     * Full constructor.
+     * 
+     * @param duration
+     *            How long inactive things should be kept in the cache.
+     * @param unit
+     *            The <code>duration</code>'s unit of measurement.
+     * @param expiryHandler
+     *            Callback that is given all expired values from the cache just
+     *            before they are thrown away.
+     */
+    UsageTrackingCache(final long duration, @Nonnull final TimeUnit unit,
+            @Nonnull final ExpiryHandler<K, V> expiryHandler) {
+        activeCacheByKey = new HashMap<>();
+        activeCacheByValue = new IdentityHashMap();
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+        cacheBuilder = cacheBuilder.expireAfterAccess(duration, unit);
+        final RemovalListener removalHandler = new RemovalListener<K, CacheEntry<K, V>>() {
+            @Override
+            public void onRemoval(RemovalNotification<K, CacheEntry<K, V>> notification) {
+                final K key = notification.getKey();
+                if (!activeCacheByKey.containsKey(key)) {
+                    final CacheEntry<K, V> record = notification.getValue();
+                    final V value = record.getValue();
+                    expiryHandler.entryDroppedFromCache(key, value);
+                }
+            }
+        };
+        cacheBuilder = cacheBuilder.removalListener(removalHandler);
+        durationCache = cacheBuilder.build();
+    }
+
+    /**
+     * Looks up an existing entry in the cache. If it finds an entry then it
+     * returns the entry and increments the usage count for that entry, and the
+     * caller MUST ensure that {@link #decrementUsage(Object)} is later called
+     * on the result. If it doesn't find an entry in the cache then it returns
+     * null (and the caller will most likely decide to call
+     * {@link #cacheAndIncrementUsage(Object, Object)} ).
+     * 
+     * @param key
+     *            The key used to look up the entry in the cache.
+     * @return An existing cache entry, or null.
+     */
+    @CheckForNull
+    public V getAndIncrementUsage(@Nonnull K key) {
+        final CacheEntry<K, V> activeRecord = activeCacheByKey.get(key);
+        if (activeRecord != null) {
+            // we have an entry that's currently in use
+            activeRecord.incrementUsageCount(); // bump activity count
+            final V value = activeRecord.getValue();
+            durationCache.cleanUp(); // force cleanup activity
+            return value;
+        }
+        final CacheEntry<K, V> durationRecord = durationCache.getIfPresent(key);
+        if (durationRecord != null) {
+            final V value = durationRecord.getValue();
+            // while we don't have an entry that's currently in use, we do have
+            // one that we stopped using recently.
+            durationRecord.incrementUsageCount(); // bump its activity count
+            // put it in the "active" cache
+            activeCacheByKey.put(key, durationRecord);
+            activeCacheByValue.put(value, durationRecord);
+            // remove it from the duration cache
+            durationCache.invalidate(key);
+            durationCache.cleanUp();
+            return value;
+        }
+        return null;
+    }
+
+    /**
+     * Puts an entry in the cache with a usage count of 1. The caller MUST
+     * ensure that {@link #decrementUsage(Object)} is later called on the entry
+     * that has been cached.
+     * 
+     * @param key
+     *            The key used to look up the entry in the cache.
+     * @param entry
+     *            The entry to be cached.
+     */
+    public void cacheAndIncrementUsage(@Nonnull K key, @Nonnull V entry) {
+        durationCache.cleanUp(); // force cleanup activity
+        final CacheEntry<K, V> record = new CacheEntry<>(key, entry, 1);
+        final CacheEntry<K, V> oldKeyRecord = activeCacheByKey.put(key, record);
+        final CacheEntry<K, V> oldValueRecord = activeCacheByValue.put(entry, record);
+        if (oldKeyRecord != null || oldValueRecord != null) {
+            final CacheEntry<K, V> oldRecord = oldKeyRecord != null ? oldKeyRecord : oldValueRecord;
+            activeCacheByKey.put(key, oldRecord);
+            activeCacheByValue.put(entry, oldRecord);
+            throw new IllegalStateException("Cannot cache " + record + " because there's already a record " + oldRecord
+                    + " present in the activeCache.");
+        }
+    }
+
+    /**
+     * Decrements the usage count on a cache entry, potentially removing it from
+     * active usage. This method MUST be called once and only once for every
+     * time that {@link #getAndIncrementUsage(Object)} returned a non-null value
+     * and for every time that {@link #cacheAndIncrementUsage(Object, Object)}
+     * was called.
+     * 
+     * @param entry
+     *            The entry that is no longer in use.
+     */
+    public void decrementUsage(@Nonnull V entry) {
+        durationCache.cleanUp(); // force cleanup activity
+        final CacheEntry<K, V> record = activeCacheByValue.get(entry);
+        if (record == null) {
+            throw new IllegalStateException("No active record for entry " + entry);
+        }
+        final boolean stillActive = record.decrementUsageCount();
+        if (stillActive) {
+            return;
+        }
+        // if we got this far then the entry has just ceased to be active.
+        final K key = record.getKey();
+        activeCacheByKey.remove(key);
+        activeCacheByValue.remove(entry);
+        durationCache.put(key, record);
+        durationCache.cleanUp();
+    }
+
+    private static class CacheEntry<K, V> {
+        private final K mKey;
+        private final V mValue;
+        private int mUsageCount;
+
+        CacheEntry(K key, V value, int usageCount) {
+            this.mKey = key;
+            this.mValue = value;
+            this.mUsageCount = usageCount;
+        }
+
+        void incrementUsageCount() {
+            mUsageCount++;
+        }
+
+        boolean decrementUsageCount() {
+            mUsageCount--;
+            return mUsageCount > 0;
+        }
+
+        K getKey() {
+            return mKey;
+        }
+
+        V getValue() {
+            return mValue;
+        }
+
+        @Override
+        public String toString() {
+            return "CacheEntry[key=" + mKey + ", value=" + mValue + ", usageCount=" + mUsageCount + "]";
+        }
+    }
+}

--- a/src/main/java/io/jenkins/docker/client/UsageTrackingCache.java
+++ b/src/main/java/io/jenkins/docker/client/UsageTrackingCache.java
@@ -115,6 +115,7 @@ public class UsageTrackingCache<K, V> {
             durationCache.cleanUp();
             return value;
         }
+        durationCache.cleanUp(); // force cleanup activity
         return null;
     }
 
@@ -129,7 +130,6 @@ public class UsageTrackingCache<K, V> {
      *            The entry to be cached.
      */
     public void cacheAndIncrementUsage(@Nonnull K key, @Nonnull V entry) {
-        durationCache.cleanUp(); // force cleanup activity
         final CacheEntry<K, V> record = new CacheEntry<>(key, entry, 1);
         final CacheEntry<K, V> oldKeyRecord = activeCacheByKey.put(key, record);
         final CacheEntry<K, V> oldValueRecord = activeCacheByValue.put(entry, record);

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
@@ -58,11 +58,8 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
 
     @Override
     public void afterContainerStarted(DockerAPI api, String workdir, String containerId) throws IOException, InterruptedException {
-        final DockerClient client = api.takeClient();
-        try {
+        try(final DockerClient client = api.getClient()) {
             injectRemotingJar(containerId, workdir, client);
-        } finally {
-            api.releaseClient(client);
         }
     }
 
@@ -107,8 +104,7 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
             logger.println("Connecting to docker container "+containerId);
 
             final String execId;
-            final DockerClient client = api.takeClient();
-            try {
+            try(final DockerClient client = api.getClient()) {
                 final ExecCreateCmd cmd = client.execCreateCmd(containerId)
                         .withAttachStdin(true)
                         .withAttachStdout(true)
@@ -120,8 +116,6 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
                 }
                 final ExecCreateCmdResponse exec = cmd.exec();
                 execId = exec.getId();
-            } finally {
-                api.releaseClient(client);
             }
 
             String js = "{ \"Detach\": false, \"Tty\": false }";

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
@@ -89,8 +89,13 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
     }
 
     public final ComputerLauncher createLauncher(final DockerAPI api, @Nonnull final String containerId, String workdir, TaskListener listener) throws IOException, InterruptedException {
-
-        InspectContainerResponse inspect = api.getClient().inspectContainerCmd(containerId).exec();
+        final InspectContainerResponse inspect;
+        final DockerClient client = api.takeClient();
+        try {
+            inspect = client.inspectContainerCmd(containerId).exec();
+        } finally {
+            api.releaseClient(client);
+        }
         final ComputerLauncher launcher = createLauncher(api, workdir, inspect, listener);
 
         final Boolean running = inspect.getState().getRunning();
@@ -100,11 +105,11 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
         }
 
         return new DelegatingComputerLauncher(launcher) {
-
             @Override
             public void launch(SlaveComputer computer, TaskListener listener) throws IOException, InterruptedException {
+                final DockerClient client = api.takeClient();
                 try {
-                    InspectContainerResponse response = api.getClient().inspectContainerCmd(containerId).exec();
+                    client.inspectContainerCmd(containerId).exec();
                 } catch (NotFoundException e) {
                     // Container has been removed
                     Queue.withLock( () -> {
@@ -112,6 +117,8 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
                         node.terminate(listener);
                     });
                     return;
+                } finally {
+                    api.releaseClient(client);
                 }
                 super.launch(computer, listener);
             }
@@ -123,6 +130,4 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
      * DockerAgentConnector so adequate setup did take place.
      */
     protected abstract ComputerLauncher createLauncher(DockerAPI api, String workdir, InspectContainerResponse inspect, TaskListener listener) throws IOException, InterruptedException;
-
-
 }

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -3,6 +3,7 @@ package io.jenkins.docker.connector;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ExposedPort;
@@ -197,12 +198,14 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
                 tar.closeArchiveEntry();
                 tar.close();
 
+                final DockerClient client = api.takeClient();
                 try (InputStream is = new ByteArrayInputStream(bos.toByteArray())) {
-
-                    api.getClient().copyArchiveToContainerCmd(containerId)
+                    client.copyArchiveToContainerCmd(containerId)
                             .withTarInputStream(is)
                             .withRemotePath("/root")
                             .exec();
+                } finally {
+                    api.releaseClient(client);
                 }
             }
         }

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -198,14 +198,12 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
                 tar.closeArchiveEntry();
                 tar.close();
 
-                final DockerClient client = api.takeClient();
-                try (InputStream is = new ByteArrayInputStream(bos.toByteArray())) {
+                try (InputStream is = new ByteArrayInputStream(bos.toByteArray());
+                     DockerClient client = api.getClient()) {
                     client.copyArchiveToContainerCmd(containerId)
                             .withTarInputStream(is)
                             .withRemotePath("/root")
                             .exec();
-                } finally {
-                    api.releaseClient(client);
                 }
             }
         }

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/config.jelly
@@ -31,6 +31,10 @@
         <f:enum>${it.description}</f:enum>
     </f:entry>
 
+    <f:entry title="${%Pull timeout}" field="pullTimeout">
+        <f:number default="300"/>
+    </f:entry>
+
     <f:entry title="Node Properties">
         <f:repeatableHeteroProperty field="nodeProperties" oneEach="true" hasHeader="true"
                                     addCaption="Add Node Property" deleteCaption="Delete Node Property"/>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-pullTimeout.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-pullTimeout.html
@@ -1,0 +1,13 @@
+<div>
+    Timeout, in seconds, to apply when expecting data from the Docker API when performing the docker pull operation.
+    0 means no time limit, but this is not recommended (if your docker API locks up, some aspects of Jenkins can also lock up).
+    <br/>
+    i.e. you probably want this set to as long as it takes to pull the entire image onto a fresh docker server.
+    e.g. a few minutes.
+    <p>
+    Note:
+    This overrides the read timeout specified for the cloud,
+    but only for the docker pull operation
+    (as this operation is expected to take longer than most docker operations).
+    </p>
+</div>

--- a/src/main/resources/io/jenkins/docker/client/DockerAPI/help-readTimeout.html
+++ b/src/main/resources/io/jenkins/docker/client/DockerAPI/help-readTimeout.html
@@ -2,10 +2,9 @@
     Timeout, in seconds, to apply when expecting data from the Docker API.
     0 means no time limit, but this is not recommended (if your docker API locks up, some aspects of Jenkins can also lock up).
     <p>
-    NOTE: This timeout applies to <em>all</em> docker API actions.
-    This includes docker pull requests (which can take some time to complete)
-    as well as
-    docker image builds (if it "goes quiet" for too long, your build will fail).
+    NOTE: This timeout does not apply to all docker API actions.
+    Docker pull requests (which can take some time to complete) have their own value specified in the template.
+    Docker image builds have no timeout at all (you with want a timeout, use an inactivity timeout on your build as a whole).
     <br/>
-    i.e. you probably want this set to a few minutes, rather than a few seconds.
+    i.e. you probably want this set to a few seconds, e.g. as long as it takes for your docker service to respond to a &quot;container start&quot; request.
 </div>

--- a/src/test/java/io/jenkins/docker/client/DockerClientParametersTest.java
+++ b/src/test/java/io/jenkins/docker/client/DockerClientParametersTest.java
@@ -1,0 +1,107 @@
+package io.jenkins.docker.client;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+import org.junit.Test;
+
+public class DockerClientParametersTest {
+    @Test
+    public void testHashCodeAndEquals() {
+        final String dockerUri1 = "dockerUri1";
+        final String dockerUri1a = new String(dockerUri1);
+        final String dockerUri2 = "dockerUri2";
+        final String credentialsId1 = "credentialsId1";
+        final String credentialsId1a = new String(credentialsId1);
+        final String credentialsId2 = "credentialsId2";
+        final Integer readTimeoutInMsOrNull1 = Integer.valueOf(1234);
+        final Integer readTimeoutInMsOrNull1a = new Integer(1234);
+        final Integer readTimeoutInMsOrNull2 = Integer.valueOf(5678);
+        final Integer readTimeoutInMsOrNull3 = null;
+        final Integer connectTimeoutInMsOrNull1 = Integer.valueOf(5678);
+        final Integer connectTimeoutInMsOrNull1a = new Integer(5678);
+        final Integer connectTimeoutInMsOrNull2 = Integer.valueOf(1234);
+        final Integer connectTimeoutInMsOrNull3 = null;
+        final DockerClientParameters i1 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull1, connectTimeoutInMsOrNull1);
+        final DockerClientParameters i2 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull3, connectTimeoutInMsOrNull3);
+        final DockerClientParameters e1 = new DockerClientParameters(dockerUri1a, credentialsId1a, readTimeoutInMsOrNull1a, connectTimeoutInMsOrNull1a);
+        final DockerClientParameters e2 = new DockerClientParameters(dockerUri1a, credentialsId1a, readTimeoutInMsOrNull3, connectTimeoutInMsOrNull3);
+
+        final DockerClientParameters d01 = new DockerClientParameters(dockerUri2, credentialsId1, readTimeoutInMsOrNull1, connectTimeoutInMsOrNull1);
+        final DockerClientParameters d02 = new DockerClientParameters(dockerUri1, credentialsId2, readTimeoutInMsOrNull1, connectTimeoutInMsOrNull1);
+        final DockerClientParameters d03 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull2, connectTimeoutInMsOrNull1);
+        final DockerClientParameters d04 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull3, connectTimeoutInMsOrNull1);
+        final DockerClientParameters d05 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull1, connectTimeoutInMsOrNull2);
+        final DockerClientParameters d06 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull1, connectTimeoutInMsOrNull3);
+
+        assertEquals(i1, i1);
+        assertEquals(i1, e1);
+        assertEquals(e1, i1);
+        assertEquals(i1.hashCode(), e1.hashCode());
+        assertEquals(i2, e2);
+        assertEquals(e2, i2);
+        assertEquals(i2.hashCode(), e2.hashCode());
+        assertNotEquals(i1, null);
+        assertNotEquals(i1, "Foo");
+        assertNotEquals(i1, d01);
+        assertNotEquals(d01, i1);
+        assertNotEquals(i1.hashCode(), d01.hashCode());
+        assertNotEquals(i1, d02);
+        assertNotEquals(d02, i1);
+        assertNotEquals(i1.hashCode(), d02.hashCode());
+        assertNotEquals(i1, d03);
+        assertNotEquals(d03, i1);
+        assertNotEquals(i1.hashCode(), d03.hashCode());
+        assertNotEquals(i1, d04);
+        assertNotEquals(d04, i1);
+        assertNotEquals(i1.hashCode(), d04.hashCode());
+        assertNotEquals(i1, d05);
+        assertNotEquals(d05, i1);
+        assertNotEquals(i1.hashCode(), d05.hashCode());
+        assertNotEquals(i1, d06);
+        assertNotEquals(d06, i1);
+        assertNotEquals(i1.hashCode(), d06.hashCode());
+    }
+
+    @Test
+    public void testGetters() {
+        final String dockerUri1 = "dockerUri";
+        final String credentialsId1 = "credentialsId";
+        final Integer readTimeoutInMsOrNull1 = Integer.valueOf(123);
+        final Integer readTimeoutInMsOrNull2 = null;
+        final Integer connectTimeoutInMsOrNull1 = Integer.valueOf(456);
+        final Integer connectTimeoutInMsOrNull2 = null;
+        final DockerClientParameters i1 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull1, connectTimeoutInMsOrNull1);
+        final DockerClientParameters i2 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull2, connectTimeoutInMsOrNull2);
+        
+        assertEquals(dockerUri1, i1.getDockerUri());
+        assertEquals(credentialsId1, i1.getCredentialsId());
+        assertEquals(readTimeoutInMsOrNull1, i1.getReadTimeoutInMsOrNull());
+        assertEquals(readTimeoutInMsOrNull2, i2.getReadTimeoutInMsOrNull());
+        assertEquals(connectTimeoutInMsOrNull1, i1.getConnectTimeoutInMsOrNull());
+        assertEquals(connectTimeoutInMsOrNull2, i2.getConnectTimeoutInMsOrNull());
+    }
+
+    @Test
+    public void testToString() {
+        final String dockerUri1 = "MyDockerURI";
+        final String credentialsId1 = "MyCredentials";
+        final Integer readTimeoutInMsOrNull1 = Integer.valueOf(1928);
+        final Integer readTimeoutInMsOrNull2 = null;
+        final Integer connectTimeoutInMsOrNull1 = Integer.valueOf(3746);
+        final Integer connectTimeoutInMsOrNull2 = null;
+        final DockerClientParameters i1 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull1, connectTimeoutInMsOrNull1);
+        final DockerClientParameters i2 = new DockerClientParameters(dockerUri1, credentialsId1, readTimeoutInMsOrNull2, connectTimeoutInMsOrNull2);
+
+        final String s1 = i1.toString();
+        final String s2 = i2.toString();
+        assertThat(s1, containsString(dockerUri1));
+        assertThat(s1, containsString(credentialsId1));
+        assertThat(s1, containsString(readTimeoutInMsOrNull1.toString()));
+        assertThat(s1, containsString(connectTimeoutInMsOrNull1.toString()));
+        assertThat(s2, containsString(dockerUri1));
+        assertThat(s2, containsString(credentialsId1));
+        assertThat(s2, containsString("null"));
+        assertThat(s2, containsString("null"));
+    }
+}

--- a/src/test/java/io/jenkins/docker/client/UsageTrackingCacheTest.java
+++ b/src/test/java/io/jenkins/docker/client/UsageTrackingCacheTest.java
@@ -112,8 +112,6 @@ public class UsageTrackingCacheTest {
         assertNothingExpired(expiryList);
     }
 
-    // TODO: ensure that expiry handler isn't called when we don't expect it to
-    // be called
     @Test
     public void getAndIncrementUsageGivenOldInactiveDataInCacheThenDiscardsOldDataAndReturnsNull() throws Exception {
         final String key = "key";
@@ -172,15 +170,15 @@ public class UsageTrackingCacheTest {
 
     private static <L> void assertNothingExpired(List<L> list) {
         assertNotNull(list);
-        assertEquals(0, list.size());
+        assertEquals("Number of keys and values in the expiryList", 0, list.size());
     }
 
     private static <K extends L, V extends L, L> void assertExpired(List<L> expiryList, K key, V value) {
         assertNotNull(expiryList);
+        assertEquals("Number of keys and values in the expiryList", 2, expiryList.size());
         final L actualExpiredKey = expiryList.get(0);
-        assertEquals(key, actualExpiredKey);
+        assertEquals("Expired key", key, actualExpiredKey);
         final L actualExpiredValue = expiryList.get(1);
-        assertEquals(value, actualExpiredValue);
-        assertEquals(2, expiryList.size());
+        assertEquals("Expired value", value, actualExpiredValue);
     }
 }

--- a/src/test/java/io/jenkins/docker/client/UsageTrackingCacheTest.java
+++ b/src/test/java/io/jenkins/docker/client/UsageTrackingCacheTest.java
@@ -1,0 +1,186 @@
+package io.jenkins.docker.client;
+
+import static org.junit.Assert.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+public class UsageTrackingCacheTest {
+
+    @Test
+    public void getAndIncrementUsageGivenEmptyCacheThenReturnsNull() {
+        final String key = "key";
+        final List<Object> expiryList = Lists.newArrayList();
+        final UsageTrackingCache.ExpiryHandler<String, Object> expiryHandler = expiryTracker(expiryList);
+        final UsageTrackingCache<String, Object> instance = new UsageTrackingCache<>(1, TimeUnit.DAYS, expiryHandler);
+
+        final Object actual = instance.getAndIncrementUsage(key);
+
+        assertNull(actual);
+        assertNothingExpired(expiryList);
+    }
+
+    @Test
+    public void cacheAndIncrementUsageGivenClashingEntryThenThrows() {
+        final String key = "key";
+        final Object value = value("value");
+        final List<Object> expiryList = Lists.newArrayList();
+        final UsageTrackingCache.ExpiryHandler<String, Object> expiryHandler = expiryTracker(expiryList);
+        final UsageTrackingCache<String, Object> instance = new UsageTrackingCache<>(1, TimeUnit.DAYS, expiryHandler);
+        instance.cacheAndIncrementUsage(key, value);
+
+        try {
+            instance.cacheAndIncrementUsage(key, value);
+            fail("Expected an exception by now");
+        } catch (IllegalStateException expected) {
+        }
+        assertNothingExpired(expiryList);
+    }
+
+    @Test
+    public void getAndIncrementUsageGivenActiveDataThenReturnsSameDataEveryTime() {
+        final String key = "key";
+        final Object value = value("value");
+        final List<Object> expiryList = Lists.newArrayList();
+        final UsageTrackingCache.ExpiryHandler<String, Object> expiryHandler = expiryTracker(expiryList);
+        final UsageTrackingCache<String, Object> instance = new UsageTrackingCache<>(1, TimeUnit.DAYS, expiryHandler);
+        instance.cacheAndIncrementUsage(key, value);
+
+        final Object actual1 = instance.getAndIncrementUsage(key);
+        final Object actual2 = instance.getAndIncrementUsage(key);
+        final Object actual3 = instance.getAndIncrementUsage(key);
+
+        assertEquals(value, actual1);
+        assertEquals(value, actual2);
+        assertEquals(value, actual3);
+        assertNothingExpired(expiryList);
+    }
+
+    @Test
+    public void decrementUsageGivenNoActivityThenThrows() {
+        final Object value = value("value");
+        final List<Object> expiryList = Lists.newArrayList();
+        final UsageTrackingCache.ExpiryHandler<String, Object> expiryHandler = expiryTracker(expiryList);
+        final UsageTrackingCache<String, Object> instance = new UsageTrackingCache<>(1, TimeUnit.DAYS, expiryHandler);
+
+        try {
+            instance.decrementUsage(value);
+            fail("Expected an exception by now");
+        } catch (IllegalStateException expected) {
+        }
+        assertNothingExpired(expiryList);
+    }
+
+    @Test
+    public void decrementUsageGivenOneTooManyCallsThenThrows() {
+        final String key = "key";
+        final Object value = value("value");
+        final List<Object> expiryList = Lists.newArrayList();
+        final UsageTrackingCache.ExpiryHandler<String, Object> expiryHandler = expiryTracker(expiryList);
+        final UsageTrackingCache<String, Object> instance = new UsageTrackingCache<>(1, TimeUnit.DAYS, expiryHandler);
+        instance.cacheAndIncrementUsage(key, value); // count=1
+        final Object actual1 = instance.getAndIncrementUsage(key); // count=2
+        assertEquals(value, actual1);
+        instance.decrementUsage(value); // count=1
+        instance.decrementUsage(value); // count=0 so inactive
+
+        try {
+            instance.decrementUsage(value);
+            fail("Expected an exception by now");
+        } catch (IllegalStateException expected) {
+        }
+        assertNothingExpired(expiryList);
+    }
+
+    @Test
+    public void getAndIncrementUsageGivenRecentButInactiveDataInCacheThenReturnsCachedData() {
+        final String key = "key";
+        final Object value = value("value");
+        final List<Object> expiryList = Lists.newArrayList();
+        final UsageTrackingCache.ExpiryHandler<String, Object> expiryHandler = expiryTracker(expiryList);
+        final UsageTrackingCache<String, Object> instance = new UsageTrackingCache<>(1, TimeUnit.DAYS, expiryHandler);
+        instance.cacheAndIncrementUsage(key, value); // count=1
+        instance.decrementUsage(value); // count=0 so inactive
+
+        final Object actual = instance.getAndIncrementUsage(key);
+
+        assertEquals(value, actual);
+        assertNothingExpired(expiryList);
+    }
+
+    // TODO: ensure that expiry handler isn't called when we don't expect it to
+    // be called
+    @Test
+    public void getAndIncrementUsageGivenOldInactiveDataInCacheThenDiscardsOldDataAndReturnsNull() throws Exception {
+        final String key = "key";
+        final Object value = value("value");
+        final List<Object> expiryList = Lists.newArrayList();
+        final UsageTrackingCache.ExpiryHandler<String, Object> expiryHandler = expiryTracker(expiryList);
+        final UsageTrackingCache<String, Object> instance = new UsageTrackingCache<>(1, TimeUnit.MILLISECONDS,
+                expiryHandler);
+        instance.cacheAndIncrementUsage(key, value); // count=1
+        instance.decrementUsage(value); // count=0 so inactive
+        // cache could expire the entry any time from now onwards
+        Thread.sleep(50L); // force cache to expire
+
+        final Object actual = instance.getAndIncrementUsage(key);
+        assertNull(actual);
+
+        assertExpired(expiryList, key, value);
+    }
+    @Test
+    public void expiryHandlerGivenOldActiveDataInCacheThenNotCalled() throws Exception {
+        final String key = "key";
+        final Object value = value("value");
+        final List<Object> expiryList = Lists.newArrayList();
+        final UsageTrackingCache.ExpiryHandler<String, Object> expiryHandler = expiryTracker(expiryList);
+        final UsageTrackingCache<String, Object> instance = new UsageTrackingCache<>(1, TimeUnit.MILLISECONDS,
+                expiryHandler);
+        instance.cacheAndIncrementUsage(key, value); // count=1
+        // cache could expire the entry any time from now onwards, but shouldn't as it's active
+        Thread.sleep(50L); // force cache to expire
+
+        final Object actual = instance.getAndIncrementUsage(key);
+        assertEquals(value, actual);
+
+        assertNothingExpired(expiryList);
+    }
+
+    private static Object value(final String s) {
+        return new Object() {
+            @Override
+            public String toString() {
+                return s;
+            }
+        };
+    }
+
+    private static <K extends L, V extends L, L> UsageTrackingCache.ExpiryHandler<K, V> expiryTracker(
+            final List<L> expiryList) {
+        return new UsageTrackingCache.ExpiryHandler<K, V>() {
+            @Override
+            public void entryDroppedFromCache(K key, V value) {
+                expiryList.add(key);
+                expiryList.add(value);
+            }
+        };
+    }
+
+    private static <L> void assertNothingExpired(List<L> list) {
+        assertNotNull(list);
+        assertEquals(0, list.size());
+    }
+
+    private static <K extends L, V extends L, L> void assertExpired(List<L> expiryList, K key, V value) {
+        assertNotNull(expiryList);
+        final L actualExpiredKey = expiryList.get(0);
+        assertEquals(key, actualExpiredKey);
+        final L actualExpiredValue = expiryList.get(1);
+        assertEquals(value, actualExpiredValue);
+        assertEquals(2, expiryList.size());
+    }
+}


### PR DESCRIPTION
This PR provides improved readTimeout functionality and connection caching, implementing #624.

Docker connection readTimeouts no longer apply to docker pull and docker build commands.
Docker build build-steps no longer have a timeout - builds have their own timeout functionality.
Docker templates now have their own pullTimeout field that's used as the max time for the docker pull to complete.
Deprecated DockerCloud.getClient() in favor of DockerCloud.getDockerApi().takeClient() and .releaseClient().  Refactored code so that all plugin code now calls DockerAPI.takeClient()
and finally { releaseClient }.