### PR TITLE
[JENKINS-48460] Gracefully handle an unconfigured cloud

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerWatchdog.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerWatchdog.java
@@ -138,7 +138,13 @@ public class DockerContainerWatchdog extends AsyncPeriodicWork {
 
             try {
                 for (DockerCloud dc : getAllClouds()) {
-                    LOGGER.info("Checking Docker Cloud {} at {}", dc.getDisplayName(), dc.getDockerApi().getDockerHost().getUri());
+                    String uri = dc.getDockerApi().getDockerHost().getUri();
+                    if (uri == null) {
+                        LOGGER.info("Skipping unconfigured Docker Cloud {}", dc.getDisplayName());
+                        continue; // currently declines to default it, contrary to getUri Javadoc
+                    }
+
+                    LOGGER.info("Checking Docker Cloud {} at {}", dc.getDisplayName(), uri);
                     listener.getLogger().println(String.format("Checking Docker Cloud %s", dc.getDisplayName()));
 
                     csmMerged = processCloud(dc, nodeMap, csmMerged, snapshotInstance);


### PR DESCRIPTION
Addresses the exception reported in [JENKINS-48460](https://issues.jenkins-ci.org/browse/JENKINS-48460). The discussion about the `docker-slaves` plugin seems to be independent.