### PR TITLE
Mitigate JENKINS-51203 and issue 644.

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -351,10 +351,11 @@ public class DockerCloud extends Cloud {
                             slave = t.provisionNode(api, TaskListener.NULL);
                             slave.setCloudId(DockerCloud.this.name);
                             plannedNode.complete(slave);
-
-                            // On provisioning completion, let's trigger NodeProvisioner
-                            Jenkins.getInstance().addNode(slave);
-
+                            // Do NOT call Jenkins.getInstance().addNode(slave)
+                            // because the Jenkins-core cloud provisioning logic
+                            // that called us originally will do that for us
+                            // (now we've called plannedNode.complete) and, more
+                            // importantly, it'll do it safely.
                         } catch (Exception ex) {
                             LOGGER.error("Error in provisioning; template='{}' for cloud='{}'",
                                     t, getDisplayName(), ex);


### PR DESCRIPTION
Issue #644 reported a couple of common exception failures that were being seen on a (fairly busy) Jenkins server.  These exceptions triggered the "don't use a faulty template/cloud for 5 minutes" functionality and the "fairly busy" Jenkins server then stopped working for 5 minutes, which wasn't good.

The issues turned out to be two-fold:
1) `Slave.setNodeProperties` is buggy and unreliable (see [JENKINS-51203](https://issues.jenkins-ci.org/browse/JENKINS-51203), so we need to avoid calling it if we can do so, and retry calling it until it works if we do need to use it.
2) `Jenkins.addNode` is also unreliable (see the TODO comment in [Nodes.java](https://github.com/jenkinsci/jenkins/blob/d2276c3c9b16fd46a3912ab8d58c418e67d8ce3e/core/src/main/java/jenkins/model/Nodes.java#L141)), so we also need to retry that until it works.

In both cases, we retry with a small delay and try up to 10 times, with the exception from the last attempt being allowed to bubble up "as normal" if it consistently failed.
(in both cases, it's safe to call the method multiple times with the same argument, so retries are safe)