### PR TITLE
Add --label to Build/Publish Docker Image-Step

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction.java
@@ -11,6 +11,7 @@ import org.kohsuke.accmod.Restricted;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Created by magnayn on 10/01/2014.
@@ -32,6 +33,7 @@ public class DockerBuildImageAction implements Action, Serializable, Cloneable, 
     public final boolean pushOnSuccess;
     public /* almost final */ boolean noCache;
     public /* almost final */ boolean pull;
+    public Map<String, String> labels;
 
     @Deprecated
     public DockerBuildImageAction(String containerHost,
@@ -76,12 +78,32 @@ public class DockerBuildImageAction implements Action, Serializable, Cloneable, 
         setPull(pull);
     }
 
+    /**
+     * For internal use only, use {@link #DockerBuildImageAction(String, String, List, boolean, boolean)} instead.
+     */
+    @Restricted(NoExternalUse.class)
+    public DockerBuildImageAction(String containerHost,
+                                  String containerId,
+                                  List<String> tags,
+                                  boolean cleanupWithJenkinsJobDelete,
+                                  boolean pushOnSuccess,
+                                  boolean noCache,
+                                  boolean pull,
+                                  Map<String, String> labels) {
+        this(containerHost, containerId, tags, cleanupWithJenkinsJobDelete, pushOnSuccess, noCache, pull);
+        setLabels(labels);
+    }
+
     public void setPull(boolean pull) {
         this.pull = pull;
     }
 
     public void setNoCache(boolean noCache) {
         this.noCache = noCache;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
     }
 
     public String getIconFileName() {

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/config.jelly
@@ -47,4 +47,8 @@
         <f:checkbox default="false"/>
     </f:entry>
 
+    <f:entry title="${%Label list}" field="labels">
+        <f:expandableTextbox />
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-labels.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-labels.html
@@ -1,0 +1,4 @@
+<div>
+    If set, builds the image with <code>--labels</code> to add labels to the image built
+    See the docker <a href="https://docs.docker.com/engine/reference/commandline/build/">build command</a> for more information.
+</div>


### PR DESCRIPTION
This adds the ability to add labels to a docker image build.

This is usefull for example encoding build number, git hash and so on into the docker image.