### PR TITLE
Add a configuration for securityOptions

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -216,6 +216,15 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         return dockerTemplateBase.getExtraHostsString();
     }
 
+    @CheckForNull
+    public List<String> getSecurityOpts() {
+        return dockerTemplateBase.getSecurityOpts();
+    }
+
+    public String getSecurityOptsString() {
+        return dockerTemplateBase.getSecurityOptsString();
+    }
+
     public DockerRegistryEndpoint getRegistry() {
         return dockerTemplateBase.getRegistry();
     }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -104,6 +104,9 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
     @CheckForNull
     private List<String> extraHosts;
 
+    @CheckForNull
+    private List<String> securityOpts;
+
     @DataBoundConstructor
     public DockerTemplateBase(String image) {
         if (image == null) {
@@ -405,6 +408,16 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         return Joiner.on("\n").join(extraHosts);
     }
 
+    public String getSecurityOptsString() {
+        if (securityOpts == null) return null;
+        return Joiner.on("\n").join(securityOpts);
+    }
+
+    @DataBoundSetter
+    public void setSecurityOptsString(String securityOpts) {
+        this.securityOpts = splitAndFilterEmptyList(securityOpts, "\n");
+    }
+
     // -- UI binding End
 
 
@@ -642,6 +655,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         sb.append(", cpuShares=").append(cpuShares);
         sb.append(", shmSize=").append(shmSize);
         sb.append(", privileged=").append(privileged);
+        sb.append(", securityOpts=").append(securityOpts);
         sb.append(", tty=").append(tty);
         sb.append(", macAddress='").append(macAddress).append('\'');
         sb.append(", extraHosts=").append(extraHosts);
@@ -677,6 +691,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         if (cpuShares != null ? !cpuShares.equals(that.cpuShares) : that.cpuShares != null) return false;
         if (shmSize != null ? !shmSize.equals(that.shmSize) : that.shmSize != null) return false;
         if (macAddress != null ? !macAddress.equals(that.macAddress) : that.macAddress != null) return false;
+        if (securityOpts != null ? !securityOpts.equals(that.securityOpts) : that.securityOpts != null) return false;
         return extraHosts != null ? extraHosts.equals(that.extraHosts) : that.extraHosts == null;
     }
 
@@ -699,6 +714,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         result = 31 * result + (cpuShares != null ? cpuShares.hashCode() : 0);
         result = 31 * result + (shmSize != null ? shmSize.hashCode() : 0);
         result = 31 * result + (privileged ? 1 : 0);
+        result = 31 * result + (securityOpts != null ? securityOpts.hashCode() : 0);
         result = 31 * result + (tty ? 1 : 0);
         result = 31 * result + (macAddress != null ? macAddress.hashCode() : 0);
         result = 31 * result + (extraHosts != null ? extraHosts.hashCode() : 0);

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -426,7 +426,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
 
     @CheckForNull
     public List<String> getSecurityOpts() {
-        return this.securityOpts;
+        return securityOpts;
     }
 
     @CheckForNull

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -414,7 +414,9 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
     }
 
     public String getSecurityOptsString() {
-        if (securityOpts == null) return null;
+        if (securityOpts == null) {
+            return "";
+        }
         return Joiner.on("\n").join(securityOpts);
     }
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -427,21 +427,23 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         return Joiner.on("\n").join(extraHosts);
     }
 
-    @CheckForNull
+    @Nullable
     public List<String> getSecurityOpts() {
         return this.securityOpts;
     }
 
+    @Nullable
     public String getSecurityOptsString() {
-        if (securityOpts == null) return null;
-        return Joiner.on("\n").join(securityOpts);
+        return securityOpts == null ? null : Joiner.on("\n").join(securityOpts);
+    }
+
+    public void setSecurityOpts( List<String> securityOpts ) {
+        this.securityOpts = securityOpts;
     }
 
     @DataBoundSetter
     public void setSecurityOptsString(String securityOpts) {
-        this.securityOpts = isEmpty(securityOpts) ?
-                        Collections.emptyList() :
-                        splitAndFilterEmptyList(securityOpts, "\n");
+        setSecurityOpts( isEmpty(securityOpts) ? null : splitAndFilterEmptyList(securityOpts, "\n") );
     }
 
     @DataBoundSetter
@@ -835,9 +837,10 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         public FormValidation doCheckSecurityOptsString(@QueryParameter String securityOptsString) {
             final List<String> securityOpts = splitAndFilterEmptyList(securityOptsString, "\n");
             for (String securityOpt : securityOpts) {
-                if (securityOpt.trim().split("=").length < 2) {
-                    return FormValidation.error("Wrong security option format: '%s'", securityOpt);
+                if ( !( securityOpt.trim().split("=").length == 2 || securityOpt.trim().startsWith( "no-new-privileges" ) ) ) {
+                    return FormValidation.warning("Security option may be incorrect. Please double check syntax: '%s'", securityOpt);
                 }
+
             }
             return FormValidation.ok();
         }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -780,7 +780,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
             final List<String> extraHosts = splitAndFilterEmptyList(extraHostsString, "\n");
             for (String extraHost : extraHosts) {
                 if (extraHost.trim().split(":").length < 2) {
-                    return FormValidation.error("Wrong extraHost {}", extraHost);
+                    return FormValidation.error("Wrong extraHost format: '%s'", extraHost);
                 }
             }
             return FormValidation.ok();
@@ -790,7 +790,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
             final List<String> securityOpts = splitAndFilterEmptyList(securityOptsString, "\n");
             for (String securityOpt : securityOpts) {
                 if (securityOpt.trim().split("=").length < 2) {
-                    return FormValidation.error("Wrong security option: {}", securityOpt);
+                    return FormValidation.error("Wrong security option format: '%s'", securityOpt);
                 }
             }
             return FormValidation.ok();

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -1,21 +1,26 @@
 package com.nirima.jenkins.plugins.docker;
 
-import static org.apache.commons.lang.StringUtils.isEmpty;
-import static org.apache.commons.lang.StringUtils.trimToNull;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Volume;
+import com.github.dockerjava.api.model.VolumesFrom;
+import com.github.dockerjava.api.model.Device;
+import com.github.dockerjava.core.NameParser;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
+import com.nirima.jenkins.plugins.docker.utils.JenkinsUtils;
+import hudson.Extension;
+import hudson.Util;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
@@ -25,28 +30,20 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.model.Bind;
-import com.github.dockerjava.api.model.Device;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Volume;
-import com.github.dockerjava.api.model.VolumesFrom;
-import com.github.dockerjava.core.NameParser;
-import com.google.common.base.Function;
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
-import com.google.common.collect.Iterables;
-import com.nirima.jenkins.plugins.docker.utils.JenkinsUtils;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
-import hudson.Extension;
-import hudson.Util;
-import hudson.model.Describable;
-import hudson.model.Descriptor;
-import hudson.model.Item;
-import hudson.util.FormValidation;
-import hudson.util.ListBoxModel;
-import jenkins.model.Jenkins;
+import static org.apache.commons.lang.StringUtils.isEmpty;
+import static org.apache.commons.lang.StringUtils.trimToNull;
 
 /**
  * Base for docker templates - does not include Jenkins items like labels.

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -414,15 +414,15 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
     }
 
     public String getSecurityOptsString() {
-        if (securityOpts == null) {
-            return "";
-        }
+        if (securityOpts == null) return null;
         return Joiner.on("\n").join(securityOpts);
     }
 
     @DataBoundSetter
     public void setSecurityOptsString(String securityOpts) {
-        this.securityOpts = splitAndFilterEmptyList(securityOpts, "\n");
+        this.securityOpts = isEmpty(securityOpts) ?
+                        Collections.emptyList() :
+                        splitAndFilterEmptyList(securityOpts, "\n");
     }
 
     // -- UI binding End
@@ -781,6 +781,16 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
             for (String extraHost : extraHosts) {
                 if (extraHost.trim().split(":").length < 2) {
                     return FormValidation.error("Wrong extraHost {}", extraHost);
+                }
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckSecurityOptsString(@QueryParameter String securityOptsString) {
+            final List<String> securityOpts = splitAndFilterEmptyList(securityOptsString, "\n");
+            for (String securityOpt : securityOpts) {
+                if (securityOpt.trim().split("=").length < 2) {
+                    return FormValidation.error("Wrong security option: {}", securityOpt);
                 }
             }
             return FormValidation.ok();

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -427,12 +427,12 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         return Joiner.on("\n").join(extraHosts);
     }
 
-    @Nullable
+    @CheckForNull
     public List<String> getSecurityOpts() {
         return this.securityOpts;
     }
 
-    @Nullable
+    @CheckForNull
     public String getSecurityOptsString() {
         return securityOpts == null ? null : Joiner.on("\n").join(securityOpts);
     }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -837,7 +837,6 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
                 if ( !( securityOpt.trim().split("=").length == 2 || securityOpt.trim().startsWith( "no-new-privileges" ) ) ) {
                     return FormValidation.warning("Security option may be incorrect. Please double check syntax: '%s'", securityOpt);
                 }
-
             }
             return FormValidation.ok();
         }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -408,6 +408,11 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         return Joiner.on("\n").join(extraHosts);
     }
 
+    @CheckForNull
+    public List<String> getSecurityOpts() {
+        return this.securityOpts;
+    }
+
     public String getSecurityOptsString() {
         if (securityOpts == null) return null;
         return Joiner.on("\n").join(securityOpts);
@@ -598,6 +603,11 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         if (shmSize != null && shmSize > 0) {
             final Long shmSizeInByte = shmSize * 1024L * 1024L;
             containerConfig.getHostConfig().withShmSize(shmSizeInByte);
+        }
+
+        final List<String> securityOptions = getSecurityOpts();
+        if (CollectionUtils.isNotEmpty(securityOptions)) {
+            containerConfig.getHostConfig().withSecurityOpts( securityOptions );
         }
 
         return containerConfig;

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
@@ -75,7 +75,7 @@
       <span class="warning">at your own risk</span>
     </f:entry>
 
-    <f:entry title="${%Security Options}" field="securityOpts">
+    <f:entry title="${%Security Options}" field="securityOptsString">
       <f:expandableTextbox />
     </f:entry>
 

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
@@ -75,6 +75,10 @@
       <span class="warning">at your own risk</span>
     </f:entry>
 
+    <f:entry title="${%Security Options}" field="securityOpts">
+      <f:expandableTextbox />
+    </f:entry>
+
     <f:entry title="${%Allocate a pseudo-TTY}" field="tty">
       <f:checkbox />
     </f:entry>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-securityOpts.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-securityOpts.html
@@ -1,0 +1,3 @@
+<div>
+    A list of new line separated security options.
+</div>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-securityOpts.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-securityOpts.html
@@ -1,3 +1,5 @@
 <div>
-    A list of new line separated security options.
+    <p>A list of new line separated security options.</p>
+    <p>Each line represents an option for the <i>--security-opt</i> parameter sent to the docker server. The options are in the format <code>key=value</code>.</p>
+    <p>Please check <a href="https://docs.docker.com/engine/reference/run/#security-configuration">https://docs.docker.com/engine/reference/run/#security-configuration</a> for further information.
 </div>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-securityOptsString.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-securityOptsString.html
@@ -1,5 +1,5 @@
 <div>
     <p>A list of new line separated security options.</p>
-    <p>Each line represents an option for the <i>--security-opt</i> parameter sent to the docker server. The options are in the format <code>key=value</code>.</p>
+    <p>Each line represents an option for the <code>--security-opt</code> parameter sent to the docker server. The options are in the format <code>key=value</code>.</p>
     <p>Please check <a href="https://docs.docker.com/engine/reference/run/#security-configuration">https://docs.docker.com/engine/reference/run/#security-configuration</a> for further information.
 </div>


### PR DESCRIPTION
Setting the security options are required to add a windows docker container to an Active Directory. The Docker-Java plugin supports this options.

AFAIK this has been in discussion about two years ago, but was discarded due to the docker-java plugin not being able to set the option either. That has changed last December.