### PR TITLE
SSH retry count and wait time correction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ work
 *~
 
 dependency-reduced-pom.xml
+.DS_Store

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -225,10 +225,10 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
         // TODO we could (also) have a more generic mechanism relying on healthcheck (inspect State.Health.Status)
         final PortUtils.ConnectionCheck connectionCheck =
                 PortUtils.connectionCheck( address )
-                        .withRetries( 30 )
-                        .withEveryRetryWaitFor( 2, TimeUnit.SECONDS );
+                        .withRetries( maxNumRetries )
+                        .withEveryRetryWaitFor( retryWaitTime, TimeUnit.SECONDS );
         if (!connectionCheck.execute() || !connectionCheck.useSSH().execute()) {
-            throw new IOException("SSH service didn't started after 60s.");
+            throw new IOException("SSH service didn't start after " + retryWaitTime*maxNumRetries + "s.");
         }
 
         return sshKeyStrategy.getSSHLauncher(address, this);

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -70,6 +70,8 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
     public DockerComputerSSHConnector(SSHKeyStrategy sshKeyStrategy) {
         this.sshKeyStrategy = sshKeyStrategy;
         this.port = 22;
+        this.maxNumRetries = 30;
+        this.retryWaitTime = 2;
     }
 
     public SSHKeyStrategy getSshKeyStrategy() {

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/help-maxNumRetries.html
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/help-maxNumRetries.html
@@ -1,0 +1,1 @@
+The number of attempts to connect to the newly-spun Docker container

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/help-retryWaitTime.html
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/help-retryWaitTime.html
@@ -1,0 +1,1 @@
+Number of seconds to wait between attempts to connect to the newly-spun Docker container


### PR DESCRIPTION
DockerComputerSSHConnector now correctly retries a SSH connection up to _maxRetryCount_ times and waits _retryWaitTime_ seconds before attempting another connection.  Added some documentation to make the action of these fields more evident.

Neither the maxRetryCount or the retryWaitTime were applied to the SSH connection logic despite being collected on the Jenkins screen since 0.1
