### PR TITLE
Legal stuff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 - First, and most importantly, make sure you're in the right place.
 There's more than one docker plugin on Jenkins and raising an issue for one plugin in the issues for another just wastes everyone's time (including yours).
-See the README.md file for details.
+See the [README.md](README.md) file for details.
 - Be helpful and make no demands.
   * This code is Free Open-Source Software - if you're not paying me then it's not "my job" to make it "work for you".
   * If you're reporting and fixing an issue yourself then you only need to explain what problem you're fixing in enough detail that the maintainer(s) can understand why your changes are in the public interest.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 - First, and most importantly, make sure you're in the right place.
 There's more than one docker plugin for Jenkins and raising an issue about one plugin in the issues area for another plugin causes a lot of confusion.
-See the [README.md](README.md) file for details.
+See the [README](README.md) file for details.
 - Please do not use the issue tracker to ask questions.
 This facility is for reporting (and fixing) bugs in the code.
 If you're not 100% sure it's a bug in the code then please seek help elsewhere.
@@ -17,8 +17,9 @@ The [plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Docker+Plugin) 
 
 # Legal conditions
 
-- Any contributions (code, information etc) submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
-- As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
+- Any contributions (code, information etc) submitted will be subject to the same [license](LICENSE) as the rest of the code.
+No new restrictions/conditions are permitted.
+- As a contributor, you MUST have the legal right to grant permission for your contribution to be used under these conditions.
 
 # Reporting a new issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # General
 
 - First, and most importantly, make sure you're in the right place.
-There's more than one docker plugin on Jenkins and raising an issue for one plugin in the issues for another just wastes everyone's time (including yours).
+There's more than one docker plugin on Jenkins and raising an issue about one plugin in the issues area for another plugin causes a lot of confusion.
 See the [README.md](README.md) file for details.
 - Be helpful and make no demands.
-  * This code is Free Open-Source Software - if you're not paying me then it's not "my job" to make it "work for you".
+  * This code is Free Open-Source Software - nobody is obliged to make things work for you *but* you have legal permission to fix things yourself.
   * If you're reporting and fixing an issue yourself then you only need to explain what problem you're fixing in enough detail that the maintainer(s) can understand why your changes are in the public interest.
-  * If you're relying on someone else to fix a problem then you need to make it as easy as possible for others to fix it for you, and you need to test any fixes provided.
+  * If you're relying on someone else to fix a problem then you should to make it as easy as possible for others to fix it for you, and you should test any fixes provided.
 
 # Creating new issue
 
@@ -15,7 +15,7 @@ See the [README.md](README.md) file for details.
   * How is this failing?
   * What should happen instead?
 - Provide step-by-step instructions for how to reproduce the issue.
-  * Try to avoid relying on custom docker images or for the repro case.  Ideally, reproduce with a `jenkins/(ssh-slave|jnlp-slave|slave)` image with a dumb freestyle job, as that makes life easier for everyone.
+  * Try to avoid relying on custom docker images or for the repro case. Ideally, reproduce with a `jenkins/(ssh-slave|jnlp-slave|slave)` image with a dumb freestyle job, as that makes life easier for everyone.
 - Specify the Jenkins core version you're seeing the issue with, along with a full list of installed plugins with versions.
 - Check `Manage Jenkins` -> `Manage Old Data` for out of date configuration data and provide this info.
 - Check and provide errors from system jenkins.log and errors from `Manage Jenkins` -> `System Log`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,66 @@
+# General
+
+- First, and most importantly, make sure you're in the right place.
+There's more than one docker plugin on Jenkins and raising an issue for one plugin in the issues for another just wastes everyone's time (including yours).
+See the README.md file for details.
+- Be helpful and make no demands.
+  * This code is Free Open-Source Software - if you're not paying me then it's not "my job" to make it "work for you".
+  * If you're reporting and fixing an issue yourself then you only need to explain what problem you're fixing in enough detail that the maintainer(s) can understand why your changes are in the public interest.
+  * If you're relying on someone else to fix a problem then you need to make it as easy as possible for others to fix it for you, and you need to test any fixes provided.
+
 # Creating new issue
 
-- try reproduce with `jenkins/(ssh-slave|jnlp-slave|slave)` image with dumb freestyle job
-- provide full description of issue
-- check `Manage Jenkins` -> `Manage Old Data` for not updated configuraiton and provide this info
-- provide full list of installed plugins with versions, jenkins core version
-- check and provide errors from system jenkins.log and errors from `Manage Jenkins` -> `System Log`
-- provide Cloud section from $JENKINS_HOME/config.xml file
-- describe how your docker infrastructure looks like
-- provide docker host/api version
-- provide steps for reproducing
-- any code or log example surround with right markdown https://help.github.com/articles/github-flavored-markdown/
+- Provide a full description of the issue you are facing.
+  * What are you trying to do?
+  * How is this failing?
+  * What should happen instead?
+- Provide step-by-step instructions for how to reproduce the issue.
+  * Try to avoid relying on custom docker images or for the repro case.  Ideally, reproduce with a `jenkins/(ssh-slave|jnlp-slave|slave)` image with a dumb freestyle job, as that makes life easier for everyone.
+- Specify the Jenkins core version you're seeing the issue with, along with a full list of installed plugins with versions.
+- Check `Manage Jenkins` -> `Manage Old Data` for out of date configuration data and provide this info.
+- Check and provide errors from system jenkins.log and errors from `Manage Jenkins` -> `System Log`.
+  * If that log is too verbose, create a `docker-plugin` log that only logs `com.nirima.jenkins.plugin.docker` and `io.jenkins.docker` (e.g. at level "ALL") and grab what's logged when you reproduce the issue.
+  * Exceptions and stacktraces are *especially* useful, so don't omit those...
+  * ...except please note that exceptions logged by the docker-java library are "expected behaviour" (include those, but don't worry about them).
+  * Note that sensitive information may be visible in logs, so take care to redact logs where necessary.
+- Provide a copy/paste of the `Cloud` section from $JENKINS_HOME/config.xml file (redacted where neccessary).
+- Describe what your docker infrastructure looks like, e.g. single vs multiple, hosts vs swarms, where Jenkins is in relation to that etc.
+- Provide docker host/api version.
+- Ensure that any code or log example surround with right markdown https://help.github.com/articles/github-flavored-markdown/ otherwise it'll be unreadable.
 
 # For pull requests
 
-- Refer to some existed issue or provide description like for issue
+- Legal notice:
+  * Any code submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
+  * As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
+- A PR's description must EITHER refer to an existing issue (either in github or on Jenkins JIRA) OR include a full description as for "Creating new issue".
+- A single PR should EITHER be making functional changes OR making (non-functional) cosmetic/refactoring changes to the code.
+Please do not do both in the same PR or it makes life difficult for anyone else merging your changes.
+- For functional-change PRs, keep changes to a minimum (to make merges easier).
+- Coding style:
+  * Try to fit in.
+  Not all of the code within this plugin is written in the same "style".
+  Any changes you make must fit in with the existing style that is prevalent within the area in which you are working.
+  i.e. code in the same style that the existing method/class/package uses.
+  * If you can't tolerate inconsistencies, submit a cosmetic PR that applies the formatting/whitespace/non-functional changes that you want made.
+  * If in doubt, use 4 spaces for indentation, avoid using tabs, avoid trailing whitespace and make sure every file ends with a newline.
+- Unit tests:
+  * Any new functionality must be unit tested.
+  * PRs that add unit-tests for existing functionality will be very welcome too.
+  * Unit tests should be as fast as possible but *must* be reliable (Tests that behave inconsistently cause trouble for everyone else trying to work on the code).
+- Clean builds:
+  * Any submitted PRs should automatically get built and tested; PRs will not be considered for merger until they are showing a clean build.
+  If you believe that the build failed for reasons unconnected to your changes, close your PR, wait 10 minutes, then re-open it (just re-open the same PR; don't create a new one) to trigger a rebuild.
+  Repeat until it builds clean, changing your code if necessary.
+  * Don't give findbugs anything new to complain about.
+  * Don't give the compiler/IDEs anything new to warn about.
+- Preserve existing functionality by default:
+  * Make sure that existing users don't find that their functionality has changed after they've upgraded from an old version of the plugin to a version of the plugin that contains your changes.
+  * When adding new functionality, make sure the defaults are unchanged so that nobody finds new, unexpected, things happening after upgrading.
+- Configuration data changes:
+  * If the PR adds a new field to an existing (or new) data structure, make sure you've written good help text for it that explains what it's for, why it's useful, and an example.
+  Implement corresponding `doCheck` methods to provide validation when users are entering this data from the WebUI.
+  * If the PR changes an existing field, make sure that the code copes with reading in data from older versions of the plugin.
 
 # Links
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,26 @@
 # General
 
 - First, and most importantly, make sure you're in the right place.
-There's more than one docker plugin on Jenkins and raising an issue about one plugin in the issues area for another plugin causes a lot of confusion.
+There's more than one docker plugin for Jenkins and raising an issue about one plugin in the issues area for another plugin causes a lot of confusion.
 See the [README.md](README.md) file for details.
+- Please do not use the issue tracker to ask questions.
+This facility is for reporting (and fixing) bugs in the code.
+If you're not 100% sure it's a bug in the code then please seek help elsewhere.
+e.g. the [jenkins-users google group](https://groups.google.com/forum/#!forum/jenkinsci-users).
+- [RTFM](https://en.wikipedia.org/wiki/RTFM).
+The Jenkins UI pages include help that should explain things.
+The [plugin's wiki page](https://wiki.jenkins.io/display/JENKINS/Docker+Plugin) gives additional information.
 - Be helpful and make no demands.
   * This code is Free Open-Source Software - nobody is obliged to make things work for you *but* you have legal permission to fix things yourself.
   * If you're reporting and fixing an issue yourself then you only need to explain what problem you're fixing in enough detail that the maintainer(s) can understand why your changes are in the public interest.
   * If you're relying on someone else to fix a problem then you should to make it as easy as possible for others to fix it for you, and you should test any fixes provided.
 
-# Creating new issue
+# Legal conditions
+
+- Any contributions (code, information etc) submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
+- As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
+
+# Reporting a new issue
 
 - Provide a full description of the issue you are facing.
   * What are you trying to do?
@@ -16,7 +28,7 @@ See the [README.md](README.md) file for details.
   * What should happen instead?
 - Provide step-by-step instructions for how to reproduce the issue.
   * Try to avoid relying on custom docker images or for the repro case. Ideally, reproduce with a `jenkins/(ssh-slave|jnlp-slave|slave)` image with a dumb freestyle job, as that makes life easier for everyone.
-- Specify the Jenkins core version you're seeing the issue with, along with a full list of installed plugins with versions.
+- Specify the Jenkins core & plugin version (of all docker-related plugins) that you're seeing the issue with.
 - Check `Manage Jenkins` -> `Manage Old Data` for out of date configuration data and provide this info.
 - Check and provide errors from system jenkins.log and errors from `Manage Jenkins` -> `System Log`.
   * If that log is too verbose, create a `docker-plugin` log that only logs `com.nirima.jenkins.plugin.docker` and `io.jenkins.docker` (e.g. at level "ALL") and grab what's logged when you reproduce the issue.
@@ -26,16 +38,13 @@ See the [README.md](README.md) file for details.
 - Provide a copy/paste of the `Cloud` section from $JENKINS_HOME/config.xml file (redacted where neccessary).
 - Describe what your docker infrastructure looks like, e.g. single vs multiple, hosts vs swarms, where Jenkins is in relation to that etc.
 - Provide docker host/api version.
-- Ensure that any code or log example surround with right markdown https://help.github.com/articles/github-flavored-markdown/ otherwise it'll be unreadable.
+- Ensure that any code or log example surround with [the right markdown](https://help.github.com/articles/github-flavored-markdown/) otherwise it'll be unreadable.
 
-# For pull requests
+# Submitting pull requests
 
-- Legal notice:
-  * Any code submitted will be subject to the same license as the rest of the code. No new restrictions/conditions are permitted.
-  * As a contributor, you MUST have the legal right to grant permission for the contribution to be used under these conditions.
 - A PR's description must EITHER refer to an existing issue (either in github or on Jenkins JIRA) OR include a full description as for "Creating new issue".
 - A single PR should EITHER be making functional changes OR making (non-functional) cosmetic/refactoring changes to the code.
-Please do not do both in the same PR or it makes life difficult for anyone else merging your changes.
+Please do not do both in the same PR as this makes life difficult for anyone else merging your changes.
 - For functional-change PRs, keep changes to a minimum (to make merges easier).
 - Coding style:
   * Try to fit in.
@@ -48,12 +57,12 @@ Please do not do both in the same PR or it makes life difficult for anyone else 
   * Any new functionality must be unit tested.
   * PRs that add unit-tests for existing functionality will be very welcome too.
   * Unit tests should be as fast as possible but *must* be reliable (Tests that behave inconsistently cause trouble for everyone else trying to work on the code).
-- Clean builds:
+- Clean build & test:
   * Any submitted PRs should automatically get built and tested; PRs will not be considered for merger until they are showing a clean build.
   If you believe that the build failed for reasons unconnected to your changes, close your PR, wait 10 minutes, then re-open it (just re-open the same PR; don't create a new one) to trigger a rebuild.
   Repeat until it builds clean, changing your code if necessary.
-  * Don't give findbugs anything new to complain about.
-  * Don't give the compiler/IDEs anything new to warn about.
+  * Please provide unit-tests for your contribution.
+  * Don't give findbugs, the compiler or any IDEs anything new to complain about.
 - Preserve existing functionality by default:
   * Where possible, ensure that existing users don't find that their functionality has changed after they've upgraded from an old version of the plugin to a version of the plugin that contains your changes.
   * When adding new functionality, try to keep the defaults are unchanged so that nobody finds new, unexpected, things happening after upgrading.
@@ -65,5 +74,6 @@ Please do not do both in the same PR or it makes life difficult for anyone else 
 
 # Links
 
-- https://wiki.jenkins-ci.org/display/JENKINS/Beginners+Guide+to+Contributing
-- https://wiki.jenkins-ci.org/display/JENKINS/Extend+Jenkins
+- https://wiki.jenkins.io/display/JENKINS/Docker+Plugin
+- https://wiki.jenkins.io/display/JENKINS/Beginners+Guide+to+Contributing
+- https://wiki.jenkins.io/display/JENKINS/Extend+Jenkins

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Please do not do both in the same PR or it makes life difficult for anyone else 
   Any changes you make must fit in with the existing style that is prevalent within the area in which you are working.
   i.e. code in the same style that the existing method/class/package uses.
   * If you can't tolerate inconsistencies, submit a cosmetic PR that applies the formatting/whitespace/non-functional changes that you want made.
-  * If in doubt, use 4 spaces for indentation, avoid using tabs, avoid trailing whitespace and make sure every file ends with a newline.
+  * If in doubt, use 4 spaces for indentation, avoid using tabs, avoid trailing whitespace, use unix end-of-line codes (LF, not CR/LF), and make sure every file ends with a newline.
 - Unit tests:
   * Any new functionality must be unit tested.
   * PRs that add unit-tests for existing functionality will be very welcome too.
@@ -55,8 +55,9 @@ Please do not do both in the same PR or it makes life difficult for anyone else 
   * Don't give findbugs anything new to complain about.
   * Don't give the compiler/IDEs anything new to warn about.
 - Preserve existing functionality by default:
-  * Make sure that existing users don't find that their functionality has changed after they've upgraded from an old version of the plugin to a version of the plugin that contains your changes.
-  * When adding new functionality, make sure the defaults are unchanged so that nobody finds new, unexpected, things happening after upgrading.
+  * Where possible, ensure that existing users don't find that their functionality has changed after they've upgraded from an old version of the plugin to a version of the plugin that contains your changes.
+  * When adding new functionality, try to keep the defaults are unchanged so that nobody finds new, unexpected, things happening after upgrading.
+  * Ensure any breaking changes are well documented in the PR description.
 - Configuration data changes:
   * If the PR adds a new field to an existing (or new) data structure, make sure you've written good help text for it that explains what it's for, why it's useful, and an example.
   Implement corresponding `doCheck` methods to provide validation when users are entering this data from the WebUI.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -4,6 +4,11 @@ If you get some troubles with docker and Jenkins then you first need to determin
 There is more than one plugin for Jenkins that provides docker-related capabilities, and this is just one of them.
 See the README.md file for further details.
 
+Note: The stacktrace(s) you see will also indicate which plugin is causing the issue.
+If none of the classes mentioned in the exception stacktrace are classes from this plugin then it probably is not originating from this plugin.
+
+Please read CONTRIBUTING.md as well, as that's got a lot of useful information in there too that'll help people help you.
+
 If you are sure that this plugin is the source of your troubles then please report:
  - [ ] docker-plugin version you use
  - [ ] jenkins version you use
@@ -11,7 +16,5 @@ If you are sure that this plugin is the source of your troubles then please repo
  - [ ] details of the docker container(s) involved and details of how the docker-plugin is connecting to them
  - [ ] stack trace / logs / any technical details that could help diagnose this issue
 
-Note: The stacktrace(s) you see will also indicate which plugin is causing the issue.
-If none of the classes mentioned in the exception stacktrace are classes from this plugin then it probably is not originating from this plugin.
 
 Lastly, before submitting a bug report, remove this explanatory text, leaving just the important information.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,12 +2,12 @@ Firstly, please do not use the issue tracker to ask questions, join jenkins-user
 
 If you get some troubles with docker and Jenkins then you first need to determine which plugin you are using.
 There is more than one plugin for Jenkins that provides docker-related capabilities, and this is just one of them.
-See the README.md file for further details.
+See the [README.md](README.md) file for further details.
 
 Note: The stacktrace(s) you see will also indicate which plugin is causing the issue.
 If none of the classes mentioned in the exception stacktrace are classes from this plugin then it probably is not originating from this plugin.
 
-Please read CONTRIBUTING.md as well, as that's got a lot of useful information in there too that'll help people help you.
+Please read [the contribution guidelines](CONTRIBUTING.md) as well, as that's got a lot of useful information in there too that'll help people help you.
 
 If you are sure that this plugin is the source of your troubles then please report:
  - [ ] docker-plugin version you use

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-docker-plugin
-=============
+# Docker plugin for Jenkins
 
 [![Build Status](https://ci.jenkins.io/buildStatus/icon?job=Plugins/docker-plugin/master)](https://ci.jenkins.io/job/Plugins/job/docker-plugin/job/master/)
 
@@ -22,4 +21,5 @@ and Jenkins can then run docker containers to provide Jenkins (slave) Nodes on w
 
 More documentation available on the Jenkins wiki: https://plugins.jenkins.io/docker-plugin
 
-Note: There is more than one docker plugin for Jenkins and if you are using Jenkins [pipeline / workflow / Jenkinsfile](https://jenkins.io/doc/book/pipeline/docker/) builds with code including terms like `docker.withDockerRegistry` or `docker.image` etc as provided by the [`docker-workflow`](https://plugins.jenkins.io/docker-workflow) plugin then _this is not the repository you are looking for_.
+Note: There is more than one docker plugin for Jenkins.
+e.g. if you are using Jenkins [pipeline / workflow / Jenkinsfile](https://jenkins.io/doc/book/pipeline/docker/) builds with code including terms like `docker.withDockerRegistry` or `docker.image` etc then you're using the [`docker-workflow`](https://plugins.jenkins.io/docker-workflow) plugin and should probably go to its repository instead of this one.

--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,34 @@
     <name>Docker plugin</name>
     <description>Provide Cloud Provisioning and other Docker features</description>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Docker+Plugin</url>
-    
+    <licenses>
+        <license>
+            <name>The MIT license</name>
+            <url>https://www.opensource.org/licenses/mit</url>
+            <distribution>repo</distribution>
+        </license>
+     </licenses>
+
     <developers>
-        <developer>
+        <!--
+        Previous maintainers "hall of fame":
+        <developer> 2014-2016
+            <id>magnayn</id>
+            <name>Nigel Magnay</name>
+        </developer>
+        <developer> 2015
+            <id>KostyaSha</id>
+            <name>Kanstantsin Shautsou</name>
+            <timezone>UTC+3</timezone>
+        </developer>
+        <developer> 2017-2018
             <id>ndeloof</id>
             <name>Nicolas De Loof</name>
+        </developer>
+        -->
+        <developer> <!-- 2018... -->
+            <id>pjdarton</id>
+            <name>Peter Darton</name>
         </developer>
     </developers>
 
@@ -160,8 +183,6 @@
             <version>3.0.0</version>
         </dependency>
 
-
-
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness-tools</artifactId>
@@ -201,13 +222,13 @@
                 <artifactId>findbugs-maven-plugin</artifactId>
                 <configuration>
                     <failOnError>false</failOnError>     <!-- FIXME need to review findbugs errors -->
-                </configuration>                 
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <failOnError>false</failOnError>
-                </configuration>                 
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
@@ -257,7 +278,6 @@
       </profile>
     </profiles>
 
-
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/docker-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/docker-plugin.git</developerConnection>
@@ -277,6 +297,5 @@
             <url>http://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -19,32 +19,41 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Docker+Plugin</url>
     <licenses>
         <license>
-            <name>The MIT license</name>
-            <url>https://www.opensource.org/licenses/mit</url>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
             <distribution>repo</distribution>
         </license>
      </licenses>
 
     <developers>
-        <!--
-        Previous maintainers "hall of fame":
-        <developer> 2014-2016
+        <developer>
             <id>magnayn</id>
             <name>Nigel Magnay</name>
+            <roles>
+                <role>maintainer (retired)</role>
+            </roles>
         </developer>
-        <developer> 2015
+        <developer>
             <id>KostyaSha</id>
             <name>Kanstantsin Shautsou</name>
             <timezone>UTC+3</timezone>
+            <roles>
+                <role>maintainer (retired)</role>
+            </roles>
         </developer>
-        <developer> 2017-2018
+        <developer>
             <id>ndeloof</id>
             <name>Nicolas De Loof</name>
+            <roles>
+                <role>maintainer (retired)</role>
+            </roles>
         </developer>
-        -->
-        <developer> <!-- 2018... -->
+        <developer>
             <id>pjdarton</id>
             <name>Peter Darton</name>
+            <roles>
+                <role>maintainer</role>
+            </roles>
         </developer>
     </developers>
 


### PR DESCRIPTION
Existing contribution guidelines didn't mention the requirement that *ALL* contributions have to be released under the same license as the rest of the plugin (MIT in this case).
My friendly corporate lawyer suggested that it'd be a good idea to make this clear.

I've also added a ton of other "if you're writing a PR, please ensure..." stuff in the hope that folks might do that.

See also similar PRs, as any comments/changes there may be relevant here:
1. https://github.com/jenkinsci/extra-tool-installers-plugin/pull/17
1. https://github.com/jenkinsci/vsphere-cloud-plugin/pull/109
1. https://github.com/jenkinsci/wsclean-plugin/pull/8