### PR TITLE
Ignore conflict while removing container

### DIFF
--- a/src/main/java/io/jenkins/docker/DockerTransientNode.java
+++ b/src/main/java/io/jenkins/docker/DockerTransientNode.java
@@ -1,6 +1,7 @@
 package io.jenkins.docker;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.exception.NotModifiedException;
 import com.nirima.jenkins.plugins.docker.DockerCloud;
@@ -247,6 +248,9 @@ public class DockerTransientNode extends Slave {
             }
         } catch (NotFoundException e) {
             logger.println("Container '" + containerId + "' already gone " + containerDescription + ".");
+            containerNowRemoved = true;
+        } catch (ConflictException e) {
+            logger.println("Container '" + containerId + "' removal already in progress.");
             containerNowRemoved = true;
         } catch (Exception ex) {
             logger.error("Failed to remove container '" + containerId + "' " + containerDescription + " due to exception:", ex);


### PR DESCRIPTION
In some circumstances we try to remove docker container while it is still being terminated. Seems such a race condition can happen with pipelines as we detect both Pipeline job and PlaceholderTask completion. 

```sh
PlaceholderExecutable:ExecutorStepExecution.PlaceholderTask{runId=CompileTest#22494,label=docker-2ae12755b
75761,context=CpsStepContext[4:node]:Owner[CompileTest/22494:CompileTest #22494],cookie=561ba1da-fd51-4ee6-9bc3-5d4bb75a9fd0,auth=null} seems to be finished
...

2018-11-15 14:00:06.624+0000 [id=2063173]       FINE    c.n.j.p.d.s.DockerOnceRetentionStrategy#done: terminating docker-2ae12755b75761 since CompileTestTest #544 seems to be finished
2018-11-15 14:00:06.625+0000 [id=2063198]       INFO    i.j.docker.DockerTransientNode$1#println: Disconnected computer for slave 'docker-2ae12755b75761'.
2018-11-15 14:00:06.625+0000 [id=2063198]       INFO    i.j.docker.DockerTransientNode$1#println: Removed Node for slave 'docker-2ae12755b75761'.
2018-11-15 14:00:07.005+0000 [id=2062533]       INFO    i.j.docker.DockerTransientNode$1#println: Stopped container '056930a8ce961fabcd357f7c349c36aad55242075a9af838b963c4b27fddc4e9' for slave 'docker-2ae12755b75761'.
2018-11-15 14:00:07.005+0000 [id=2063233]       INFO    i.j.docker.DockerTransientNode$1#println: Stopped container '056930a8ce961fabcd357f7c349c36aad55242075a9af838b963c4b27fddc4e9' for slave 'docker-2ae12755b75761'.
2018-11-15 14:00:07.011+0000 [id=2062533]       SEVERE  i.j.docker.DockerTransientNode$1#error: Failed to remove container '056930a8ce961fabcd357f7c349c36aad55242075a9af838b963c4b27fddc4e9' for slave 'docker-2ae12755b75761' due to exception:
com.github.dockerjava.api.exception.ConflictException: {"message":"removal of container 056930a8ce961fabcd357f7c349c36aad55242075a9af838b963c4b27fddc4e9 is already in progress"}
```

Not sure about the root cause for this, but at least we can ignore conflict in container removal to avoid spamming the logs