### PR TITLE
Add capabilities and security options

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerSimpleTemplate.java
@@ -29,7 +29,10 @@ public class DockerSimpleTemplate extends DockerTemplateBase {
                                 boolean privileged,
                                 boolean tty,
                                 String macAddress,
-                                String extraHostsString) {
+                                String extraHostsString,
+                                String capabilitiesToAddString,
+                                String capabilitiesToDropString,
+                                String security) {
         super(image,
                 pullCredentialsId,
                 dnsString,
@@ -48,7 +51,10 @@ public class DockerSimpleTemplate extends DockerTemplateBase {
                 privileged,
                 tty,
                 macAddress,
-                extraHostsString);
+                extraHostsString,
+                capabilitiesToAddString,
+                capabilitiesToDropString,
+                security);
     }
 
     @Override

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -6,6 +6,7 @@ import com.github.dockerjava.api.command.InspectImageResponse;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Capability;
 import com.github.dockerjava.api.model.PortBinding;
 import com.github.dockerjava.api.model.PullResponseItem;
 import com.github.dockerjava.core.command.PullImageResultCallback;
@@ -214,6 +215,31 @@ public class DockerTemplate implements Describable<DockerTemplate> {
 
     public String getExtraHostsString() {
         return dockerTemplateBase.getExtraHostsString();
+    }
+
+    @CheckForNull
+    public List<Capability> getCapabilitiesToAdd() {
+        return dockerTemplateBase.getCapabilitiesToAdd();
+    }
+
+    public String getCapabilitiesToAddString() {
+        return dockerTemplateBase.getCapabilitiesToAddString();
+    }
+
+    @CheckForNull
+    public List<Capability> getCapabilitiesToDrop() {
+        return dockerTemplateBase.getCapabilitiesToDrop();
+    }
+
+    public String getCapabilitiesToDropString() {
+        return dockerTemplateBase.getCapabilitiesToDropString();
+    }
+
+    @CheckForNull
+    public List<String> getSecurityOpts() { return dockerTemplateBase.getSecurityOpts(); }
+
+    public String getSecurityOptsString() {
+        return dockerTemplateBase.getSecurityOptsString();
     }
 
     public DockerRegistryEndpoint getRegistry() {
@@ -593,7 +619,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
     /**
      * Returns a node name for a new node that doesn't clash with any we've
      * currently got.
-     * 
+     *
      * @param templateName
      *            The template's {@link #getName()}. This is used as a prefix for
      *            the node name.

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -218,7 +218,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
     }
 
     @CheckForNull
-    public List<Capability> getCapabilitiesToAdd() {
+    public List<String> getCapabilitiesToAdd() {
         return dockerTemplateBase.getCapabilitiesToAdd();
     }
 
@@ -227,7 +227,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
     }
 
     @CheckForNull
-    public List<Capability> getCapabilitiesToDrop() {
+    public List<String> getCapabilitiesToDrop() {
         return dockerTemplateBase.getCapabilitiesToDrop();
     }
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderControlOptionRun.java
@@ -161,7 +161,8 @@ public class DockerBuilderControlOptionRun extends DockerBuilderControlCloudOpti
         DockerTemplateBase template = new DockerSimpleTemplate(xImage, pullCredentialsId,
                 dnsString, network, xCommand,
                 volumesString, volumesFrom, environmentsString, xHostname,
-                memoryLimit, memorySwap, cpuShares, shmSize, bindPorts, bindAllPorts, privileged, tty, macAddress, null);
+                memoryLimit, memorySwap, cpuShares, shmSize, bindPorts, bindAllPorts, privileged, tty, macAddress,
+                null, null, null, null);
 
         LOG.info("Starting container for image {}", xImage);
         llog.println("Starting container for image " + xImage);

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
@@ -87,6 +87,18 @@
       <f:expandableTextbox />
     </f:entry>
 
+    <f:entry title="${%Capabilities to add}" field="capabilitiesToAddString">
+      <f:expandableTextbox />
+    </f:entry>
+
+    <f:entry title="${%Capabilities to drop}" field="capabilitiesToDropString">
+      <f:expandableTextbox />
+    </f:entry>
+
+    <f:entry title="${%Security options}" field="securityOptsString">
+          <f:expandableTextbox />
+    </f:entry>
+
     </f:nested>
   </f:advanced>
 

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
@@ -54,7 +54,8 @@ public class DockerCloudTest {
         final DockerTemplate template = new DockerTemplate(
                 new DockerTemplateBase("image", "pullCredentialsId", "dnsString", "network",
                         "dockerCommand", "volumesString", "volumesFroString", "environmentString",
-                        "hostname", 128, 256, 42, 102, "bindPorts", true, true, true, "macAddress", "extraHostsString"),
+                        "hostname", 128, 256, 42, 102, "bindPorts", true, true, true, "macAddress", "extraHostsString",
+                        "SYS_ADMIN", "CHOWN", "seccomp=unconfined"),
                 new DockerComputerAttachConnector("jenkins"),
                 "labelString", "remoteFs", "10");
         template.setPullStrategy(DockerImagePullStrategy.PULL_NEVER);

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
@@ -48,7 +48,7 @@ public class DockerTemplateBaseTest {
     }
 
     private static void testFillContainerShmSize(final String imageName, final Integer shmSizeToSet,
-            final boolean shmSizeIsExpectedToBeSet, final Long expectedShmSizeSet) {
+                                                 final boolean shmSizeIsExpectedToBeSet, final Long expectedShmSizeSet) {
         // Given
         final CreateContainerCmd mockCmd = mock(CreateContainerCmd.class);
         final HostConfig mockHostConfig = mock(HostConfig.class);
@@ -78,7 +78,7 @@ public class DockerTemplateBaseTest {
     }
 
     private static void testFillContainerEnvironmentVariable(final String imageName,
-            final String environmentStringToSet, final boolean envsIsExpectedToBeSet, final String... expectedEnvsSet) {
+                                                             final String environmentStringToSet, final boolean envsIsExpectedToBeSet, final String... expectedEnvsSet) {
         // Given
         final CreateContainerCmd mockCmd = mock(CreateContainerCmd.class);
         final DockerTemplateBase instanceUnderTest = new DockerTemplateBase(imageName);
@@ -99,7 +99,7 @@ public class DockerTemplateBaseTest {
 
     @Test
     public void fillContainerConfigGivenSecurityOptions() {
-        testFillContainerSecurityOpts("null",null, false,
+        testFillContainerSecurityOpts("null", null, false,
                 null);
         String seccompSecurityOptUnconfined = "seccomp=unconfined";
         testFillContainerSecurityOpts("unconfined", Arrays.asList(seccompSecurityOptUnconfined), true,
@@ -114,7 +114,7 @@ public class DockerTemplateBaseTest {
     }
 
     private static void testFillContainerSecurityOpts(final String imageName, final List<String> securityOptsToSet,
-                                                 final boolean securityOptsIsExpectedToBeSet, final List<String> expectedSecurityOpts) {
+                                                      final boolean securityOptsIsExpectedToBeSet, final List<String> expectedSecurityOpts) {
         // Given
         final CreateContainerCmd mockCmd = mock(CreateContainerCmd.class);
         final HostConfig mockHostConfig = mock(HostConfig.class);
@@ -135,15 +135,22 @@ public class DockerTemplateBaseTest {
 
     @Test
     public void fillContainerConfigGivenCapabilitiesToAdd() {
-        testFillContainerCapabilitiesToAdd("null",null, false,
+        testFillContainerCapabilitiesToAdd("null", null, false,
                 null);
+        String toAddInString = "AUDIT_CONTROL";
         Capability toAdd = Capability.AUDIT_CONTROL;
-        testFillContainerCapabilitiesToAdd("toAdd", Arrays.asList(toAdd), true,
+        testFillContainerCapabilitiesToAdd("toAdd", Arrays.asList(toAddInString), true,
                 Arrays.asList(toAdd));
     }
 
-    private static void testFillContainerCapabilitiesToAdd(final String imageName, final List<Capability> capabilitiesToSet,
-                                                      final boolean capabilitiesIsExpectedToBeSet, final List<Capability> expectedCapabilities) {
+    @Test(expected = IllegalArgumentException.class)
+    public void fillContainerConfigGivenCapabilitiesToAddWithException() {
+        testFillContainerCapabilitiesToAdd("not existing", Arrays.asList("DUMMY"), false,
+                null);
+    }
+
+    private static void testFillContainerCapabilitiesToAdd(final String imageName, final List<String> capabilitiesToSet,
+                                                           final boolean capabilitiesIsExpectedToBeSet, final List<Capability> expectedCapabilities) {
         // Given
         final CreateContainerCmd mockCmd = mock(CreateContainerCmd.class);
         final DockerTemplateBase instanceUnderTest = new DockerTemplateBase(imageName);
@@ -162,15 +169,22 @@ public class DockerTemplateBaseTest {
 
     @Test
     public void fillContainerConfigGivenCapabilitiesToDrop() {
-        testFillContainerCapabilitiesToDrop("null",null, false,
+        testFillContainerCapabilitiesToDrop("null", null, false,
                 null);
+        String toDropInString = "AUDIT_CONTROL";
         Capability toDrop = Capability.AUDIT_CONTROL;
-        testFillContainerCapabilitiesToDrop("toDrop", Arrays.asList(toDrop), true,
+        testFillContainerCapabilitiesToDrop("toDrop", Arrays.asList(toDropInString), true,
                 Arrays.asList(toDrop));
     }
 
-    private static void testFillContainerCapabilitiesToDrop(final String imageName, final List<Capability> capabilitiesToSet,
-                                                           final boolean capabilitiesIsExpectedToBeSet, final List<Capability> expectedCapabilities) {
+    @Test(expected = IllegalArgumentException.class)
+    public void fillContainerConfigGivenCapabilitiesToDropWithException() {
+        testFillContainerCapabilitiesToDrop("not existing", Arrays.asList("DUMMY"), false,
+                null);
+    }
+
+    private static void testFillContainerCapabilitiesToDrop(final String imageName, final List<String> capabilitiesToSet,
+                                                            final boolean capabilitiesIsExpectedToBeSet, final List<Capability> expectedCapabilities) {
         // Given
         final CreateContainerCmd mockCmd = mock(CreateContainerCmd.class);
         final DockerTemplateBase instanceUnderTest = new DockerTemplateBase(imageName);

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
@@ -75,8 +75,8 @@ public class DockerTemplateTest {
         assertTrue("Error, wrong cpuShares", 1000 == instance.getDockerTemplateBase().cpuShares);
         assertTrue("Error, wrong shmSize", 1002 == instance.getDockerTemplateBase().shmSize);
 
-        assertTrue("Error, wrong capAdd", instance.getDockerTemplateBase().getCapabilitiesToAdd().contains(Capability.CHOWN));
-        assertTrue("Error, wrong capDrop", instance.getDockerTemplateBase().getCapabilitiesToDrop().contains(Capability.NET_ADMIN));
+        assertTrue("Error, wrong capAdd", instance.getDockerTemplateBase().getCapabilitiesToAdd().contains("CHOWN"));
+        assertTrue("Error, wrong capDrop", instance.getDockerTemplateBase().getCapabilitiesToDrop().contains("NET_ADMIN"));
     }
 
 }

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateTest.java
@@ -2,6 +2,7 @@ package com.nirima.jenkins.plugins.docker;
 
 import static org.junit.Assert.*;
 
+import com.github.dockerjava.api.model.Capability;
 import org.junit.Test;
 
 public class DockerTemplateTest {
@@ -35,12 +36,16 @@ public class DockerTemplateTest {
     boolean tty = false;
     String macAddress = "92:d0:c6:0a:29:33";
     String extraHostsString = "extraHostsString";
+    String capabilitiesToAddString = "CHOWN";
+    String capabilitiesToDropString = "NET_ADMIN";
+    String securityOpts = "seccomp=unconfined";
 
 
     private DockerTemplate getDockerTemplateInstanceWithDNSHost(String dnsString) {
         final DockerTemplateBase dockerTemplateBase = new DockerTemplateBase(image, null, dnsString, network,
                 dockerCommand, volumesString, volumesString, environmentsString,
-                hostname, memoryLimit, memorySwap, cpuShares, shmSize, bindPorts, bindAllPorts, privileged, tty, macAddress, extraHostsString);
+                hostname, memoryLimit, memorySwap, cpuShares, shmSize, bindPorts, bindAllPorts, privileged, tty, macAddress,
+                extraHostsString, capabilitiesToAddString, capabilitiesToDropString, securityOpts);
 
         return new DockerTemplate(dockerTemplateBase, null, labelString, remoteFs, instanceCapStr);
     }
@@ -69,6 +74,9 @@ public class DockerTemplateTest {
         assertTrue("Error, wrong memorySwap", 1280 == instance.getDockerTemplateBase().memorySwap);
         assertTrue("Error, wrong cpuShares", 1000 == instance.getDockerTemplateBase().cpuShares);
         assertTrue("Error, wrong shmSize", 1002 == instance.getDockerTemplateBase().shmSize);
+
+        assertTrue("Error, wrong capAdd", instance.getDockerTemplateBase().getCapabilitiesToAdd().contains(Capability.CHOWN));
+        assertTrue("Error, wrong capDrop", instance.getDockerTemplateBase().getCapabilitiesToDrop().contains(Capability.NET_ADMIN));
     }
 
 }

--- a/src/test/resources/seccomp.json
+++ b/src/test/resources/seccomp.json
@@ -1,0 +1,10 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "syscalls": [
+    {
+      "name": "accept",
+      "action": "SCMP_ACT_ALLOW",
+      "args": null
+    }
+  ]
+}


### PR DESCRIPTION
Following features are added in this PR : 

- Capabilities : add or drop a capability
- Security options : add some security options (typically a seccomp profile)

Typically, this will allow to define a slave with less privileges than the existing "Privileged" checkbox by leveraging on Capabilities and Seccomp. You will be able to provide an agent with dedicated profile (such as node for E2E tests that can launch only Chrome Headless with associated seccomp profile).

For instance, if user adds **seccomp=file.json** as a security option, the code will take the **file.json** as an input and passes the corresponding JSON directly to the docker-java library.

Test against last Jenkins, everything seems to work.
You can check the running slave with inspect and see that CapAdd or CapDrop are filled in case of Capabilities options ; for the security options, you have look for the SecurityOpt field.