### PR TITLE
Cloud/Template help improvements

### DIFF
--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-containerCap.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerCloud/help-containerCap.html
@@ -1,6 +1,7 @@
 <div>
     <p>The maximum number of <b>containers</b> that this provider is allowed to run in total (value is independent of the template/image).</p>
-    <p>Note that also containers, which have <b>not</b> been created by Jenkins, are counted as well.</p>
-    <p>Defaulted to 100, if not specified otherwise.</p>
-    <p>A value of zero (0) disables provisioning of containers altogether. If you want to disable this limit, enter a non-reachable high value, such as 2147483647.</p>
+    <p>Note that containers which have <b>not</b> been created by Jenkins are not included in this total.</p>
+    <p>A negative value, or zero, or 2147483647 all mean "no limit" is imposed on the provider as a whole,
+    although per-template instance limits (if any) will still apply.</p>
+    <p>Defaults to 100.</p>
 </div>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-instanceCapStr.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-instanceCapStr.html
@@ -1,5 +1,7 @@
 <div>
-    <strong>Deprecated</strong> you should configure template with memory/cpu constraints, so docker infrastructure can manage resource consumption.
-    <p>Maximal number of instances of this template to run, or empty for unlimited.</p>
-    <p>Note that also those containers (using the same image) are counted which have <b>not</b> been started by Jenkins.</p>
+    <p>The maximum number of containers, based on this template, that this provider is allowed to run in total.</p>
+    <p>Note that containers which have <b>not</b> been created by Jenkins are not included in this total.</p>
+    <p>A negative value, or zero, or 2147483647 all mean "no limit" is imposed on the this template,
+    although the overall cloud instance limit (if any) will still apply.</p>
+    <p><strong>Deprecated</strong> you should configure template with memory/cpu constraints, so docker infrastructure can manage resource consumption.</p>
 </div>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-environment.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-environment.html
@@ -1,3 +1,0 @@
-<div>
-    New line separated list of key=value form.
-</div>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-environmentsString.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-environmentsString.html
@@ -1,0 +1,28 @@
+<div>
+    <p>
+    Zero or more environment variables that are set within the docker container.
+    This is a multi-line text field.
+    Each line must be of the form key=value and specify one variable name and its value.
+    </p>
+    <p>
+    Note that quotes are not interpreted.
+    <br/>
+    e.g. <textarea readonly="true" rows="1" cols="10" class="setting-input">foo="bar"</textarea> will result in the quotes being part of foo's value.
+    </p>
+    <p>
+    Note also that whitespace is easily broken.
+    Editing this field this without first expanding the box to its multi-line form
+    will cause any whitespace within a line to be turned into end of line codes,
+    breaking up the line and thus changing its meaning.
+    <br/>
+    e.g. The single setting:
+    <br/>
+    &nbsp;<textarea readonly="true" rows="1" cols="60" class="setting-input">JENKINS_SLAVE_SSH_PUBKEY=ssh-rsa MyPubKey jenkins@hostname&#10;</textarea>
+    <br/>
+    can be (accidentally) turned into three separate settings:
+    <br/>
+    &nbsp;<textarea readonly="true" rows="3" cols="60" class="setting-input">JENKINS_SLAVE_SSH_PUBKEY=ssh-rsa&#10;MyPubKey&#10;jenkins@hostname&#10;</textarea>
+    <br/>
+    thus preventing the configuration from working as was intended.
+    </p>
+</div>


### PR DESCRIPTION
Correction: Cloud and Template containerCap does *not* count containers that were not started by (this) Jenkins.
Correction: Help for template's environment variables field was mis-named as "environment" not "environmentString" so it did not appear.
Enhancement: Added extra advice for editing environment variables field as it's far too easy to accidentally corrupt whitespace.