### PR TITLE
Fix/Debug Docker Slave SSH Connection not possible due to NoRouteToHostException when connecting to 0.0.0.0

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/utils/PortUtils.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/utils/PortUtils.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.concurrent.TimeUnit;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static com.google.common.base.Preconditions.checkState;
@@ -65,6 +67,11 @@ public class PortUtils {
             try (Socket ignored = new Socket(host, port)) {
                 return true;
             } catch (IOException e) {
+                ByteArrayOutputStream out = new ByteArrayOutputStream(); 
+                e.printStackTrace(new PrintStream(out));
+                String str = new String(out.toByteArray());
+                LOGGER.warn("This is a message from AppIDMan opening the socket didn't work because of: ");
+                LOGGER.warn(str);
                 return false;
             }
         }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/utils/PortUtils.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/utils/PortUtils.java
@@ -41,7 +41,7 @@ public class PortUtils {
         private long retryDelay = (long) SECONDS.toMillis(2);
 
         private ConnectionCheck(String host, int port) {
-            this.host = host;
+            this.host = "127.0.0.1";//host;
             this.port = port;
         }
 

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -279,7 +279,7 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
         }
         String host = getExternalIP(api, ir, networkSettings, sshBindings);
 
-        return new InetSocketAddress(host, port);
+        return new InetSocketAddress("127.0.0.1", port);
     }
 
     private String getExternalIP(DockerAPI api, InspectContainerResponse ir, NetworkSettings networkSettings,


### PR DESCRIPTION
Lately i was trying out jenkins docker-slaves with the docker-plugin. 

Jenkins spawned the docker containers as configured but it could never connect to them. 
I tried to find out why for mutiple days, but i couldn't find aynthing(since the related Exception was silenced) . Then i decided to go ahead and add some log lines to the plugin and build it from source.

That's why i added some logging see : https://github.com/jenkinsci/docker-plugin/commit/a0da3d28b4c40666bc6952d0068e16d7b715c7aa

After adding this log lines i could finally see the reason why it couldn't connect:

> Testing connectivity to 0.0.0.0 port 33425
> This is a message from AppIDMan the socket didn't work because of: 
> Feb 11, 2019 10:47:57 AM WARNING com.nirima.jenkins.plugins.docker.utils.PortUtils$ConnectionCheck executeOnce
java.net.NoRouteToHostException: No route to host (Host unreachable)
>	at java.net.PlainSocketImpl.socketConnect(Native Method)
>	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
>	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:204)
>	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
>	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
>	at java.net.Socket.connect(Socket.java:589)
>	at java.net.Socket.connect(Socket.java:538)
>	at java.net.Socket.<init>(Socket.java:434)
>	at java.net.Socket.<init>(Socket.java:211)
>	at com.nirima.jenkins.plugins.docker.utils.PortUtils$ConnectionCheck.executeOnce(PortUtils.java:67)
>	at com.nirima.jenkins.plugins.docker.utils.PortUtils$ConnectionCheck.execute(PortUtils.java:84)
>	at io.jenkins.docker.connector.DockerComputerSSHConnector.createLauncher(DockerComputerSSHConnector.java:252)
>	at io.jenkins.docker.connector.DockerComputerConnector.createLauncher(DockerComputerConnector.java:91)
>	at com.nirima.jenkins.plugins.docker.DockerTemplate.doProvisionNode(DockerTemplate.java:566)
>	at com.nirima.jenkins.plugins.docker.DockerTemplate.provisionNode(DockerTemplate.java:528)
>	at com.nirima.jenkins.plugins.docker.DockerCloud$1.run(DockerCloud.java:364)
>	at jenkins.util.ContextResettingExecutorService$1.run(ContextResettingExecutorService.java:28)
>	at jenkins.security.ImpersonatingExecutorService$1.run(ImpersonatingExecutorService.java:59)
>	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
>	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
>	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
>	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
>	at java.lang.Thread.run(Thread.java:748)

The root cause of this issue is that when a Socket to ```0.0.0.0``` is opened in Java it **can** raise an NoRouteToHostException . I opened a StackOverflow question [here](https://stackoverflow.com/questions/54636989/java-socket-fails-to-connect-to-0-0-0-0-with-noroutetohostexception-instead-of) regarding investigation of the root cause. 

In order to fix/workaround https://github.com/jenkinsci/docker-plugin/commit/30a85b086ef6df57bd1bf776e88cbbf68eab7ab7 this problem i hardcoded host to ```127.0.0.1``` on ```PortUtils.java``` and ```DockerComputerSSHConnector.java``` . With this "fix" jenkins can connect to the docker slaves. 
I'm quite certain that this dirty fix I used is **not** the correct way to do it, i just included it so i can demonstrate to you what the issue is and how it can be resolved. 

I would really appreciate if you can make a real fix out of it if.
**Or** if you think this is a Environment Issue with my Server tell me how to fix it. 

Also I'd be really happy if you could include the logging of the exception this might help other people as well if there are some socket errors. 

Thank you.