### PR TITLE
Fix Docker Jenkins JNLP Agent image name

### DIFF
--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/config.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/config.jelly
@@ -10,7 +10,7 @@
             <li>
                 Entrypoint must be able to accept jenkins slave connection parameters.
                 See 
-                <a href="https://github.com/jenkinsci/docker-jnlp-slave">jenkins/docker-jnlp-slave</a>
+                <a href="https://github.com/jenkinsci/docker-jnlp-slave">jenkins/jnlp-slave</a>
                 as an example.
             </li>
         </ul>

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/config.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/config.jelly
@@ -9,8 +9,10 @@
             </li>
             <li>
                 Entrypoint must be able to accept jenkins slave connection parameters.
-                See 
-                <a href="https://github.com/jenkinsci/docker-jnlp-slave">jenkins/jnlp-slave</a>
+                See docker container
+                <a href="https://hub.docker.com/r/jenkins/jnlp-slave">jenkins/jnlp-slave</a>
+                and/or source
+                <a href="https://github.com/jenkinsci/docker-jnlp-slave">jenkinsci/docker-jnlp-slave</a>
                 as an example.
             </li>
         </ul>


### PR DESCRIPTION
The repository is jenkinsci/docker-jnlp-slave but the Docker image name is jenkins/jnlp-slave.
Fixing this will prevent incorrect copy/paste for users who want to try it.