### PR TITLE
Fix for issue #644

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -353,7 +353,9 @@ public class DockerCloud extends Cloud {
                             plannedNode.complete(slave);
 
                             // On provisioning completion, let's trigger NodeProvisioner
-                            Jenkins.getInstance().addNode(slave);
+                            synchronized(api){
+                                Jenkins.getInstance().addNode(slave);
+                            }
 
                         } catch (Exception ex) {
                             LOGGER.error("Error in provisioning; template='{}' for cloud='{}'",

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -390,6 +390,7 @@ public class DockerCloud extends Cloud {
             final DockerDisabled reasonForDisablement = getDisabled();
             reasonForDisablement.disableBySystem("Cloud provisioning failure", TimeUnit.MINUTES.toMillis(5), e);
             setDisabled(reasonForDisablement);
+            LOGGER.error("Disabling Docker cloud {} for 5 minutes due to {}", getDisplayName(), reasonForDisablement);
             return Collections.emptyList();
         }
     }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -474,6 +474,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
             final DockerDisabled reasonForDisablement = getDisabled();
             reasonForDisablement.disableBySystem(reason, durationInMilliseconds, ex);
             setDisabled(reasonForDisablement);
+            LOGGER.error("Disabling Docker template for 5 minutes due to {}", reasonForDisablement);
             throw ex;
         }
     }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -511,7 +511,11 @@ public class DockerTemplate implements Describable<DockerTemplate> {
             node.setMode(mode);
             node.setLabelString(labelString);
             node.setRetentionStrategy(retentionStrategy);
-            node.setNodeProperties(nodeProperties);
+            try {
+                node.setNodeProperties(nodeProperties);
+            } catch (IOException e) {
+                LOGGER.error("Caught an IOException trying to set node properties for '" + uid + "' - Some properties may not be persisted to disk. ", e);
+            }
             node.setRemoveVolumes(removeVolumes);
             node.setDockerAPI(api);
             finallyRemoveTheContainer = false;

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -511,10 +511,12 @@ public class DockerTemplate implements Describable<DockerTemplate> {
             node.setMode(mode);
             node.setLabelString(labelString);
             node.setRetentionStrategy(retentionStrategy);
-            try {
-                node.setNodeProperties(nodeProperties);
-            } catch (IOException e) {
-                LOGGER.error("Caught an IOException trying to set node properties for '" + uid + "' - Some properties may not be persisted to disk. ", e);
+            synchronized(api){
+                try {
+                    node.setNodeProperties(nodeProperties);
+                } catch (IOException e) {
+                    LOGGER.error("Caught an IOException trying to set node properties for '" + uid + "' - Some properties may not be persisted to disk. ", e);
+                }
             }
             node.setRemoveVolumes(removeVolumes);
             node.setDockerAPI(api);


### PR DESCRIPTION
With Jenkins 2.107.2 and docker-plugin 1.1.4, we find that during node provisioning, if many nodes are simultaneously requested, it is possible to have the node's persistent filesystem yanked from under it while the provisioner is trying to set node properties causing an exception to raise. The exception will trigger a disableBySystem, which we don't want since the provisioning could just proceed normally. This is currently our best workaround.

See issue #644