### PR TITLE
Fix #757 and JENKINS-59790

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -716,12 +716,7 @@ public class DockerTemplate implements Describable<DockerTemplate> {
         LOGGER.info("Started container ID {} for node {} from image: {}", containerId, nodeName, ourImage);
 
         try {
-            ourConnector.beforeContainerStarted(api, effectiveRemoteFsDir, containerId);
-            client.startContainerCmd(containerId).exec();
-            ourConnector.afterContainerStarted(api, effectiveRemoteFsDir, containerId);
-
-            final ComputerLauncher nodeLauncher = ourConnector.createLauncher(api, containerId, effectiveRemoteFsDir, listener);
-            final DockerTransientNode node = new DockerTransientNode(nodeName, containerId, effectiveRemoteFsDir, nodeLauncher);
+            final DockerTransientNode node = new DockerTransientNode(nodeName, containerId, effectiveRemoteFsDir);
             node.setNodeDescription("Docker Agent [" + ourImage + " on "+ api.getDockerHost().getUri() + " ID " + containerId + "]");
             node.setMode(getMode());
             node.setLabelString(getLabelString());
@@ -730,6 +725,11 @@ public class DockerTemplate implements Describable<DockerTemplate> {
             node.setRemoveVolumes(isRemoveVolumes());
             node.setStopTimeout(getStopTimeout());
             node.setDockerAPI(api);
+            ourConnector.beforeContainerStarted(api, effectiveRemoteFsDir, node);
+            client.startContainerCmd(containerId).exec();
+            ourConnector.afterContainerStarted(api, effectiveRemoteFsDir, node);
+            final ComputerLauncher nodeLauncher = ourConnector.createLauncher(api, containerId, effectiveRemoteFsDir, listener);
+            node.setLauncher(nodeLauncher);
             finallyRemoveTheContainer = false;
             return node;
         } finally {

--- a/src/main/java/io/jenkins/docker/DockerTransientNode.java
+++ b/src/main/java/io/jenkins/docker/DockerTransientNode.java
@@ -35,7 +35,6 @@ public class DockerTransientNode extends Slave {
     private static final long serialVersionUID = 1349729340506926183L;
     private static final Logger LOGGER = LoggerFactory.getLogger(DockerTransientNode.class.getName());
 
-    //Keeping real containerId information, but using containerName as containerId
     private final String containerId;
 
     private transient DockerAPI dockerAPI;
@@ -48,8 +47,42 @@ public class DockerTransientNode extends Slave {
 
     private AtomicBoolean acceptingTasks = new AtomicBoolean(true);
 
-    public DockerTransientNode(@Nonnull String nodeName, String containerId, String workdir, ComputerLauncher launcher) throws Descriptor.FormException, IOException {
-        super(nodeName, workdir, launcher);
+    /**
+     * @deprecated Use {@link #DockerTransientNode(String, String, String)} then
+     *             {@link #setLauncher(ComputerLauncher)}.
+     * @param nodeName    Passed to
+     *                    {@link #DockerTransientNode(String, String, String)}.
+     * @param containerId Passed to
+     *                    {@link #DockerTransientNode(String, String, String)}.
+     * @param workdir     Passed to
+     *                    {@link #DockerTransientNode(String, String, String)}.
+     * @param launcher    Passed to {@link #setLauncher(ComputerLauncher)}
+     * @throws             Descriptor.FormException See
+     *                     {@link #DockerTransientNode(String, String, String)}.
+     * @throws IOException See {@link #DockerTransientNode(String, String, String)}.
+     */
+    @Deprecated
+    public DockerTransientNode(@Nonnull String nodeName, @Nonnull String containerId, String workdir, ComputerLauncher launcher) throws Descriptor.FormException, IOException {
+        this(nodeName, containerId, workdir);
+        setLauncher(launcher);
+    }
+
+    /**
+     * Preferred constructor. Note that, unless this is a JNLP node, callers will
+     * later have to call {@link #setLauncher(ComputerLauncher)}.
+     * 
+     * @param nodeName    Name of the node; passed to
+     *                    {@link Slave#Slave(String, String, ComputerLauncher)}.
+     * @param containerId Docker container id.
+     * @param workdir     remoteFs home dir; passed to
+     *                    {@link Slave#Slave(String, String, ComputerLauncher)}.
+     * @throws             Descriptor.FormException See
+     *                     {@link Slave#Slave(String, String, ComputerLauncher)}.
+     * @throws IOException See
+     *                     {@link Slave#Slave(String, String, ComputerLauncher)}.
+     */
+    public DockerTransientNode(@Nonnull String nodeName, @Nonnull String containerId, String workdir) throws Descriptor.FormException, IOException {
+        super(nodeName, workdir, null);
         this.containerId = containerId;
         setNumExecutors(1);
         setMode(Mode.EXCLUSIVE);
@@ -65,6 +98,7 @@ public class DockerTransientNode extends Slave {
         this.acceptingTasks.set(acceptingTasks);
     }
 
+    @Nonnull
     public String getContainerId(){
         return containerId;
     }

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
@@ -21,6 +21,7 @@ import hudson.model.TaskListener;
 import hudson.remoting.Channel;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.SlaveComputer;
+import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import io.jenkins.docker.client.DockerMultiplexedInputStream;
 import jenkins.model.Jenkins;
@@ -160,7 +161,8 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
     }
 
     @Override
-    public void afterContainerStarted(DockerAPI api, String workdir, String containerId) throws IOException, InterruptedException {
+    public void afterContainerStarted(DockerAPI api, String workdir, DockerTransientNode node) throws IOException, InterruptedException {
+        final String containerId = node.getContainerId();
         try(final DockerClient client = api.getClient()) {
             injectRemotingJar(containerId, workdir, client);
         }

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
@@ -18,6 +18,7 @@ import hudson.model.Descriptor;
 import hudson.model.TaskListener;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.JNLPLauncher;
+import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import io.jenkins.docker.client.DockerEnvUtils;
 import jenkins.model.Jenkins;
@@ -200,6 +201,17 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
         if (StringUtils.isNotBlank(user)) {
             cmd.withUser(user);
         }
+    }
+
+    @Override
+    public void beforeContainerStarted(DockerAPI api, String workdir, DockerTransientNode node)
+            throws IOException, InterruptedException {
+        // For JNLP, we need to have the Jenkins Node known to Jenkins as a valid JNLP
+        // node before the container starts, otherwise it might get started before
+        // Jenkins is ready for it.
+        // That's why we explicitly add the node here instead of allowing the cloud
+        // provisioning process to add it later.
+        ensureNodeIsKnown(node);
     }
 
     private static EnvVars calculateVariablesForVariableSubstitution(final String nodeName, final String secret,

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -27,6 +27,7 @@ import hudson.plugins.sshslaves.verifiers.SshHostKeyVerificationStrategy;
 import hudson.security.ACL;
 import hudson.slaves.ComputerLauncher;
 import hudson.util.ListBoxModel;
+import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import jenkins.bouncycastle.api.PEMEncodable;
 import jenkins.model.Jenkins;
@@ -252,9 +253,10 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
     }
 
     @Override
-    public void beforeContainerStarted(DockerAPI api, String workdir, String containerId) throws IOException, InterruptedException {
+    public void beforeContainerStarted(DockerAPI api, String workdir, DockerTransientNode node) throws IOException, InterruptedException {
         final String key = sshKeyStrategy.getInjectedKey();
         if (key != null) {
+            final String containerId = node.getContainerId();
             final String authorizedKeysCommand = "#!/bin/sh\n"
                     + "[ \"$1\" = \"" + sshKeyStrategy.getUser() + "\" ] "
                     + "&& echo '" + key + "'"


### PR DESCRIPTION
Fix #757 and JENKINS-59790.
Alternative implementation to #770.

Refactor DockerTransientNode constructor so the launcher is provided post-construction.
Refactor DockerComputerConnector.beforeContainerStarted(...) so it takes a node (that holds a containerId) instead of a containerId.
Refactor DockerTemplate.doProvision(...) so that the DockerTransientNode is created without a launcher before we start the container.
Enhance DockerComputerJNLPConnector so that it adds the node to Jenkins immediately before the container is created, ensuring that it'll be known to Jenkins (just) before the JNLP process starts.

SSH and DirectAttach connectors continue as normal.
JNLP ones call `Jenkins.getInstance().addNode(dockerNode)` before the container starts, ensuring that the container is known to Jenkins before the JNLP process can start and attempt to connect.