### PR TITLE
[JENKINS-53785] Convert DockerComputerConnector$1 to non anymous class

### DIFF
--- a/src/main/java/io/jenkins/docker/connector/DockerDelegatingComputerLauncher.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerDelegatingComputerLauncher.java
@@ -1,0 +1,39 @@
+package io.jenkins.docker.connector;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.exception.NotFoundException;
+import hudson.model.Queue;
+import hudson.model.TaskListener;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.DelegatingComputerLauncher;
+import hudson.slaves.SlaveComputer;
+import io.jenkins.docker.DockerTransientNode;
+import io.jenkins.docker.client.DockerAPI;
+
+import java.io.IOException;
+
+class DockerDelegatingComputerLauncher extends DelegatingComputerLauncher {
+    private final DockerAPI api;
+    private final String containerId;
+
+    public DockerDelegatingComputerLauncher(ComputerLauncher launcher, DockerAPI api, String containerId) {
+        super(launcher);
+        this.api = api;
+        this.containerId = containerId;
+    }
+
+    @Override
+    public void launch(SlaveComputer computer, TaskListener listener) throws IOException, InterruptedException {
+        try(final DockerClient client = api.getClient()) {
+            client.inspectContainerCmd(containerId).exec();
+        } catch (NotFoundException e) {
+            // Container has been removed
+            Queue.withLock(() -> {
+                DockerTransientNode node = (DockerTransientNode) computer.getNode();
+                node.terminate(listener);
+            });
+            return;
+        }
+        super.launch(computer, listener);
+    }
+}


### PR DESCRIPTION
[JENKINS-53785](https://issues.jenkins-ci.org/browse/JENKINS-53785)

Seen through Sentry:

```
Attempt to (de-)serialize anonymous class io.jenkins.docker.connector.DockerComputerConnector$1 in file:/evergreen/data/jenkins/var/plugins/docker-plugin/WEB-INF/lib/docker-plugin.jar; see: https://jenkins.io/redirect/serialization-of-anonymous-classes/
```