### PR TITLE
Support setting additional labels on slave containers

### DIFF
--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
@@ -87,6 +87,10 @@
       <f:expandableTextbox />
     </f:entry>
 
+    <f:entry title="${%Extra Docker Labels}" field="extraDockerLabelsString">
+      <f:expandableTextbox />
+    </f:entry>
+
     </f:nested>
   </f:advanced>
 

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-extraDockerLabelsString.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-extraDockerLabelsString.html
@@ -1,0 +1,20 @@
+<div>
+    <p>A list of new line separated <em>docker</em> labels to be set on the container,
+    Specified in the form <code>"label_name=value"</code>.</p>
+
+    <p>This has no effect on Jenkins functionality, and is not related to the labels
+    used by Jenkins to map jobs to slave nodes. These labels are metadata attached
+    to the docker container itself (again, not the jenkins slave), and which can
+    typically be read using the <code>docker inspect</code> command.</p>
+
+    <p>This can be useful when using a docker cluster (like docker swarm) to pass
+    information to the scheduler, in conjunction with constraints; or to let
+    other services (portainer, prometheus...) know how they should categorize or
+    otherwise deal with this specific container.</p>
+
+    <p style="margin-bottom: 0">Notes:</p>
+    <ul style="margin-top: 0">
+    <li>spaces are the beginning and end of the label name and value will be removed</li>
+    <li>invalid lines will be ignored</li>
+    </ul>
+</div>


### PR DESCRIPTION
This patch adds an extraLabels fields to DockerTemplateBase, which is used to specify additional docker labels to set on slave containers.

This can be used for example to logically group containers, or to setup scheduling constraints on swarm.