### PR TITLE
Feature/thread start container jnlp

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -557,12 +557,13 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         LOGGER.info("Started container ID {} for node {} from image: {}", containerId, nodeName, getImage());
 
         try {
-            connector.beforeContainerStarted(api, remoteFs, containerId);
-            client.startContainerCmd(containerId).exec();
-            connector.afterContainerStarted(api, remoteFs, containerId);
-
             final ComputerLauncher launcher = connector.createLauncher(api, containerId, remoteFs, listener);
             final DockerTransientNode node = new DockerTransientNode(nodeName, containerId, remoteFs, launcher);
+
+            connector.beforeContainerStarted(api, remoteFs, containerId);
+            connector.startContainer(containerId, client, node);
+            connector.afterContainerStarted(api, remoteFs, containerId);
+
             node.setNodeDescription("Docker Agent [" + getImage() + " on "+ api.getDockerHost().getUri() + " ID " + containerId + "]");
             node.setMode(mode);
             node.setLabelString(labelString);

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -557,12 +557,12 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         LOGGER.info("Started container ID {} for node {} from image: {}", containerId, nodeName, getImage());
 
         try {
+            connector.beforeContainerStarted(api, remoteFs, containerId);
+            connector.startContainer(containerId, client, nodeName, listener);
+            connector.afterContainerStarted(api, remoteFs, containerId);
+
             final ComputerLauncher launcher = connector.createLauncher(api, containerId, remoteFs, listener);
             final DockerTransientNode node = new DockerTransientNode(nodeName, containerId, remoteFs, launcher);
-
-            connector.beforeContainerStarted(api, remoteFs, containerId);
-            connector.startContainer(containerId, client, node, listener);
-            connector.afterContainerStarted(api, remoteFs, containerId);
 
             node.setNodeDescription("Docker Agent [" + getImage() + " on "+ api.getDockerHost().getUri() + " ID " + containerId + "]");
             node.setMode(mode);

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -561,7 +561,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
             final DockerTransientNode node = new DockerTransientNode(nodeName, containerId, remoteFs, launcher);
 
             connector.beforeContainerStarted(api, remoteFs, containerId);
-            connector.startContainer(containerId, client, node);
+            connector.startContainer(containerId, client, node, listener);
             connector.afterContainerStarted(api, remoteFs, containerId);
 
             node.setNodeDescription("Docker Agent [" + getImage() + " on "+ api.getDockerHost().getUri() + " ID " + containerId + "]");

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
@@ -3,6 +3,7 @@ package io.jenkins.docker.connector;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.StartContainerCmd;
 import com.nirima.jenkins.plugins.docker.DockerSlave;
 import com.thoughtworks.xstream.InitializationException;
 import hudson.model.AbstractDescribableImpl;
@@ -10,6 +11,7 @@ import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.Which;
 import hudson.slaves.ComputerLauncher;
+import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +57,12 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
      */
     public void afterContainerStarted(DockerAPI api, String workdir, String containerId) throws IOException, InterruptedException {}
 
+    /**
+     * Specific method to start the container according connection method
+     */
+    public void startContainer(String containerId, DockerClient client, DockerTransientNode node) {
+        client.startContainerCmd(containerId).exec();
+    }
 
     /**
      * Ensure container is already set with a command, or set one to make it wait indefinitely

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
@@ -3,7 +3,6 @@ package io.jenkins.docker.connector;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.command.StartContainerCmd;
 import com.nirima.jenkins.plugins.docker.DockerSlave;
 import com.thoughtworks.xstream.InitializationException;
 import hudson.model.AbstractDescribableImpl;
@@ -11,7 +10,6 @@ import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.remoting.Which;
 import hudson.slaves.ComputerLauncher;
-import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,11 +59,11 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
      * Specific method to start the container according connection method
      * @param containerId
      * @param client
-     * @param node
+     * @param nodeName
      * @param listener
      * @throws IOException
      */
-    public void startContainer(String containerId, DockerClient client, DockerTransientNode node, TaskListener listener) throws IOException {
+    public void startContainer(String containerId, DockerClient client, String nodeName, TaskListener listener) throws IOException {
         client.startContainerCmd(containerId).exec();
         final InspectContainerResponse inspect = client.inspectContainerCmd(containerId).exec();
         final Boolean running = inspect.getState().getRunning();

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
@@ -227,9 +227,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
             @Override
             public void run() {
                 long initialTime = Instant.now().getEpochSecond();
-                long idleSecond = BigDecimal.valueOf(((DockerOnceRetentionStrategy) node.getRetentionStrategy()).getIdleMinutes())
-                        .multiply(BigDecimal.valueOf(60))
-                        .longValue();
+                final long addNodeSecondTimeout = 30; // TODO : See if it need to be configurable
                 while (isRunning) {
                     try {
                         long currentTime = Instant.now().getEpochSecond();
@@ -243,7 +241,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
                             }
                             stop();
                         }
-                        if(currentTime - initialTime > idleSecond) {
+                        if(currentTime - initialTime > addNodeSecondTimeout) {
                             throw new InterruptedException("Start container timeout");
                         }
                         Thread.sleep(1000);


### PR DESCRIPTION
See #757 and [JENKINS-59790](https://issues.jenkins-ci.org/browse/JENKINS-59790).

With JNLP connection method, adding a Jenkins node is asynchronous with when the container starts.

It is a problem when Jenkins is slow and the docker container start very quickly. The node is not yet created on Jenkins when the container ask to connect.

This solution delays the container start until the Jenkins node is created for JNLP.