### PR TITLE
Slave nodes get a copy of the template node properties

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -256,8 +256,6 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         return dockerTemplateBase.getFullImageId();
     }
 
-
-
     public DockerTemplateBase getDockerTemplateBase() {
         return dockerTemplateBase;
     }
@@ -346,7 +344,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
     public List<? extends NodeProperty<?>> getNodeProperties() {
         return Collections.unmodifiableList(nodeProperties);
     }
-    
+
     @DataBoundSetter
     public void setNodeProperties(List<? extends NodeProperty<?>> nodeProperties) {
         this.nodeProperties = nodeProperties;
@@ -442,7 +440,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         template.setPullStrategy(pullStrategy);
         template.setRemoveVolumes(removeVolumes);
         template.setRetentionStrategy((DockerOnceRetentionStrategy) retentionStrategy);
-        template.setNodeProperties(nodeProperties);
+        template.setNodeProperties(makeCopyOfList(nodeProperties));
         return template;
     }
 
@@ -564,13 +562,12 @@ public class DockerTemplate implements Describable<DockerTemplate> {
             connector.afterContainerStarted(api, remoteFs, containerId);
 
             final ComputerLauncher launcher = connector.createLauncher(api, containerId, remoteFs, listener);
-    
             final DockerTransientNode node = new DockerTransientNode(nodeName, containerId, remoteFs, launcher);
             node.setNodeDescription("Docker Agent [" + getImage() + " on "+ api.getDockerHost().getUri() + " ID " + containerId + "]");
             node.setMode(mode);
             node.setLabelString(labelString);
             node.setRetentionStrategy(retentionStrategy);
-            robustlySetNodeProperties(node, nodeProperties);
+            robustlySetNodeProperties(node, makeCopyOfList(nodeProperties));
             node.setRemoveVolumes(removeVolumes);
             node.setDockerAPI(api);
             finallyRemoveTheContainer = false;
@@ -588,6 +585,23 @@ public class DockerTemplate implements Describable<DockerTemplate> {
                 }
             }
         }
+    }
+
+    private static <T> List<T> makeCopyOfList(List<? extends T> listOrNull) {
+        final List<? extends T> originalList = Util.fixNull(listOrNull);
+        final List<T> copyList = new ArrayList<T>(originalList.size());
+        for( final T originalElement : originalList) {
+            final T copyOfElement = makeCopy(originalElement);
+            copyList.add(copyOfElement);
+        }
+        return copyList;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T makeCopy(final T original) {
+        final String xml = Jenkins.XSTREAM.toXML(original);
+        final Object copy = Jenkins.XSTREAM.fromXML(xml);
+        return (T) copy;
     }
 
     /**
@@ -701,7 +715,6 @@ public class DockerTemplate implements Describable<DockerTemplate> {
          * Get a list of all {@link NodePropertyDescriptor}s we can use to define DockerSlave NodeProperties.
          */
         public List<NodePropertyDescriptor> getNodePropertiesDescriptors() {
-
             // Copy/paste hudson.model.Slave.SlaveDescriptor.nodePropertyDescriptors marked as @Restricted for reasons I don't get
             List<NodePropertyDescriptor> result = new ArrayList<>();
             Collection<NodePropertyDescriptor> list =
@@ -711,8 +724,6 @@ public class DockerTemplate implements Describable<DockerTemplate> {
                     result.add(npd);
                 }
             }
-
-
             final Iterator<NodePropertyDescriptor> iterator = result.iterator();
             while (iterator.hasNext()) {
                 final NodePropertyDescriptor de = iterator.next();


### PR DESCRIPTION
During the review of [openstack-cloud-plugin PR 270](https://github.com/jenkinsci/openstack-cloud-plugin/pull/270), [concerns were raised](https://github.com/jenkinsci/openstack-cloud-plugin/pull/270#discussion_r317550457) about slave nodes sharing the same instance of node properties; the belief is that not all node properties are stateless and some may assume that they're only dealing with a single node.
i.e. we should deep-copy the node properties, not merely pass by reference.

So we came up with [code](https://github.com/jenkinsci/openstack-cloud-plugin/pull/270#discussion_r318989562) that copied the node properties.

The docker plugin has the same issue; this applies the same fix.