### PR TITLE
PortUtils "retries" field was actually used as "tries"

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/utils/PortUtils.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/utils/PortUtils.java
@@ -15,8 +15,6 @@ import static com.google.common.base.Preconditions.checkState;
 public class PortUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(PortUtils.class);
 
-
-
     /**
      * @param host hostname to connect to
      * @param port port to open socket
@@ -35,26 +33,47 @@ public class PortUtils {
         private final String host;
         private final int port;
 
-        private int retries = 10;
-        private long retryDelay = (long) SECONDS.toMillis(2);
+        protected static final int DEFAULT_RETRIES = 10;
+        private int retries = DEFAULT_RETRIES;
+        protected static final int DEFAULT_RETRY_DELAY_SECONDS = 2;
+        private long retryDelay = SECONDS.toMillis(DEFAULT_RETRY_DELAY_SECONDS);
 
         private ConnectionCheck(String host, int port) {
             this.host = host;
             this.port = port;
         }
 
+        /**
+         * Sets the number of retries, such that {@link #execute()} will try
+         * once more than this. If this is not set then a default of
+         * {@value #DEFAULT_RETRIES} will be used.
+         * 
+         * @param retries
+         *            Number of retries. Negative values will be treated as
+         *            zero.
+         * @return this
+         */
         public ConnectionCheck withRetries(int retries) {
             this.retries = retries;
             return this;
         }
 
+        /**
+         * Sets the delay between tries. If this is not set then a default of
+         * {@value #DEFAULT_RETRY_DELAY_SECONDS} seconds will be used.
+         * 
+         * @param time
+         *            The lengthy of time.
+         * @param units
+         *            The units of that length.
+         * @return this
+         */
         public ConnectionCheck withEveryRetryWaitFor(int time, TimeUnit units) {
             retryDelay = units.toMillis(time);
             return this;
         }
 
         public ConnectionCheckSSH useSSH() {
-
             return new ConnectionCheckSSH(this);
         }
 
@@ -69,23 +88,29 @@ public class PortUtils {
             }
         }
 
-        public boolean execute() {
-
+        /**
+         * Tests the connection. If {@link #withRetries(int)} was set to more
+         * than zero then more than one attempt will be made, waiting (for the
+         * period specified by {@link #withEveryRetryWaitFor(int, TimeUnit)})
+         * between attempts.
+         * 
+         * @return true if the connection succeeded, false if it failed despite
+         *         any retries.
+         * @throws InterruptedException
+         *             if interrupted while waiting between retries.
+         */
+        public boolean execute() throws InterruptedException {
             LOGGER.trace("Testing connectivity to {} port {}", host, port );
-
             for (int i = 1; i <= retries; i++) {
                 if (executeOnce()) {
                     return true;
                 }
-                try {
-                    Thread.sleep(retryDelay);
-                } catch (InterruptedException e) {
-                    return false; // quit if interrupted
-                }
+                Thread.sleep(retryDelay);
             }
-
+            if (executeOnce()) {
+                return true;
+            }
             LOGGER.warn("Could not connect to {} port {}. Are you sure this location is contactable from Jenkins?", host, port);
-
             return false;
         }
     }
@@ -104,36 +129,60 @@ public class PortUtils {
         }
 
         /**
-         * Connects to sshd on host:port
-         * Retries while attempts reached with delay
-         * First with tcp port wait, then with ssh connection wait
+         * Tests the SSH connection. If the parent
+         * {@link ConnectionCheck#withRetries(int)} was set to more than zero
+         * then more than one attempt will be made, waiting (for the period
+         * specified by the parent
+         * {@link ConnectionCheck#withEveryRetryWaitFor(int, TimeUnit)}) between
+         * attempts. Note that, prior to testing that the port accepts SSH
+         * connection, it will first be tested to verify that it is open to TCP
+         * connections using {@link ConnectionCheck#execute()}, and this will
+         * also be subjected to retries, so that the total retry time for a port
+         * that is initially unavailable and then slow to accept SSH connections
+         * can be up to double what might be expected.
+         * 
+         * @return true if the connection succeeded, false if it failed despite
+         *         any retries.
+         * @throws InterruptedException
+         *             if interrupted while waiting between retries. Connects to
+         *             sshd on host:port. Retries while attempts reached with
+         *             delay First with tcp port wait, then with ssh connection
+         *             wait
+         * 
+         * @throws IllegalStateException
+         *             if the TCP port is not reachable despite retries.
+         * @throws InterruptedException
+         *             if interrupted while waiting between retries.
          */
-        public boolean execute() {
+        public boolean execute() throws InterruptedException {
             checkState(parent.execute(), "Port %s is not opened to connect to", parent.port);
 
-            for (int i = 1; i <= parent.retries; i++) {
-                Connection connection = new Connection(parent.host, parent.port);
-                try {
-                    connection.connect(null, 0, sshTimeoutMillis, sshTimeoutMillis);
-                    LOGGER.info("SSH port is open on {}:{}", parent.host, parent.port);
+            final int retries = Math.min(0, parent.retries);
+            final long retryDelay = parent.retryDelay;
+            final int totalTriesIntended = retries + 1;
+            int thisTryNumber;
+            for (thisTryNumber = 1; thisTryNumber <= retries; thisTryNumber++) {
+                if (executeOnce(thisTryNumber, totalTriesIntended)) {
                     return true;
-                } catch (IOException e) {
-                    LOGGER.error("Failed to connect to {}:{} (try {}/{}) - {}", parent.host, parent.port, i, parent.retries, e.getMessage());
-                } finally {
-                    connection.close();
                 }
-                try {
-                    Thread.sleep(parent.retryDelay);
-                } catch (InterruptedException e) {
-                    return false; // Quit if interrupted
-                }
+                Thread.sleep(retryDelay);
             }
-            // Tried over and again. no joy.
-            return false;
+            // last attempt
+            return executeOnce(thisTryNumber, totalTriesIntended);
+        }
+
+        private boolean executeOnce(final int thisTryNumber, final int totalTriesIntended) {
+            final Connection connection = new Connection(parent.host, parent.port);
+            try {
+                connection.connect(null, 0, sshTimeoutMillis, sshTimeoutMillis);
+                LOGGER.info("SSH port is open on {}:{}", parent.host, parent.port);
+                return true;
+            } catch (IOException e) {
+                LOGGER.error("Failed to connect to {}:{} (try {}/{}) - {}", parent.host, parent.port, thisTryNumber, totalTriesIntended, e.getMessage());
+                return false;
+            } finally {
+                connection.close();
+            }
         }
     }
-
-
-
-
 }

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/help-maxNumRetries.html
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/help-maxNumRetries.html
@@ -1,1 +1,9 @@
-The number of attempts to connect to the newly-spun Docker container
+The number of times that attempts to connect to the newly-spun Docker container will be retried before the operation is abandoned.
+<p>
+Note: That this field applies first to checks that the SSH port is open for new TCP connections, and secondly to checks that the SSH service that owns the TCP port is accepting SSH connections.
+<br/>
+e.g. a value of 3 would mean that
+(up to) 4 attempts (1 initial attempt plus 3 retries) would be made to check the availability of the TCP port,
+followed by
+(up to) 4 attempts (1 initial attempt plus 3 retries) to check the availability of the SSH service itself.
+</p>

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/help-retryWaitTime.html
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerSSHConnector/help-retryWaitTime.html
@@ -1,1 +1,1 @@
-Number of seconds to wait between attempts to connect to the newly-spun Docker container
+Number of seconds to wait between attempts to connect to the newly-started Docker container.

--- a/src/test/java/com/nirima/jenkins/plugins/docker/utils/PortUtilsTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/utils/PortUtilsTest.java
@@ -19,13 +19,16 @@ import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.allOf;
 
 /**
  * @author lanwen (Merkushev Kirill)
  */
 public class PortUtilsTest {
-
+    /** number of tries minus 1 */
     public static final int RETRY_COUNT = 2;
+    /** milliseconds */
     public static final int DELAY = (int) SECONDS.toMillis(1);
 
     @Rule
@@ -36,22 +39,34 @@ public class PortUtilsTest {
 
     @Test
     public void shouldConnectToServerSuccessfully() throws Exception {
-        assertThat("Server is up and should connect", PortUtils.connectionCheck(server.host(), server.port()).executeOnce(), is(true));
+        assertThat("Server is up and should connect",
+                PortUtils.connectionCheck(server.host(), server.port()).executeOnce(), is(true));
     }
 
     @Test
     public void shouldNotConnectToUnusedPort() throws Exception {
-        assertThat("Unused port should not be connectible", PortUtils.connectionCheck("localhost", 0).executeOnce(), is(false));
+        assertThat("Unused port should not be connectible", PortUtils.connectionCheck("localhost", 0).executeOnce(),
+                is(false));
     }
 
     @Test
     public void shouldWaitForPortAvailableUntilTimeout() throws Exception {
-        long before = currentTimeMillis();
-        assertThat("Unused port should not be connectible",
-                PortUtils.connectionCheck("localhost", 0).withRetries(RETRY_COUNT)
-                        .withEveryRetryWaitFor(DELAY, MILLISECONDS).execute(), is(false));
-        assertThat("Should wait for timeout", new Date(currentTimeMillis()),
-                greaterThanOrEqualTo(new Date(before + RETRY_COUNT * DELAY)));
+        // Given
+        // e.g. try, delay, try, delay, try = 3 tries, 2 delays.
+        final long minExpectedTime = RETRY_COUNT * DELAY;
+        final long maxExpectedTime = (RETRY_COUNT + 1) * DELAY - 1;
+
+        // When
+        final long before = currentTimeMillis();
+        final boolean actual = PortUtils.connectionCheck("localhost", 0).withRetries(RETRY_COUNT)
+                .withEveryRetryWaitFor(DELAY, MILLISECONDS).execute();
+        final long after = currentTimeMillis();
+        final long actualDuration = after - before;
+
+        // Then
+        assertThat("Unused port should not be connectible", actual, is(false));
+        assertThat("Should wait for timeout", actualDuration,
+                allOf(greaterThanOrEqualTo(minExpectedTime), lessThanOrEqualTo(maxExpectedTime)));
     }
 
     @Test
@@ -63,39 +78,63 @@ public class PortUtilsTest {
 
     @Test
     public void shouldWaitIfPortAvailableButNotSshUntilTimeout() throws Exception {
+        // Given
+        // e.g. try, delay, try, delay, try = 3 tries, 2 delays.
+        final long minExpectedTime = RETRY_COUNT * DELAY;
+        final long maxExpectedTime = (RETRY_COUNT + 1) * DELAY - 1;
 
-        long before = currentTimeMillis();
+        // When
+        final long before = currentTimeMillis();
+        final boolean actual = PortUtils.connectionCheck(server.host(), server.port()).withRetries(RETRY_COUNT)
+                .withEveryRetryWaitFor(DELAY, MILLISECONDS).useSSH().execute();
+        final long after = currentTimeMillis();
+        final long actualDuration = after - before;
 
-        assertThat(PortUtils.connectionCheck(server.host(), server.port()).withRetries(RETRY_COUNT)
-                .withEveryRetryWaitFor(DELAY, MILLISECONDS).useSSH().execute(), is(false));
-
-        assertThat("Should wait for timeout", new Date(currentTimeMillis()),
-                greaterThanOrEqualTo(new Date(before + RETRY_COUNT * DELAY)));
-
+        // Then
+        assertThat(actual, is(false));
+        assertThat("Should wait for timeout", actualDuration,
+                allOf(greaterThanOrEqualTo(minExpectedTime), lessThanOrEqualTo(maxExpectedTime)));
     }
 
     @Test
     public void shouldReturnWithoutWaitIfPortAvailable() throws Exception {
-        long before = currentTimeMillis();
-        assertThat("Used port should be connectible",
-                PortUtils.connectionCheck(server.host(), server.port()).withEveryRetryWaitFor(DELAY, MILLISECONDS).execute(), is(true));
-        assertThat("Should not wait", new Date(currentTimeMillis()), lessThan(new Date(before + DELAY)));
+        // Given
+        final long maxExpectedTime = DELAY - 1;
+
+        // When
+        final long before = currentTimeMillis();
+        final boolean actual = PortUtils.connectionCheck(server.host(), server.port())
+                .withEveryRetryWaitFor(DELAY, MILLISECONDS).execute();
+        final long after = currentTimeMillis();
+        final long actualDuration = after - before;
+
+        // Then
+        assertThat("Used port should be connectible", actual, is(true));
+        assertThat("Should not wait", actualDuration, lessThanOrEqualTo(maxExpectedTime));
     }
 
     @Test
     public void shouldRetryIfPortIsNotAvailableNow() throws Exception {
-        int retries = RETRY_COUNT * 2;
+        // Given
+        int retries = 4;
+        // e.g. try, delay, try, delay, try, delay, try, delay, try = 5 tries, 4 delays.
+        // expecting port to become available during the second delay. 
+        final long bringPortUpAfter = DELAY + DELAY/2;
+        final long minExpectedTime = 2 * DELAY;
+        final long maxExpectedTime = minExpectedTime + DELAY - 1;
+        server.stopAndRebindAfter(bringPortUpAfter, MILLISECONDS);
 
-        long before = currentTimeMillis();
-        server.stopAndRebindAfter(2 * DELAY, MILLISECONDS);
+        // When
+        final long before = currentTimeMillis();
+        final boolean actual = PortUtils.connectionCheck(server.host(), server.port()).withRetries(retries)
+                .withEveryRetryWaitFor(DELAY, MILLISECONDS).execute();
+        final long after = currentTimeMillis();
+        final long actualDuration = after - before;
 
-        assertThat("Used port should be connectible",
-                PortUtils.connectionCheck(server.host(), server.port())
-                        .withRetries(retries).withEveryRetryWaitFor(DELAY, MILLISECONDS).execute(), is(true));
-
-        assertThat("Should wait then retry", new Date(currentTimeMillis()),
-                both(greaterThanOrEqualTo(new Date(before + 2 * DELAY)))
-                        .and(lessThan(new Date(before + retries * DELAY))));
+        // Then
+        assertThat("Used port should be connectible", actual, is(true));
+        assertThat("Should wait then retry", actualDuration,
+                allOf(greaterThanOrEqualTo(minExpectedTime), lessThanOrEqualTo(maxExpectedTime)));
     }
 
     private class SomeServerRule extends ExternalResource {


### PR DESCRIPTION
* PortUtils.ConnectionCheck's "retries" field was being used as if it
were a "number of tries" field rather than "number of retries", meaning
that a figure of zero meant "don't try at all, just fail".
* The "retryDelay" delay was being done even on the final attempt,
whereas the code should only wait between attempts.
* UI help text updated to match change in meaning.
(Found during investigation for #717)