### PR TITLE
[wip] fix racing condition when using JNLP Slaves

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -559,12 +559,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         LOGGER.info("Started container ID {} for node {} from image: {}", containerId, nodeName, getImage());
 
         try {
-            connector.beforeContainerStarted(api, remoteFs, containerId);
-            client.startContainerCmd(containerId).exec();
-            connector.afterContainerStarted(api, remoteFs, containerId);
-
             final ComputerLauncher launcher = connector.createLauncher(api, containerId, remoteFs, listener);
-    
             final DockerTransientNode node = new DockerTransientNode(nodeName, containerId, remoteFs, launcher);
             node.setNodeDescription("Docker Agent [" + getImage() + " on "+ api.getDockerHost().getUri() + " ID " + containerId + "]");
             node.setMode(mode);

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
@@ -91,9 +91,9 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
         final ComputerLauncher launcher = createLauncher(api, workdir, inspect, listener);
 
         final Boolean running = inspect.getState().getRunning();
-        if (Boolean.FALSE.equals(running)) {
-            listener.error("Container {} is not running. {}", containerId, inspect.getState().getStatus());
-            throw new IOException("Container is not running.");
+        if (Boolean.TRUE.equals(running)) {
+            listener.error("Container {} is already running. {}", containerId, inspect.getState().getStatus());
+            throw new IOException("Container is already running.");
         }
 
         return new DockerDelegatingComputerLauncher(launcher, api, containerId);


### PR DESCRIPTION
Hi,
I am trying to use your plugin for launching Compute Nodes using docker images and more often than not I end up getting an error of this type:
```
[JNLP4-connect connection from 192.168.128.77/192.168.128.77:58220] Refusing headers from remote: Unknown client name: docker-0001g98ue3gzg
```
I have a hunch that the problem is happening because my containers are coming online and connecting back to the Jenkins Master L553 before the actual JenkinsNode has been created/commited L559-574.

Would it be possible to help me get a build of this plugin with those lines switched?

https://github.com/jenkinsci/docker-plugin/blob/907a3144f98931a5e61fc2ec9bcca865f407c955/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java#L541-L588