### PR TITLE
Fix retries=0 bug in PortUtils.ConnectionCheckSSH

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/utils/PortUtils.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/utils/PortUtils.java
@@ -157,7 +157,7 @@ public class PortUtils {
         public boolean execute() throws InterruptedException {
             checkState(parent.execute(), "Port %s is not opened to connect to", parent.port);
 
-            final int retries = Math.min(0, parent.retries);
+            final int retries = Math.max(0, parent.retries);
             final long retryDelay = parent.retryDelay;
             final int totalTriesIntended = retries + 1;
             int thisTryNumber;
@@ -172,16 +172,16 @@ public class PortUtils {
         }
 
         private boolean executeOnce(final int thisTryNumber, final int totalTriesIntended) {
-            final Connection connection = new Connection(parent.host, parent.port);
+            final Connection sshConnection = new Connection(parent.host, parent.port);
             try {
-                connection.connect(null, 0, sshTimeoutMillis, sshTimeoutMillis);
+                sshConnection.connect(null, 0, sshTimeoutMillis, sshTimeoutMillis);
                 LOGGER.info("SSH port is open on {}:{}", parent.host, parent.port);
                 return true;
             } catch (IOException e) {
                 LOGGER.error("Failed to connect to {}:{} (try {}/{}) - {}", parent.host, parent.port, thisTryNumber, totalTriesIntended, e.getMessage());
                 return false;
             } finally {
-                connection.close();
+                sshConnection.close();
             }
         }
     }

--- a/src/test/java/com/nirima/jenkins/plugins/docker/utils/PortUtilsTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/utils/PortUtilsTest.java
@@ -7,7 +7,6 @@ import org.junit.rules.ExternalResource;
 
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.Date;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -15,10 +14,8 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.allOf;
 
@@ -28,7 +25,7 @@ import static org.hamcrest.Matchers.allOf;
 public class PortUtilsTest {
     /** number of tries minus 1 */
     public static final int RETRY_COUNT = 2;
-    /** milliseconds */
+    /** 1 second in milliseconds */
     public static final int DELAY = (int) SECONDS.toMillis(1);
 
     @Rule
@@ -40,13 +37,13 @@ public class PortUtilsTest {
     @Test
     public void shouldConnectToServerSuccessfully() throws Exception {
         assertThat("Server is up and should connect",
-                PortUtils.connectionCheck(server.host(), server.port()).executeOnce(), is(true));
+                PortUtils.connectionCheck(server.host(), server.port()).executeOnce(), equalTo(true));
     }
 
     @Test
     public void shouldNotConnectToUnusedPort() throws Exception {
         assertThat("Unused port should not be connectible", PortUtils.connectionCheck("localhost", 0).executeOnce(),
-                is(false));
+                equalTo(false));
     }
 
     @Test
@@ -64,7 +61,7 @@ public class PortUtilsTest {
         final long actualDuration = after - before;
 
         // Then
-        assertThat("Unused port should not be connectible", actual, is(false));
+        assertThat("Unused port should not be connectible", actual, equalTo(false));
         assertThat("Should wait for timeout", actualDuration,
                 allOf(greaterThanOrEqualTo(minExpectedTime), lessThanOrEqualTo(maxExpectedTime)));
     }
@@ -91,7 +88,7 @@ public class PortUtilsTest {
         final long actualDuration = after - before;
 
         // Then
-        assertThat(actual, is(false));
+        assertThat(actual, equalTo(false));
         assertThat("Should wait for timeout", actualDuration,
                 allOf(greaterThanOrEqualTo(minExpectedTime), lessThanOrEqualTo(maxExpectedTime)));
     }
@@ -109,7 +106,7 @@ public class PortUtilsTest {
         final long actualDuration = after - before;
 
         // Then
-        assertThat("Used port should be connectible", actual, is(true));
+        assertThat("Used port should be connectible", actual, equalTo(true));
         assertThat("Should not wait", actualDuration, lessThanOrEqualTo(maxExpectedTime));
     }
 
@@ -132,7 +129,33 @@ public class PortUtilsTest {
         final long actualDuration = after - before;
 
         // Then
-        assertThat("Used port should be connectible", actual, is(true));
+        assertThat("Used port should be connectible", actual, equalTo(true));
+        assertThat("Should wait then retry", actualDuration,
+                allOf(greaterThanOrEqualTo(minExpectedTime), lessThanOrEqualTo(maxExpectedTime)));
+    }
+
+    @Test
+    public void checkSSHwillRetryOpenButFailingSSHPort() throws Exception {
+        // Given
+        final int retries = 4;
+        final int waitBetweenTries = DELAY / 2;
+        final int sshWaitDuringTry = DELAY / 3;
+        // e.g. try, delay, try, delay, try, delay, try, delay, try = 5 tries, 4 delays.
+        // expecting port to become available during the second delay.
+        final long minExpectedTime = sshWaitDuringTry + waitBetweenTries + sshWaitDuringTry + waitBetweenTries + sshWaitDuringTry + waitBetweenTries + sshWaitDuringTry + waitBetweenTries + sshWaitDuringTry;
+        final long maxExpectedTime = minExpectedTime + waitBetweenTries - 1;
+        final PortUtils.ConnectionCheck cc = PortUtils.connectionCheck(server.host(), server.port()).withRetries(retries)
+                .withEveryRetryWaitFor(waitBetweenTries, MILLISECONDS);
+        final PortUtils.ConnectionCheckSSH instance = new PortUtils.ConnectionCheckSSH(cc).withSSHTimeout(sshWaitDuringTry, MILLISECONDS);
+
+        // When
+        final long before = currentTimeMillis();
+        final boolean actual = instance.execute();
+        final long after = currentTimeMillis();
+        final long actualDuration = after - before;
+
+        // Then
+        assertThat("Used port should be connectible", actual, equalTo(false));
         assertThat("Should wait then retry", actualDuration,
                 allOf(greaterThanOrEqualTo(minExpectedTime), lessThanOrEqualTo(maxExpectedTime)));
     }


### PR DESCRIPTION
* Issue #751 - Math.min should've been Math.max
* Removed unused imports from unit test
* Fixed failure-case unit test for ConnectionCheckSSH