### PR TITLE
[REVIEW REQUESTED] Avoid broken clouds and templates

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerDisabled.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerDisabled.java
@@ -1,0 +1,243 @@
+package com.nirima.jenkins.plugins.docker;
+
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+import hudson.Extension;
+import hudson.Functions;
+import hudson.Util;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import hudson.util.Messages;
+
+/**
+ * Records that the user has disabled something "until further notice", or the
+ * system has disabled something for a period, or both.
+ */
+public class DockerDisabled extends AbstractDescribableImpl<DockerDisabled> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private boolean disabledByChoice;
+
+    private transient boolean disabledBySystem;
+    private transient long nanotimeWhenDisabledBySystem;
+    private transient long nanotimeWhenReEnableBySystem;
+    private transient String reasonWhyDisabledBySystem;
+    private transient Throwable exceptionWhenDisabledBySystem;
+
+    // Persistence functionality
+
+    @DataBoundConstructor
+    public DockerDisabled() {
+    }
+
+    @DataBoundSetter
+    public void setDisabledByChoice(final boolean disabledByChoice) {
+        this.disabledByChoice = disabledByChoice;
+    }
+
+    public boolean getDisabledByChoice() {
+        return disabledByChoice;
+    }
+
+    // Internal use functionality
+
+    /**
+     * Called from owning classes to record a problem that will cause
+     * {@link #isDisabled()} to return true for a period.
+     * 
+     * @param reasonGiven
+     *            Human-readable String stating why.
+     * @param durationInMilliseconds
+     *            Length of time, in milliseconds, the disablement should
+     *            continue.
+     * @param exception
+     *            Optional exception.
+     */
+    @Restricted(NoExternalUse.class)
+    public void disableBySystem(@Nonnull final String reasonGiven, final long durationInMilliseconds,
+            @Nullable final Throwable exception) {
+        final long durationInNanoseconds = TimeUnit.MILLISECONDS.toNanos(durationInMilliseconds);
+        final long now = readTimeNowInNanoseconds();
+        disabledBySystem = true;
+        nanotimeWhenDisabledBySystem = now;
+        nanotimeWhenReEnableBySystem = now + durationInNanoseconds;
+        reasonWhyDisabledBySystem = reasonGiven;
+        exceptionWhenDisabledBySystem = exception;
+    }
+
+    /**
+     * Indicates if we are currently disabled for any reason (either the user
+     * has ticked the disable box or
+     * {@link #disableBySystem(String, long, Throwable)} has been called
+     * recently).
+     * 
+     * @return true if we are currently disabled.
+     */
+    @Restricted(NoExternalUse.class)
+    public boolean isDisabled() {
+        return getDisabledByChoice() || getDisabledBySystem();
+    }
+
+    // WebUI access methods
+
+    @DataBoundSetter
+    public void setEnabledByChoice(final boolean enabledByChoice) {
+        setDisabledByChoice(!enabledByChoice);
+    }
+
+    public boolean getEnabledByChoice() {
+        return !getDisabledByChoice();
+    }
+
+    public boolean getDisabledBySystem() {
+        if (disabledBySystem) {
+            final long now = readTimeNowInNanoseconds();
+            final long disabledTimeRemaining = nanotimeWhenReEnableBySystem - now;
+            if (disabledTimeRemaining > 0) {
+                return true;
+            }
+            disabledBySystem = false;
+            nanotimeWhenDisabledBySystem = 0L;
+            nanotimeWhenReEnableBySystem = 0L;
+            reasonWhyDisabledBySystem = null;
+            exceptionWhenDisabledBySystem = null;
+        }
+        return false;
+    }
+
+    /** How long ago this was disabled by the system, e.g. "3 min 0 sec". */
+    public String getWhenDisabledBySystemString() {
+        if (!getDisabledBySystem()) {
+            return "";
+        }
+        final long now = readTimeNowInNanoseconds();
+        final long howLongAgoInNanoseconds = now - nanotimeWhenDisabledBySystem;
+        final long howLongAgoInMilliseconds = TimeUnit.NANOSECONDS.toMillis(howLongAgoInNanoseconds);
+        return Util.getPastTimeString(howLongAgoInMilliseconds);
+    }
+
+    /**
+     * How long ago this will remain disabled by the system, e.g. "2 min 0 sec".
+     */
+    public String getWhenReEnableBySystemString() {
+        final long now = readTimeNowInNanoseconds();
+        if (!getDisabledBySystem()) {
+            return "";
+        }
+        final long howSoonInNanoseconds = nanotimeWhenReEnableBySystem - now;
+        final long howSoonInMilliseconds = TimeUnit.NANOSECONDS.toMillis(howSoonInNanoseconds);
+        return Util.getTimeSpanString(howSoonInMilliseconds);
+    }
+
+    public String getReasonWhyDisabledBySystem() {
+        if (!getDisabledBySystem()) {
+            return "";
+        }
+        return reasonWhyDisabledBySystem;
+    }
+
+    public String getExceptionWhenDisabledBySystemString() {
+        if (!getDisabledBySystem() || exceptionWhenDisabledBySystem == null) {
+            return "";
+        }
+        return Functions.printThrowable(exceptionWhenDisabledBySystem);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DockerDisabled> {
+        public FormValidation doCheckEnabledByChoice(@QueryParameter boolean enabledByChoice,
+                @QueryParameter boolean disabledBySystem, @QueryParameter String whenDisabledBySystemString,
+                @QueryParameter String whenReEnableBySystemString, @QueryParameter String reasonWhyDisabledBySystem,
+                @QueryParameter String exceptionWhenDisabledBySystemString) {
+            if (!enabledByChoice) {
+                return FormValidation.warning("Note: Disabled.");
+            }
+            if (disabledBySystem) {
+                final String reason = Util.fixNull(reasonWhyDisabledBySystem);
+                final String disabledAgo = Util.fixNull(whenDisabledBySystemString);
+                final String enableWhen = Util.fixNull(whenReEnableBySystemString);
+                final String exception = Util.fixNull(exceptionWhenDisabledBySystemString);
+                if (!reason.isEmpty() && !disabledAgo.isEmpty() && !enableWhen.isEmpty()) {
+                    final StringBuilder html = new StringBuilder();
+                    html.append("Note: Disabled ");
+                    html.append(Util.escape(disabledAgo));
+                    html.append(" ago due to error.");
+                    html.append("  Will re-enable in ");
+                    html.append(Util.escape(enableWhen));
+                    html.append(".");
+                    html.append("<br/>Reason: ");
+                    html.append(Util.escape(reason));
+                    if (!exception.isEmpty()) {
+                        html.append(" <a href='#' class='showDetails'>");
+                        html.append(Messages.FormValidation_Error_Details());
+                        html.append("</a><pre style='display:none'>");
+                        html.append(Util.escape(exception));
+                        html.append("</pre>");
+                    }
+                    return FormValidation.warningWithMarkup(html.toString());
+                }
+            }
+            return FormValidation.ok();
+        }
+    }
+
+    // Basic Java Object methods
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DockerDisabled other = (DockerDisabled) o;
+        if (disabledByChoice != other.disabledByChoice) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = disabledByChoice ? 1 : 0;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        final boolean ByChoice = getDisabledByChoice();
+        final boolean bySystem = getDisabledBySystem();
+        if (bySystem) {
+            final String ago = getWhenDisabledBySystemString();
+            final String until = getWhenReEnableBySystemString();
+            final String why = getReasonWhyDisabledBySystem();
+            if (ByChoice) {
+                return "ByChoice,BySystem," + ago + "," + until + "," + why;
+            }
+            return "BySystem," + ago + "," + until + "," + why;
+        }
+        if (ByChoice) {
+            return "ByChoice";
+        }
+        return "No";
+    }
+
+    // Test accessor
+    @Restricted(NoExternalUse.class)
+    protected long readTimeNowInNanoseconds() {
+        return System.nanoTime();
+    }
+}

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/config.jelly
@@ -6,7 +6,9 @@
     </f:entry>
 
     <f:property field="dockerApi"/>
-    
+
+    <f:property field="disabled"/>
+
     <f:entry title="${%Expose DOCKER_HOST}" field="exposeDockerHost">
         <f:checkbox/>
     </f:entry>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerDisabled/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerDisabled/config.jelly
@@ -1,0 +1,24 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials" >
+
+    <f:entry title="${%Enabled}" field="enabledByChoice">
+        <f:checkbox/>
+    </f:entry>
+
+    <f:invisibleEntry>
+        <f:checkbox field="disabledBySystem"/>
+    </f:invisibleEntry>
+    <f:invisibleEntry>
+        <f:textbox field="whenDisabledBySystemString" />
+    </f:invisibleEntry>
+    <f:invisibleEntry>
+        <f:textbox field="whenReEnableBySystemString" />
+    </f:invisibleEntry>
+    <f:invisibleEntry>
+        <f:textbox field="reasonWhyDisabledBySystem" />
+    </f:invisibleEntry>
+    <f:invisibleEntry>
+        <f:textbox field="exceptionWhenDisabledBySystemString" />
+    </f:invisibleEntry>
+
+</j:jelly>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerDisabled/help-enabledByChoice.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerDisabled/help-enabledByChoice.html
@@ -1,0 +1,10 @@
+<div>
+    If not ticked then this functionality will be disabled.
+    <br/>
+    This can be used to e.g. take a cloud or template out of action for maintenance etc.
+    <p>
+    Note:
+    If problems are encountered then this functionality may be disabled automatically.
+    If that happens then it will be shown here.
+    In this situation, the disabled state is transient and will automatically clear after the stated period has elapsed.
+</div>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/config.jelly
@@ -5,6 +5,8 @@
         <f:textbox />
     </f:entry>
 
+    <f:property field="disabled"/>
+
     <f:property field="dockerTemplateBase"/>
 
 

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerDisabledTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerDisabledTest.java
@@ -1,0 +1,255 @@
+package com.nirima.jenkins.plugins.docker;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+public class DockerDisabledTest {
+
+    @Test
+    public void testHashCodeAndEquals() {
+        final DockerDisabled i1 = new DockerDisabled();
+        final DockerDisabled i2 = new DockerDisabled();
+        i2.setDisabledByChoice(true);
+        final DockerDisabled e1 = new DockerDisabled();
+        final DockerDisabled e2 = new DockerDisabled();
+        e2.setDisabledByChoice(true);
+        e2.disableBySystem("non", 100L, null);
+
+        assertEquals(i1, i1);
+        assertEquals(i1, e1);
+        assertEquals(i1.hashCode(), e1.hashCode());
+        assertEquals(i2, e2);
+        assertEquals(i2.hashCode(), e2.hashCode());
+        assertNotEquals(i1, i2);
+        assertNotEquals(i1.hashCode(), i2.hashCode());
+        assertNotEquals(i1, null);
+        assertNotEquals(i1, "foo");
+    }
+
+    @Test
+    public void isDisabledGivenDefaultsThenReturnsFalse() {
+        final TestClass i = new TestClass();
+
+        final boolean actual = i.isDisabled();
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isDisabledGivenUserNotDisabledThenReturnsFalse() {
+        final TestClass i = new TestClass();
+        i.setDisabledByChoice(false);
+
+        final boolean actual = i.isDisabled();
+
+        assertFalse(actual);
+    }
+
+    @Test
+    public void isDisabledGivenUserDisabledThenReturnsTrue() {
+        final TestClass i = new TestClass();
+        i.setDisabledByChoice(true);
+
+        final boolean actual = i.isDisabled();
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isDisabledGivenSystemDisabledThenReturnsTrue() {
+        final TestClass i = new TestClass();
+        final long duration = 10000L;
+        i.disableBySystem("non", duration, null);
+
+        final boolean actual = i.isDisabled();
+
+        assertTrue(actual);
+    }
+
+    @Test
+    public void isDisabledGivenSystemDisabledButTimeHasPassesThenReturnsFalseAfterTimeHasPassed() {
+        final TestClass i = new TestClass();
+        final long duration = 10000L;
+        i.disableBySystem("non", duration, null);
+
+        final boolean actual1 = i.isDisabled();
+        i.moveTimeForwards(duration - 1);
+        final boolean actual2 = i.isDisabled();
+        i.moveTimeForwards(1);
+        final boolean actual3 = i.isDisabled();
+        i.moveTimeForwards(Long.MAX_VALUE);
+        final boolean actual4 = i.isDisabled();
+
+        assertTrue(actual1);
+        assertTrue(actual2);
+        assertFalse(actual3);
+        assertFalse(actual4);
+    }
+
+    @Test
+    public void testEnabledByChoiceIsOppositeOfDisabledByChoice() {
+        final DockerDisabled i1 = new DockerDisabled();
+        final DockerDisabled i2 = new DockerDisabled();
+        i1.setDisabledByChoice(false);
+        i2.setDisabledByChoice(true);
+        final DockerDisabled e1 = new DockerDisabled();
+        final DockerDisabled e2 = new DockerDisabled();
+        e1.setEnabledByChoice(true);
+        e2.setEnabledByChoice(false);
+
+        assertFalse(i1.getDisabledByChoice());
+        assertTrue(i1.getEnabledByChoice());
+        assertFalse(e1.getDisabledByChoice());
+        assertTrue(e1.getEnabledByChoice());
+
+        assertTrue(i2.getDisabledByChoice());
+        assertFalse(i2.getEnabledByChoice());
+        assertTrue(e2.getDisabledByChoice());
+        assertFalse(e2.getEnabledByChoice());
+
+        assertEquals(i1, e1);
+        assertEquals(i2, e2);
+    }
+
+    @Test
+    public void getReasonWhyDisabledBySystemGivenGivenDefaultsThenReturnsEmptyString() {
+        final TestClass i = new TestClass();
+
+        final String actual = i.getReasonWhyDisabledBySystem();
+
+        assertEquals("", actual);
+    }
+
+    @Test
+    public void getReasonWhyDisabledBySystemGivenSystemDisabledThenReturnsReasonUntilTimeHasPassed() {
+        final TestClass i = new TestClass();
+        final long duration = 10000L;
+        final String reasonGiven = "SomeError";
+        i.disableBySystem(reasonGiven, duration, null);
+
+        final String actual1 = i.getReasonWhyDisabledBySystem();
+        i.moveTimeForwards(duration - 1);
+        final String actual2 = i.getReasonWhyDisabledBySystem();
+        i.moveTimeForwards(1);
+        final String actual3 = i.getReasonWhyDisabledBySystem();
+        i.moveTimeForwards(Long.MAX_VALUE);
+        final String actual4 = i.getReasonWhyDisabledBySystem();
+
+        assertEquals(reasonGiven, actual1);
+        assertEquals(reasonGiven, actual2);
+        assertEquals("", actual3);
+        assertEquals("", actual4);
+    }
+
+    @Test
+    public void getWhenDisabledBySystemStringGivenDefaultsThenReturnsEmptyString() {
+        final TestClass i = new TestClass();
+
+        final String actual = i.getWhenDisabledBySystemString();
+
+        assertEquals("", actual);
+    }
+
+    @Test
+    public void getWhenDisabledBySystemStringGivenSystemDisabledThenReturnsReasonUntilTimeHasPassed() {
+        final TestClass i = new TestClass();
+        final long duration = 60001L;
+        final String expected1 = "0 ms";
+        final String expected2 = "1 min 0 sec";
+        i.disableBySystem("a reason", duration, null);
+
+        final String actual1 = i.getWhenDisabledBySystemString();
+        i.moveTimeForwards(duration - 1);
+        final String actual2 = i.getWhenDisabledBySystemString();
+        i.moveTimeForwards(1);
+        final String actual3 = i.getWhenDisabledBySystemString();
+        i.moveTimeForwards(Long.MAX_VALUE);
+        final String actual4 = i.getWhenDisabledBySystemString();
+
+        assertEquals(expected1, actual1);
+        assertEquals(expected2, actual2);
+        assertEquals("", actual3);
+        assertEquals("", actual4);
+    }
+
+    @Test
+    public void getWhenReEnableBySystemStringGivenDefaultsThenReturnsEmptyString() {
+        final TestClass i = new TestClass();
+
+        final String actual = i.getWhenReEnableBySystemString();
+
+        assertEquals("", actual);
+    }
+
+    @Test
+    public void getWhenReEnableBySystemStringGivenSystemDisabledThenReturnsReasonUntilTimeHasPassed() {
+        final TestClass i = new TestClass();
+        final long duration = 120000L;
+        final String expected1 = "2 min 0 sec";
+        final String expected2 = "1 ms";
+        i.disableBySystem("another reason", duration, null);
+
+        final String actual1 = i.getWhenReEnableBySystemString();
+        i.moveTimeForwards(duration - 1);
+        final String actual2 = i.getWhenReEnableBySystemString();
+        i.moveTimeForwards(1);
+        final String actual3 = i.getWhenReEnableBySystemString();
+        i.moveTimeForwards(Long.MAX_VALUE);
+        final String actual4 = i.getWhenReEnableBySystemString();
+
+        assertEquals(expected1, actual1);
+        assertEquals(expected2, actual2);
+        assertEquals("", actual3);
+        assertEquals("", actual4);
+    }
+
+    @Test
+    public void getExceptionWhenDisabledBySystemStringGivenGivenDefaultsThenReturnsEmptyString() {
+        final TestClass i = new TestClass();
+
+        final String actual = i.getExceptionWhenDisabledBySystemString();
+
+        assertEquals("", actual);
+    }
+
+    @Test
+    public void getExceptionWhenDisabledBySystemStringGivenSystemDisabledThenReturnsReasonUntilTimeHasPassed() {
+        final TestClass i = new TestClass();
+        final long duration = 10000L;
+        final String reasonGiven = "SomeError";
+        final Throwable ex = new RuntimeException("FakeException");
+        final String expected = ex.toString();
+        i.disableBySystem(reasonGiven, duration, ex);
+
+        final String actual1 = i.getExceptionWhenDisabledBySystemString();
+        i.moveTimeForwards(duration - 1);
+        final String actual2 = i.getExceptionWhenDisabledBySystemString();
+        i.moveTimeForwards(1);
+        final String actual3 = i.getExceptionWhenDisabledBySystemString();
+        i.moveTimeForwards(Long.MAX_VALUE);
+        final String actual4 = i.getExceptionWhenDisabledBySystemString();
+
+        assertThat(actual1, startsWith(expected));
+        assertThat(actual2, startsWith(expected));
+        assertEquals("", actual3);
+        assertEquals("", actual4);
+    }
+
+    private static class TestClass extends DockerDisabled {
+        long now = System.nanoTime();
+
+        @Override
+        protected long readTimeNowInNanoseconds() {
+            return now;
+        }
+
+        public void moveTimeForwards(long milliseconds) {
+            final long nanos = TimeUnit.MILLISECONDS.toNanos(milliseconds);
+            now += nanos;
+        }
+    }
+}


### PR DESCRIPTION
Automatically temporarily disable malfunctioning templates/clouds #626 

DockerCloud and DockerTemplate now have a "Enabled" field so a user can disable an entire cloud or template until they choose to re-enable it.
If a template fails to provision, this flag is cleared (on the template) for 5 minutes.
If a cloud is unable to interrogate the docker container counts then the flag is cleared (on the entire cloud) for 5 minutes.
The cloud and template configuration pages will show when they have been temporarily disabled, why this has happened, and how long the disabling will last for.
The net effect should be that, in the event that a template or cloud fails, it'll be disabled for a few minutes, thus allowing Jenkins to try another template or cloud, thus allowing Jenkins to continue to start containers even in the event that one of its clouds/templates is unable to start containers.

Note: This doesn't currently detect containers failing to come online after they've been successfully started, it's aimed at detecting and coping with docker hosts failing rather than user configuration errors.
Also note: This PR builds upon the code from #633 so most of the changed files are actually from that PR.