### PR TITLE
Fix SSH-connector unit-tests

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -264,7 +264,7 @@ public class DockerCloud extends Cloud {
 
     private static void adjustContainersInProgress(DockerCloud cloud, DockerTemplate template, int adjustment) {
         final String cloudId = cloud.name;
-        final String templateId = template.getImage();
+        final String templateId = getTemplateId(template);
         synchronized (CONTAINERS_IN_PROGRESS) {
             Map<String, Integer> mapForThisCloud = CONTAINERS_IN_PROGRESS.get(cloudId);
             if (mapForThisCloud == null) {
@@ -285,9 +285,15 @@ public class DockerCloud extends Cloud {
         }
     }
 
-    int countContainersInProgress(DockerTemplate template) {
-        final String cloudId = super.name;
+    private static String getTemplateId(DockerTemplate template) {
         final String templateId = template.getImage();
+        return templateId;
+    }
+
+    @Restricted(NoExternalUse.class)
+    public int countContainersInProgress(DockerTemplate template) {
+        final String cloudId = super.name;
+        final String templateId = getTemplateId(template);
         synchronized (CONTAINERS_IN_PROGRESS) {
             final Map<String, Integer> allInProgressOrNull = CONTAINERS_IN_PROGRESS.get(cloudId);
             final Integer templateInProgressOrNull = allInProgressOrNull == null

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -465,20 +465,26 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
      * in a CredentialStore
      */
     private static class DockerSSHLauncher extends SSHLauncher {
+        private static final String CREDENTIAL_ID = "InstanceIdentity";
         private String user;
         private String privateKey;
 
         public DockerSSHLauncher(String host, int port, String user, String privateKey, String jvmOptions, String javaPath, String prefixStartSlaveCmd, String suffixStartSlaveCmd, Integer launchTimeoutSeconds, Integer maxNumRetries, Integer retryWaitTime, SshHostKeyVerificationStrategy sshHostKeyVerificationStrategy) {
-            super(host, port, "InstanceIdentity", jvmOptions, javaPath, prefixStartSlaveCmd, suffixStartSlaveCmd, launchTimeoutSeconds, maxNumRetries, retryWaitTime, sshHostKeyVerificationStrategy);
+            super(host, port, CREDENTIAL_ID, jvmOptions, javaPath, prefixStartSlaveCmd, suffixStartSlaveCmd, launchTimeoutSeconds, maxNumRetries, retryWaitTime, sshHostKeyVerificationStrategy);
             this.user = user;
             this.privateKey = privateKey;
         }
 
         @Override
         public StandardUsernameCredentials getCredentials() {
-            return new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, "InstanceIdentity", user,
-                    new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(privateKey), null,
-                    "private key for docker ssh agent");
+            return makeCredentials(CREDENTIAL_ID, user, privateKey);
         }
+    }
+
+    @Restricted(NoExternalUse.class)
+    static StandardUsernameCredentials makeCredentials(String credId, String user, String privateKey) {
+        return new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, credId, user,
+                new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(privateKey), null,
+                "private key for docker ssh agent");
     }
 }

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -33,6 +33,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
@@ -4,23 +4,17 @@ import com.nirima.jenkins.plugins.docker.DockerTemplate;
 import com.nirima.jenkins.plugins.docker.DockerTemplateBase;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.concurrent.ExecutionException;
-
 public class DockerComputerAttachConnectorTest extends DockerComputerConnectorTest {
+    private static final String ATTACH_SLAVE_IMAGE_IMAGENAME = "jenkins/slave";
 
     @Test
-    public void should_connect_agent() throws InterruptedException, ExecutionException, IOException, URISyntaxException {
-
+    public void connectAgentViaDirectAttach() throws Exception {
         final DockerTemplate template = new DockerTemplate(
-                new DockerTemplateBase("jenkins/slave"),
-                new DockerComputerAttachConnector("jenkins"),
-                "docker-agent", "/home/jenkins/agent", "10"
+                new DockerTemplateBase(ATTACH_SLAVE_IMAGE_IMAGENAME),
+                new DockerComputerAttachConnector(COMMON_IMAGE_USERNAME),
+                LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );
-
+        template.setName("connectAgentViaDirectAttach");
         should_connect_agent(template);
     }
-
-
 }

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
@@ -2,57 +2,136 @@ package io.jenkins.docker.connector;
 
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
+
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
+import hudson.model.Node;
 import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.slaves.Cloud;
 import hudson.tasks.Shell;
+import hudson.util.StreamTaskListener;
+import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import org.apache.commons.lang3.SystemUtils;
+import org.hamcrest.number.OrderingComparison;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public abstract class DockerComputerConnectorTest {
+    protected static final String LABEL = "docker-agent";
+    protected static final String COMMON_IMAGE_USERNAME = "jenkins";
+    protected static final String COMMON_IMAGE_HOMEDIR = "/home/jenkins/agent";
+    protected static final String INSTANCE_CAP = "10";
+
+    private static int testNumber;
+    private String cloudName;
+
+    @BeforeClass
+    public static void setUpClass() {
+        testNumber=0;
+    }
+
+    @Before
+    public void setUp() {
+        testNumber++;
+        cloudName = "DockerCloudFor" + this.getClass().getSimpleName() + testNumber;
+    }
 
     @After
-    public void cleanup() {
-        // TODO rm orphaned container
+    public void cleanup() throws Exception {
+        terminateAllDockerNodes();
+        final long startTimeMs = System.currentTimeMillis();
+        final Long maxWaitTimeMs = 60 * 1000L;
+        final long initialWaitTime = 50;
+        long currentWaitTime = initialWaitTime;
+        while( dockerIsStillBusy()) {
+            currentWaitTime = currentWaitTime * 2;
+            Thread.sleep(currentWaitTime);
+            terminateAllDockerNodes();
+            final long currentTimeMs = System.currentTimeMillis();
+            final Long elapsedTimeMs = currentTimeMs - startTimeMs;
+            Assert.assertThat(elapsedTimeMs, OrderingComparison.lessThan(maxWaitTimeMs));
+        }
+    }
+
+    private void terminateAllDockerNodes() {
+        final TaskListener tl = new StreamTaskListener(System.out, Charset.forName("UTF-8"));
+        for( final Node n : j.jenkins.getNodes() ) {
+            if( n instanceof DockerTransientNode ) {
+                final DockerTransientNode dn = (DockerTransientNode)n;
+                dn.terminate(tl);
+            }
+        }
+    }
+
+    private boolean dockerIsStillBusy() throws Exception {
+        for( final Node n : j.jenkins.getNodes() ) {
+            if( n instanceof DockerTransientNode ) {
+                return true;
+            }
+        }
+        for( final Cloud c : j.jenkins.clouds) {
+            if( c instanceof DockerCloud) {
+                DockerCloud cloud = (DockerCloud)c;
+                for( final DockerTemplate t : cloud.getTemplates() ) {
+                    final int containersInProgress = cloud.countContainersInProgress(t);
+                    if( containersInProgress > 0 ) {
+                        return true;
+                    }
+                }
+                final int containersInDocker = cloud.countContainersInDocker(null);
+                if( containersInDocker > 0 ) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
-
-    protected void should_connect_agent(DockerTemplate template) throws IOException, ExecutionException, InterruptedException {
+    protected void should_connect_agent(DockerTemplate template) throws IOException, ExecutionException, InterruptedException, TimeoutException {
 
         // FIXME on CI windows nodes don't have Docker4Windows
         Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
         String dockerHost = SystemUtils.IS_OS_WINDOWS ? "tcp://localhost:2375" : "unix:///var/run/docker.sock";
 
-        DockerCloud cloud = new DockerCloud("docker", new DockerAPI(new DockerServerEndpoint(dockerHost, null)),
+        DockerCloud cloud = new DockerCloud(cloudName, new DockerAPI(new DockerServerEndpoint(dockerHost, null)),
                 Collections.singletonList(template));
 
         j.jenkins.clouds.replaceBy(Collections.singleton(cloud));
 
         final FreeStyleProject project = j.createFreeStyleProject("test-docker-ssh");
-        project.setAssignedLabel(Label.get("docker-agent"));
+        project.setAssignedLabel(Label.get(LABEL));
         project.getBuildersList().add(new Shell("whoami"));
-        final FreeStyleBuild build = project.scheduleBuild2(0).get();
-        Assert.assertTrue(build.getResult() == Result.SUCCESS);
-        Assert.assertTrue(build.getLog().contains("jenkins"));
+        final QueueTaskFuture<FreeStyleBuild> scheduledBuild = project.scheduleBuild2(0);
+        try {
+            final FreeStyleBuild build = scheduledBuild.get(60L, TimeUnit.SECONDS);
+            Assert.assertTrue(build.getResult() == Result.SUCCESS);
+            Assert.assertTrue(build.getLog().contains("jenkins"));
+        } finally {
+            scheduledBuild.cancel(true);
+        }
     }
-
-
 }

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
@@ -16,15 +16,14 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.ExecutionException;
 
 public class DockerComputerJNLPConnectorTest extends DockerComputerConnectorTest {
+    private static final String JNLP_SLAVE_IMAGE_IMAGENAME = "jenkins/jnlp-slave";
 
     @Test
-    public void should_connect_agent() throws InterruptedException, ExecutionException, IOException, URISyntaxException {
+    public void connectAgentViaJNLP() throws Exception {
 
         final JenkinsLocationConfiguration location = JenkinsLocationConfiguration.get();
         URI uri = URI.create(location.getUrl());
@@ -37,16 +36,17 @@ public class DockerComputerJNLPConnectorTest extends DockerComputerConnectorTest
         }
 
         final DockerTemplate template = new DockerTemplate(
-                new DockerTemplateBase("jenkins/jnlp-slave"),
-                new DockerComputerJNLPConnector(new JNLPLauncher(null, null)).withUser("jenkins")
+                new DockerTemplateBase(JNLP_SLAVE_IMAGE_IMAGENAME),
+                new DockerComputerJNLPConnector(new JNLPLauncher(null, null)).withUser(COMMON_IMAGE_USERNAME)
                         .withJenkinsUrl(uri.toString()),
-                "docker-agent", "/home/jenkins/agent", "10"
+                        LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );
 
         if (SystemUtils.IS_OS_LINUX) {
             template.getDockerTemplateBase().setNetwork("host");
         }
 
+        template.setName("connectAgentViaJNLP");
         should_connect_agent(template);
     }
 

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
@@ -1,5 +1,7 @@
 package io.jenkins.docker.connector;
 
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.PortBinding;
@@ -7,26 +9,59 @@ import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.core.command.CreateContainerCmdImpl;
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
 import com.nirima.jenkins.plugins.docker.DockerTemplateBase;
+import com.trilead.ssh2.signature.RSAKeyAlgorithm;
+
+import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy;
 import io.jenkins.docker.client.DockerAPI;
+import jenkins.bouncycastle.api.PEMEncodable;
+
+import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static hudson.remoting.Base64.encode;
+
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 
 public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest {
 
+    private static final String SSH_SLAVE_IMAGE_IMAGENAME = "jenkins/ssh-slave";
+    private static final String SSH_SLAVE_IMAGE_JAVAPATH = "/usr/local/openjdk-8/bin/java";
+
     @Test
-    public void should_connect_agent() throws InterruptedException, ExecutionException, IOException {
-
+    public void connectAgentViaSSHUsingInjectSshKey() throws Exception {
+        final DockerComputerSSHConnector.SSHKeyStrategy sshKeyStrategy = new DockerComputerSSHConnector.InjectSSHKey(COMMON_IMAGE_USERNAME);
+        final DockerComputerSSHConnector connector = new DockerComputerSSHConnector(sshKeyStrategy);
+        connector.setJavaPath(SSH_SLAVE_IMAGE_JAVAPATH);
         final DockerTemplate template = new DockerTemplate(
-                new DockerTemplateBase("jenkins/ssh-slave"),
-                new DockerComputerSSHConnector(new DockerComputerSSHConnector.InjectSSHKey("jenkins")),
-                "docker-agent", "/home/jenkins/agent", "10"
+                new DockerTemplateBase(SSH_SLAVE_IMAGE_IMAGENAME),
+                connector,
+                LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );
+        template.setName("connectAgentViaSSHUsingInjectSshKey");
+        should_connect_agent(template);
+    }
 
+    @Test
+    public void connectAgentViaSSHUsingCredentialsKey() throws Exception {
+        final InstanceIdentity id = InstanceIdentity.get();
+        final String privateKey = PEMEncodable.create(id.getPrivate()).encode();
+        final String publicKey = "ssh-rsa " + encode(new RSAKeyAlgorithm().encodePublicKey(id.getPublic()));
+        final String credentialsId = "tempCredId";
+        final StandardUsernameCredentials credentials = DockerComputerSSHConnector.makeCredentials(credentialsId, COMMON_IMAGE_USERNAME, privateKey);
+        SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        final DockerComputerSSHConnector.SSHKeyStrategy sshKeyStrategy = new DockerComputerSSHConnector.ManuallyConfiguredSSHKey(credentialsId, new NonVerifyingKeyVerificationStrategy());
+        final DockerComputerSSHConnector connector = new DockerComputerSSHConnector(sshKeyStrategy);
+        connector.setJavaPath(SSH_SLAVE_IMAGE_JAVAPATH);
+        final DockerTemplate template = new DockerTemplate(
+                new DockerTemplateBase(SSH_SLAVE_IMAGE_IMAGENAME),
+                connector,
+                LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
+        );
+        template.getDockerTemplateBase().setEnvironmentsString("JENKINS_SLAVE_SSH_PUBKEY=" + publicKey);
+        template.setName("connectAgentViaSSHUsingCredentialsKey");
         should_connect_agent(template);
     }
 


### PR DESCRIPTION
* The official ssh-slave (now) requires additional configuration for the
old unit test to work, as java is no longer found on the PATH when the
container is invoked as it is here.  That broke the injected-key test.
* There never was a unit-test for the specified-credentials method (only
the injected-key one) so that's been added too.
* The unit-test's cleanup code was a TODO statement, so it left things
in a mess that tended to prevent other tests from running properly.