### PR TITLE
Namespaces for Container Label Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## 1.1.x [draft only!]
-* The label keys used for containers created have changed to ensure that they comply with [Docker's guidelines](https://docs.docker.com/config/labels-custom-metadata/) [#660](https://docs.docker.com/config/labels-custom-metadata/). Find below the mapping between the old label keys and the new one's in case you made use of them in foreign tools:
-   | Old Label Key Identifier | New Label Key Identifier
-   |--------------------------|-----------------------------------------------------------|
-   | JenkinsId                | com.nirima.jenkins.plugins.docker.JenkinsId               |
-   | JenkinsServerUrl         | com.nirima.jenkins.plugins.docker.JenkinsServerUrl        |
-   | JenkinsContainerImage    | com.nirima.jenkins.plugins.docker.JenkinsContainerImage   |
-   | JenkinsNodeName          | com.nirima.jenkins.plugins.docker.JenkinsNodeName         |
-   | JenkinsTemplateName      | com.nirima.jenkins.plugins.docker.JenkinsTemplateName     |
-
 ## 1.1.4 (2018-04-19)
 * Automatically avoid using broken clouds/templates [#626](https://github.com/jenkinsci/docker-plugin/issues/626)
 * Improved "read timeout" handling and added template "pull timeout" [#624](https://github.com/jenkinsci/docker-plugin/issues/624)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.1.x [draft only!]
+* The label keys used for containers created have changed to ensure that they comply with [Docker's guidelines](https://docs.docker.com/config/labels-custom-metadata/) [#660](https://docs.docker.com/config/labels-custom-metadata/). Find below the mapping between the old label keys and the new one's in case you made use of them in foreign tools:
+   | Old Label Key Identifier | New Label Key Identifier
+   |--------------------------|-----------------------------------------------------------|
+   | JenkinsId                | com.nirima.jenkins.plugins.docker.JenkinsId               |
+   | JenkinsServerUrl         | com.nirima.jenkins.plugins.docker.JenkinsServerUrl        |
+   | JenkinsContainerImage    | com.nirima.jenkins.plugins.docker.JenkinsContainerImage   |
+   | JenkinsNodeName          | com.nirima.jenkins.plugins.docker.JenkinsNodeName         |
+   | JenkinsTemplateName      | com.nirima.jenkins.plugins.docker.JenkinsTemplateName     |
+
 ## 1.1.4 (2018-04-19)
 * Automatically avoid using broken clouds/templates [#626](https://github.com/jenkinsci/docker-plugin/issues/626)
 * Improved "read timeout" handling and added template "pull timeout" [#624](https://github.com/jenkinsci/docker-plugin/issues/624)

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -599,10 +599,10 @@ public class DockerCloud extends Cloud {
      */
     public int countContainersInDocker(final String imageName) throws Exception {
         final Map<String, String> labelFilter = new HashMap<>();
-        labelFilter.put(DockerContainerLabelKeys.CONTAINER_LABEL_JENKINS_INSTANCE_ID,
+        labelFilter.put(DockerContainerLabelKeys.JENKINS_INSTANCE_ID,
                 DockerTemplateBase.getJenkinsInstanceIdForContainerLabel());
         if (imageName != null) {
-            labelFilter.put(DockerContainerLabelKeys.CONTAINER_LABEL_IMAGE, imageName);
+            labelFilter.put(DockerContainerLabelKeys.CONTAINER_IMAGE, imageName);
         }
         final List<?> containers;
         try(final DockerClient client = dockerApi.getClient()) {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -599,10 +599,10 @@ public class DockerCloud extends Cloud {
      */
     public int countContainersInDocker(final String imageName) throws Exception {
         final Map<String, String> labelFilter = new HashMap<>();
-        labelFilter.put(DockerTemplateBase.CONTAINER_LABEL_JENKINS_INSTANCE_ID,
+        labelFilter.put(DockerContainerLabelKeys.CONTAINER_LABEL_JENKINS_INSTANCE_ID,
                 DockerTemplateBase.getJenkinsInstanceIdForContainerLabel());
         if (imageName != null) {
-            labelFilter.put(DockerTemplateBase.CONTAINER_LABEL_IMAGE, imageName);
+            labelFilter.put(DockerContainerLabelKeys.CONTAINER_LABEL_IMAGE, imageName);
         }
         final List<?> containers;
         try(final DockerClient client = dockerApi.getClient()) {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
@@ -13,7 +13,7 @@ import jenkins.model.Jenkins;
  * @author eaglerainbow
  *
  */
-public interface DockerContainerLabelKeys {
+public final class DockerContainerLabelKeys {
 
     /**
      * As requested by https://docs.docker.com/config/labels-custom-metadata/, keys of labels used
@@ -22,7 +22,7 @@ public interface DockerContainerLabelKeys {
      * 
      * Label keys defined in this interface already have this namespace prefixed.
      */
-    static final String PLUGIN_LABEL_KEY_NAMESPACE = "com.nirima.jenkins.plugins.docker.";
+    private static final String PLUGIN_LABEL_KEY_NAMESPACE = "com.nirima.jenkins.plugins.docker.";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
@@ -15,27 +15,35 @@ import jenkins.model.Jenkins;
  */
 public interface DockerContainerLabelKeys {
 
+    /**
+     * As requested by https://docs.docker.com/config/labels-custom-metadata/, keys of labels used
+     * in docker shall be prefixed by a namespace using the reverse DNS notation.
+     * All label keys of this plugin shall use this namespace as a prefix. 
+     * 
+     * Label keys defined in this interface already have this namespace prefixed.
+     */
+    static final String PLUGIN_LABEL_KEY_NAMESPACE = "com.nirima.jenkins.plugins.docker.";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
      * setting its value to our {@link DockerTemplateBase#getJenkinsInstanceIdForContainerLabel()}, so that we
      * can recognize our own containers later.
      */
-    static final String JENKINS_INSTANCE_ID = "JenkinsId";
+    static final String JENKINS_INSTANCE_ID = PLUGIN_LABEL_KEY_NAMESPACE + "JenkinsId";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
      * setting its value to our {@link Jenkins#getRootUrl()}, so that we
      * can recognize our own containers later.
      */
-    static final String JENKINS_URL = "JenkinsServerUrl";
+    static final String JENKINS_URL = PLUGIN_LABEL_KEY_NAMESPACE + "JenkinsServerUrl";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
      * setting its value to our {@link #getImage()}, so that we
      * can recognize our own containers later.
      */
-    static final String CONTAINER_IMAGE = "JenkinsContainerImage";
+    static final String CONTAINER_IMAGE = PLUGIN_LABEL_KEY_NAMESPACE + "JenkinsContainerImage";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
@@ -43,7 +51,7 @@ public interface DockerContainerLabelKeys {
      * can recognize our own containers later.
      */
     @Restricted(NoExternalUse.class) 
-    static final String NODE_NAME = "JenkinsNodeName";
+    static final String NODE_NAME = PLUGIN_LABEL_KEY_NAMESPACE + "JenkinsNodeName";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
@@ -51,6 +59,6 @@ public interface DockerContainerLabelKeys {
      * can recognize our own containers later.
      */
     @Restricted(NoExternalUse.class) 
-    static final String TEMPLATE_NAME = "JenkinsTemplateName";
+    static final String TEMPLATE_NAME = PLUGIN_LABEL_KEY_NAMESPACE + "JenkinsTemplateName";
     
 }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
@@ -22,7 +22,7 @@ public final class DockerContainerLabelKeys {
      * 
      * Label keys defined in this interface already have this namespace prefixed.
      */
-    private static final String PLUGIN_LABEL_KEY_NAMESPACE = "com.nirima.jenkins.plugins.docker.";
+    private static final String PLUGIN_LABEL_KEY_NAMESPACE = DockerContainerLabelKeys.class.getPackage().getName()+".";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
@@ -1,0 +1,55 @@
+package com.nirima.jenkins.plugins.docker;
+
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import hudson.model.Node;
+import jenkins.model.Jenkins;
+
+/**
+ * This constant interface defines the identifiers of label keys used at containers, which
+ * are generated using this plugin.
+ * 
+ * @author eaglerainbow
+ *
+ */
+public interface DockerContainerLabelKeys {
+
+    /**
+     * Name of the Docker "label" that we'll put into every container we start,
+     * setting its value to our {@link DockerTemplateBase#getJenkinsInstanceIdForContainerLabel()}, so that we
+     * can recognize our own containers later.
+     */
+    static String CONTAINER_LABEL_JENKINS_INSTANCE_ID = "JenkinsId";
+    
+    /**
+     * Name of the Docker "label" that we'll put into every container we start,
+     * setting its value to our {@link Jenkins#getRootUrl()}, so that we
+     * can recognize our own containers later.
+     */
+    static String CONTAINER_LABEL_JENKINS_URL = "JenkinsServerUrl";
+    
+    /**
+     * Name of the Docker "label" that we'll put into every container we start,
+     * setting its value to our {@link #getImage()}, so that we
+     * can recognize our own containers later.
+     */
+    static String CONTAINER_LABEL_IMAGE = "JenkinsContainerImage";
+    
+    /**
+     * Name of the Docker "label" that we'll put into every container we start,
+     * setting its value to our {@link Node#getNodeName()}, so that we
+     * can recognize our own containers later.
+     */
+    @Restricted(NoExternalUse.class) 
+    static String CONTAINER_LABEL_NODE_NAME = "JenkinsNodeName";
+    
+    /**
+     * Name of the Docker "label" that we'll put into every container we start,
+     * setting its value to our {@link #getName()}, so that we
+     * can recognize our own containers later.
+     */
+    @Restricted(NoExternalUse.class) 
+    static String CONTAINER_LABEL_TEMPLATE_NAME = "JenkinsTemplateName";
+    
+}

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
@@ -40,7 +40,7 @@ public interface DockerContainerLabelKeys {
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
-     * setting its value to our {@link #getImage()}, so that we
+     * setting its value to the value of {@link DockerTemplateBase#getImage()}, so that we
      * can recognize our own containers later.
      */
     static final String CONTAINER_IMAGE = PLUGIN_LABEL_KEY_NAMESPACE + "JenkinsContainerImage";
@@ -55,7 +55,7 @@ public interface DockerContainerLabelKeys {
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
-     * setting its value to our {@link #getName()}, so that we
+     * setting its value to the value of {@link DockerTemplate#getName()}, so that we
      * can recognize our own containers later.
      */
     @Restricted(NoExternalUse.class) 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
@@ -15,26 +15,27 @@ import jenkins.model.Jenkins;
  */
 public interface DockerContainerLabelKeys {
 
+    
     /**
      * Name of the Docker "label" that we'll put into every container we start,
      * setting its value to our {@link DockerTemplateBase#getJenkinsInstanceIdForContainerLabel()}, so that we
      * can recognize our own containers later.
      */
-    static String JENKINS_INSTANCE_ID = "JenkinsId";
+    static final String JENKINS_INSTANCE_ID = "JenkinsId";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
      * setting its value to our {@link Jenkins#getRootUrl()}, so that we
      * can recognize our own containers later.
      */
-    static String JENKINS_URL = "JenkinsServerUrl";
+    static final String JENKINS_URL = "JenkinsServerUrl";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
      * setting its value to our {@link #getImage()}, so that we
      * can recognize our own containers later.
      */
-    static String CONTAINER_IMAGE = "JenkinsContainerImage";
+    static final String CONTAINER_IMAGE = "JenkinsContainerImage";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
@@ -42,7 +43,7 @@ public interface DockerContainerLabelKeys {
      * can recognize our own containers later.
      */
     @Restricted(NoExternalUse.class) 
-    static String NODE_NAME = "JenkinsNodeName";
+    static final String NODE_NAME = "JenkinsNodeName";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
@@ -50,6 +51,6 @@ public interface DockerContainerLabelKeys {
      * can recognize our own containers later.
      */
     @Restricted(NoExternalUse.class) 
-    static String TEMPLATE_NAME = "JenkinsTemplateName";
+    static final String TEMPLATE_NAME = "JenkinsTemplateName";
     
 }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerLabelKeys.java
@@ -20,21 +20,21 @@ public interface DockerContainerLabelKeys {
      * setting its value to our {@link DockerTemplateBase#getJenkinsInstanceIdForContainerLabel()}, so that we
      * can recognize our own containers later.
      */
-    static String CONTAINER_LABEL_JENKINS_INSTANCE_ID = "JenkinsId";
+    static String JENKINS_INSTANCE_ID = "JenkinsId";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
      * setting its value to our {@link Jenkins#getRootUrl()}, so that we
      * can recognize our own containers later.
      */
-    static String CONTAINER_LABEL_JENKINS_URL = "JenkinsServerUrl";
+    static String JENKINS_URL = "JenkinsServerUrl";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
      * setting its value to our {@link #getImage()}, so that we
      * can recognize our own containers later.
      */
-    static String CONTAINER_LABEL_IMAGE = "JenkinsContainerImage";
+    static String CONTAINER_IMAGE = "JenkinsContainerImage";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
@@ -42,7 +42,7 @@ public interface DockerContainerLabelKeys {
      * can recognize our own containers later.
      */
     @Restricted(NoExternalUse.class) 
-    static String CONTAINER_LABEL_NODE_NAME = "JenkinsNodeName";
+    static String NODE_NAME = "JenkinsNodeName";
     
     /**
      * Name of the Docker "label" that we'll put into every container we start,
@@ -50,6 +50,6 @@ public interface DockerContainerLabelKeys {
      * can recognize our own containers later.
      */
     @Restricted(NoExternalUse.class) 
-    static String CONTAINER_LABEL_TEMPLATE_NAME = "JenkinsTemplateName";
+    static String TEMPLATE_NAME = "JenkinsTemplateName";
     
 }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -1,26 +1,5 @@
 package com.nirima.jenkins.plugins.docker;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.QueryParameter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectImageResponse;
@@ -55,6 +34,25 @@ import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import io.jenkins.docker.connector.DockerComputerConnector;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
 
 public class DockerTemplate implements Describable<DockerTemplate> {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -14,7 +14,6 @@ import com.google.common.base.Strings;
 import com.nirima.jenkins.plugins.docker.launcher.DockerComputerLauncher;
 import com.nirima.jenkins.plugins.docker.strategy.DockerOnceRetentionStrategy;
 import com.nirima.jenkins.plugins.docker.utils.UniqueIdGenerator;
-
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Describable;

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -226,14 +226,14 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         final CreateContainerCmd result = dockerTemplateBase.fillContainerConfig(containerConfig);
         final String templateName = getName();
         final String nodeName = calcUnusedNodeName(templateName);
-        result.getLabels().put(DockerContainerLabelKeys.CONTAINER_LABEL_TEMPLATE_NAME, templateName);
+        result.getLabels().put(DockerContainerLabelKeys.TEMPLATE_NAME, templateName);
         setNodeNameInContainerConfig(result, nodeName);
         return result;
     }
 
     @Restricted(NoExternalUse.class) // public for tests only
     public static void setNodeNameInContainerConfig(CreateContainerCmd containerConfig, String nodeName) {
-        containerConfig.getLabels().put(DockerContainerLabelKeys.CONTAINER_LABEL_NODE_NAME, nodeName);
+        containerConfig.getLabels().put(DockerContainerLabelKeys.NODE_NAME, nodeName);
     }
 
     /**
@@ -247,7 +247,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
      *         node for the container that will be created by this command.
      */
     public static String getNodeNameFromContainerConfig(CreateContainerCmd containerConfig) {
-        return containerConfig.getLabels().get(DockerContainerLabelKeys.CONTAINER_LABEL_NODE_NAME);
+        return containerConfig.getLabels().get(DockerContainerLabelKeys.NODE_NAME);
     }
 
     // --

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -1,7 +1,5 @@
 package com.nirima.jenkins.plugins.docker;
 
-import org.kohsuke.stapler.QueryParameter;
-
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserListBoxModel;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
@@ -19,7 +17,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.nirima.jenkins.plugins.docker.utils.JenkinsUtils;
 import com.trilead.ssh2.Connection;
-
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.Describable;

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -483,9 +483,9 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         containerConfig.withPrivileged(privileged);
 
         Map<String,String> map = new HashMap<>();
-        map.put(DockerContainerLabelKeys.CONTAINER_LABEL_JENKINS_INSTANCE_ID, getJenkinsInstanceIdForContainerLabel());
-        map.put(DockerContainerLabelKeys.CONTAINER_LABEL_JENKINS_URL, getJenkinsUrlForContainerLabel());
-        map.put(DockerContainerLabelKeys.CONTAINER_LABEL_IMAGE, getImage());
+        map.put(DockerContainerLabelKeys.JENKINS_INSTANCE_ID, getJenkinsInstanceIdForContainerLabel());
+        map.put(DockerContainerLabelKeys.JENKINS_URL, getJenkinsUrlForContainerLabel());
+        map.put(DockerContainerLabelKeys.CONTAINER_IMAGE, getImage());
 
         containerConfig.withLabels(map);
 
@@ -575,7 +575,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
 
     /**
      * Calculates the value we use for the Docker label called
-     * {@link DockerContainerLabelKeys#CONTAINER_LABEL_JENKINS_URL} that we put into every
+     * {@link DockerContainerLabelKeys#JENKINS_URL} that we put into every
      * container we make, so that we can recognize our own containers later.
      */
     static String getJenkinsUrlForContainerLabel() {
@@ -586,7 +586,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
 
     /**
      * Calculates the value we use for the Docker label called
-     * {@link DockerContainerLabelKeys#CONTAINER_LABEL_JENKINS_INSTANCE_ID} that we put into every
+     * {@link DockerContainerLabelKeys#JENKINS_INSTANCE_ID} that we put into every
      * container we make, so that we can recognize our own containers later.
      */
     static String getJenkinsInstanceIdForContainerLabel() {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -1,25 +1,5 @@
 package com.nirima.jenkins.plugins.docker;
 
-import static org.apache.commons.lang.StringUtils.isEmpty;
-import static org.apache.commons.lang.StringUtils.trimToNull;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
-
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
-import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
-import org.kohsuke.stapler.AncestorInPath;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHAuthenticator;
@@ -52,7 +32,26 @@ import hudson.security.AccessControlled;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
+import org.kohsuke.stapler.AncestorInPath;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.apache.commons.lang.StringUtils.trimToNull;
 /**
  * Base for docker templates - does not include Jenkins items like labels.
  */

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -49,6 +49,7 @@ import java.util.Map;
 
 import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.trimToNull;
+
 /**
  * Base for docker templates - does not include Jenkins items like labels.
  */


### PR DESCRIPTION
As by-product of #658, we have detected that https://docs.docker.com/config/labels-custom-metadata/ requests consumers of docker to use namespaces for their containre label keys. 

This PR proposes to prefix container label keys used with `com.nirima.jenkins.plugins.docker.`. 
Moreover, it refactors the existing coding such that all labels are centrally available at a constant interface.

## Mapping between old and new label keys

| Old Label Key Identifier | New Label Key Identifier
|--------------------------|-----------------------------------------------------------|
| JenkinsId                | com.nirima.jenkins.plugins.docker.JenkinsId               |
| JenkinsServerUrl         | com.nirima.jenkins.plugins.docker.JenkinsServerUrl        |
| JenkinsContainerImage    | com.nirima.jenkins.plugins.docker.JenkinsContainerImage   |
| JenkinsNodeName          | com.nirima.jenkins.plugins.docker.JenkinsNodeName         |
| JenkinsTemplateName      | com.nirima.jenkins.plugins.docker.JenkinsTemplateName     |