### PR TITLE
Rework DockerBuilderPublisher to work under dockerNode()

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -362,6 +362,7 @@ public class DockerCloud extends Cloud {
                             // TODO where can we log provisioning progress ?
                             final DockerAPI api = DockerCloud.this.getDockerApi();
                             slave = t.provisionNode(api, TaskListener.NULL);
+                            slave.setDockerAPI(api);
                             slave.setCloudId(DockerCloud.this.name);
                             plannedNode.complete(slave);
 

--- a/src/main/java/io/jenkins/docker/pipeline/DockerNodeStepExecution.java
+++ b/src/main/java/io/jenkins/docker/pipeline/DockerNodeStepExecution.java
@@ -92,6 +92,7 @@ class DockerNodeStepExecution extends StepExecution {
         Computer computer = null;
         try {
             node = t.provisionNode(api, listener);
+            node.setDockerAPI(api);
             node.setAcceptingTasks(false); // Prevent this node to be used by tasks from build queue
             Jenkins.getInstance().addNode(node);
 

--- a/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepTest.java
+++ b/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepTest.java
@@ -259,6 +259,22 @@ public class DockerNodeStepTest {
         });
     }
 
+    @Test
+    public void dockerBuilderPublisher() throws Exception {
+        story.addStep(new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                WorkflowJob j = story.j.jenkins.createProject(WorkflowJob.class, "dockerBuilderPublisher");
+                j.setDefinition(new CpsFlowDefinition("dockerNode(dockerHost: 'unix:///var/run/docker.sock', image: 'jenkins/slave', remoteFs: '/home/jenkins') {\n" +
+                        "  writeFile(file: 'Dockerfile', text: 'FROM jenkins/slave')\n" +
+                        "  step([$class: 'DockerBuilderPublisher', dockerFileDirectory: ''])\n" +
+                        "}\n", true));
+                WorkflowRun r = story.j.buildAndAssertSuccess(j);
+                story.j.assertLogContains("Successfully built", r);
+            }
+        });
+    }
+
     public static class PathModifierStep extends Step {
         private String element;
 


### PR DESCRIPTION
DockerBuilderPublisher couldn't be run without providing a cloud name
under dockerNode(), because dockerNode never did set a cloudName on the
DockerTransientNode.

This reworks DockerBuilderPublisher to be capable of launching the
building on a DockerApi directly, because thats what it actually needs,
and thats what dockerNode has.

Signed-off-by: Anton Lundin <glance@acc.umu.se>