### PR TITLE
Remove no-op line from DockerTemplate

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -110,7 +110,6 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         this.dockerTemplateBase = dockerTemplateBase;
         this.connector = connector;
         this.labelString = Util.fixNull(labelString);
-        this.remoteFs = remoteFs;
 
         if (Strings.isNullOrEmpty(instanceCapStr)) {
             this.instanceCap = Integer.MAX_VALUE;


### PR DESCRIPTION
In recent changes, DockerTemplate's @DataBoundConstructor lost its
remoteFs argument, but the line "this.remoteFs = remoteFs;" remained (by
accident) despite that line no longer having any effect.