### PR TITLE
Enhance attach connection method and try to fix unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 A pre-release can be downloaded from https://ci.jenkins.io/job/Plugins/job/docker-plugin/job/master/
 * Enhancement: container stop timeout now configurable [#732](https://github.com/jenkinsci/docker-plugin/issues/732)
 * Fix possible resource leak [#786](https://github.com/jenkinsci/docker-plugin/issues/786)
-* Enhancement: can now add/drop capabilites [#696](https://github.com/jenkinsci/docker-plugin/issues/696)
+* Enhancement: can now add/drop docker capabilites [#696](https://github.com/jenkinsci/docker-plugin/issues/696)
+* Enhancement: can now customise "attach" connections [#790](https://github.com/jenkinsci/docker-plugin/issues/790)
 
 ## 1.2.0
 _2020-04-02_

--- a/src/main/java/com/nirima/jenkins/plugins/docker/strategy/DockerOnceRetentionStrategy.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/strategy/DockerOnceRetentionStrategy.java
@@ -22,6 +22,8 @@ import java.util.logging.Logger;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+import java.util.Objects;
+
 /**
  * Mix of {@link org.jenkinsci.plugins.durabletask.executors.OnceRetentionStrategy} (1.3) and {@link CloudRetentionStrategy}
  * that allows configure it parameters and has Descriptor.
@@ -116,12 +118,15 @@ public class DockerOnceRetentionStrategy extends RetentionStrategy<DockerCompute
     }
 
     @Override
+    public int hashCode() {
+        return Objects.hash(idleMinutes);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         DockerOnceRetentionStrategy that = (DockerOnceRetentionStrategy) o;
-
         return idleMinutes == that.idleMinutes;
     }
 

--- a/src/main/java/io/jenkins/docker/FastNodeProvisionerStrategy.java
+++ b/src/main/java/io/jenkins/docker/FastNodeProvisionerStrategy.java
@@ -80,10 +80,9 @@ public class FastNodeProvisionerStrategy extends Strategy {
         if (availableCapacity >= currentDemand) {
             LOGGER.log(FINE, "Provisioning completed");
             return PROVISIONING_COMPLETED;
-        } else {
-            LOGGER.log(FINE, "Provisioning not complete, consulting remaining strategies");
-            return CONSULT_REMAINING_STRATEGIES;
         }
+        LOGGER.log(FINE, "Provisioning not complete, consulting remaining strategies");
+        return CONSULT_REMAINING_STRATEGIES;
     }
 
     /**

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
@@ -1,11 +1,17 @@
 package io.jenkins.docker.connector;
 
+import static com.nirima.jenkins.plugins.docker.DockerTemplateBase.splitAndFilterEmpty;
+
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.ExecCreateCmd;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.google.common.base.Joiner;
+
+import hudson.EnvVars;
 import hudson.Extension;
+import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.TaskListener;
 import hudson.remoting.Channel;
@@ -13,8 +19,12 @@ import hudson.slaves.ComputerLauncher;
 import hudson.slaves.SlaveComputer;
 import io.jenkins.docker.client.DockerAPI;
 import io.jenkins.docker.client.DockerMultiplexedInputStream;
+import jenkins.model.Jenkins;
+
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
@@ -25,13 +35,26 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.net.Socket;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class DockerComputerAttachConnector extends DockerComputerConnector implements Serializable {
 
+    @CheckForNull
     private String user;
+    @CheckForNull
+    private String javaExe;
+    @CheckForNull
+    private String[] jvmArgs;
+    @CheckForNull
+    private String[] entryPointCmd;
 
     @DataBoundConstructor
     public DockerComputerAttachConnector() {
@@ -41,15 +64,104 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
         this.user = user;
     }
 
+    @Nonnull
     public String getUser() {
-        return user;
+        return user==null ? "" : user;
     }
 
     @DataBoundSetter
     public void setUser(String user) {
-        this.user = user;
+        if ( user==null || user.trim().isEmpty()) {
+            this.user = null;
+        } else {
+            this.user = user;
+        }
     }
 
+    @Nonnull
+    public String getJavaExe() {
+        return javaExe==null ? "" : javaExe;
+    }
+
+    @DataBoundSetter
+    public void setJavaExe(String javaExe) {
+        if ( javaExe==null || javaExe.trim().isEmpty()) {
+            this.javaExe = null;
+        } else {
+            this.javaExe = javaExe;
+        }
+    }
+
+    @CheckForNull
+    public String[] getEntryPointCmd(){
+        return entryPointCmd;
+    }
+
+    @Nonnull
+    public String getEntryPointCmdString() {
+        if (entryPointCmd == null) return "";
+        return Joiner.on("\n").join(entryPointCmd);
+    }
+
+    @DataBoundSetter
+    public void setEntryPointCmdString(String entryPointCmdString) {
+        setEntryPointCmd(splitAndFilterEmpty(entryPointCmdString, "\n"));
+    }
+
+    public void setEntryPointCmd(String[] entryPointCmd) {
+        if (entryPointCmd == null || entryPointCmd.length == 0) {
+            this.entryPointCmd = null;
+        } else {
+            this.entryPointCmd = entryPointCmd;
+        }
+    }
+
+    @CheckForNull
+    public String[] getJvmArgs(){
+        return jvmArgs;
+    }
+
+    @Nonnull
+    public String getJvmArgsString() {
+        if (jvmArgs == null) return "";
+        return Joiner.on("\n").join(jvmArgs);
+    }
+
+    @DataBoundSetter
+    public void setJvmArgsString(String jvmArgsString) {
+        setJvmArgs(splitAndFilterEmpty(jvmArgsString, "\n"));
+    }
+
+    public void setJvmArgs(String[] jvmArgs) {
+        if (jvmArgs == null || jvmArgs.length == 0) {
+            this.jvmArgs = null;
+        } else {
+            this.jvmArgs = jvmArgs;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Arrays.hashCode(entryPointCmd);
+        result = prime * result + Arrays.hashCode(jvmArgs);
+        result = prime * result + Objects.hash(javaExe, user);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!super.equals(obj)) {
+            return false;
+        }
+        DockerComputerAttachConnector other = (DockerComputerAttachConnector) obj;
+        return Arrays.equals(entryPointCmd, other.entryPointCmd) && Objects.equals(javaExe, other.javaExe)
+                && Arrays.equals(jvmArgs, other.jvmArgs) && Objects.equals(user, other.user);
+    }
 
     @Override
     public void beforeContainerCreated(DockerAPI api, String workdir, CreateContainerCmd cmd) throws IOException, InterruptedException {
@@ -63,21 +175,70 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
         }
     }
 
-    @Override
-    protected ComputerLauncher createLauncher(DockerAPI api, String workdir, InspectContainerResponse inspect, TaskListener listener) throws IOException, InterruptedException {
-        return new DockerAttachLauncher(api, inspect.getId(), user, workdir);
+    @Restricted(NoExternalUse.class)
+    public enum ArgumentVariables {
+        JavaExe("JAVA", "The java binary, e.g. java, /usr/bin/java etc."), //
+        JvmArgs("JVM_ARGS", "Any arguments for the JVM itself, e.g. -Xmx250m."), //
+        JarName("JAR_NAME", "The name of the jar file the node must run, e.g. slave.jar."), //
+        RemoteFs("FS_DIR",
+                "The filesystem folder in which the slave process is to be run."), //
+        JenkinsUrl("JENKINS_URL", "The Jenkins root URL.");
+        private final String name;
+        private final String description;
+
+        ArgumentVariables(String name, String description) {
+            this.name = name;
+            this.description = description;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getDescription() {
+            return description;
+        }
     }
 
+    private static final String DEFAULT_ENTRY_POINT_CMD_STRING = "${" + ArgumentVariables.JavaExe.getName() + "}\n"
+            + "${" + ArgumentVariables.JvmArgs.getName() + "}\n"
+            + "-jar\n"
+            + "${" + ArgumentVariables.RemoteFs.getName() + "}/${" + ArgumentVariables.JarName.getName() + "}\n"
+            + "-noReconnect\n"
+            + "-noKeepAlive\n"
+            + "-slaveLog\n"
+            + "${" + ArgumentVariables.RemoteFs.getName() + "}/agent.log";
+
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DockerComputerAttachConnector that = (DockerComputerAttachConnector) o;
-        return user != null ? user.equals(that.user) : that.user == null;
+    protected ComputerLauncher createLauncher(DockerAPI api, String workdir, InspectContainerResponse inspect, TaskListener listener) throws IOException, InterruptedException {
+        return new DockerAttachLauncher(api, inspect.getId(), getUser(), workdir, getJavaExe(), getJvmArgsString(), getEntryPointCmdString());
     }
+
 
     @Extension(ordinal = 100) @Symbol("attach")
     public static class DescriptorImpl extends Descriptor<DockerComputerConnector> {
+
+        public String getDefaultJavaExe() {
+            return "java";
+        }
+
+        public String getJavaExeVariableName() {
+            return ArgumentVariables.JavaExe.name;
+        }
+
+        public String getJvmArgsVariableName() {
+            return ArgumentVariables.JvmArgs.name;
+        }
+
+        public Collection<ArgumentVariables> getEntryPointCmdVariables() {
+            return Arrays.asList(ArgumentVariables.values());
+        }
+
+        public Collection<String> getDefaultEntryPointCmd() {
+            final String[] args = splitAndFilterEmpty(DEFAULT_ENTRY_POINT_CMD_STRING, "\n");
+            return Arrays.asList(args);
+        }
+
         @Override
         public String getDisplayName() {
             return "Attach Docker container";
@@ -85,23 +246,35 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
     }
 
     private static class DockerAttachLauncher extends ComputerLauncher {
-
         private final DockerAPI api;
         private final String containerId;
         private final String user;
         private final String remoteFs;
+        private final String javaExe;
+        private final String jvmArgs;
+        private final String entryPointCmd;
 
-        private DockerAttachLauncher(DockerAPI api, String containerId, String user, String remoteFs) {
+        private DockerAttachLauncher(DockerAPI api, String containerId, String user, String remoteFs, String javaExe, String jvmArgs, String entryPointCmd) {
             this.api = api;
             this.containerId = containerId;
             this.user = user;
             this.remoteFs = remoteFs;
+            this.javaExe = javaExe;
+            this.jvmArgs = jvmArgs;
+            this.entryPointCmd = entryPointCmd;
         }
 
         @Override
         public void launch(final SlaveComputer computer, TaskListener listener) throws IOException, InterruptedException {
             final PrintStream logger = computer.getListener().getLogger();
-            logger.println("Connecting to docker container "+containerId);
+            final String jenkinsUrl = Jenkins.getInstance().getRootUrl();
+            final String effectiveJavaExe = javaExe.isEmpty() ? "java" : javaExe;
+            final String effectiveJvmArgs = jvmArgs.isEmpty() ? "" : jvmArgs;
+            final EnvVars knownVariables = calculateVariablesForVariableSubstitution(effectiveJavaExe, effectiveJvmArgs, remoting.getName(), remoteFs, jenkinsUrl);
+            final String effectiveEntryPointCmdString = StringUtils.isNotBlank(entryPointCmd) ? entryPointCmd : DEFAULT_ENTRY_POINT_CMD_STRING;
+            final String resolvedEntryPointCmdString = Util.replaceMacro(effectiveEntryPointCmdString, knownVariables);
+            final String[] resolvedEntryPointCmd = splitAndFilterEmpty(resolvedEntryPointCmdString, "\n");
+            logger.println("Connecting to docker container " + containerId + ", running command " + Joiner.on(" ").join(resolvedEntryPointCmd));
 
             final String execId;
             try(final DockerClient client = api.getClient()) {
@@ -110,7 +283,7 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
                         .withAttachStdout(true)
                         .withAttachStderr(true)
                         .withTty(false)
-                        .withCmd("java", "-jar", remoteFs + '/' + remoting.getName(), "-noReconnect", "-noKeepAlive", "-slaveLog", remoteFs + "/agent.log");
+                        .withCmd(resolvedEntryPointCmd);
                 if (StringUtils.isNotBlank(user)) {
                     cmd.withUser(user);
                 }
@@ -158,6 +331,46 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
                 }
             });
 
+        }
+
+        private static EnvVars calculateVariablesForVariableSubstitution(final String javaExe, final String jvmArgs, final String jarName, final String remoteFs,
+                final String jenkinsUrl) throws IOException, InterruptedException {
+            final EnvVars knownVariables = new EnvVars();
+            final Jenkins j = Jenkins.getInstance();
+            addEnvVars(knownVariables, j.getGlobalNodeProperties());
+            for (final ArgumentVariables v : ArgumentVariables.values()) {
+                // This switch statement MUST handle all possible
+                // values of v.
+                final String argValue;
+                switch (v) {
+                    case JavaExe :
+                        argValue = javaExe;
+                        break;
+                    case JvmArgs :
+                        argValue = jvmArgs;
+                        break;
+                    case JarName :
+                        argValue = jarName;
+                        break;
+                    case RemoteFs :
+                        argValue = remoteFs;
+                        break;
+                    case JenkinsUrl :
+                        argValue = jenkinsUrl;
+                        break;
+                    default :
+                        final String msg = "Internal code error: Switch statement is missing \"case " + v.name()
+                                + " : argValue = ... ; break;\" code.";
+                        // If this line throws an exception then it's because
+                        // someone has added a new variable to the enum without
+                        // adding code above to handle it.
+                        // The two have to be kept in step in order to
+                        // ensure that the help text stays in step.
+                        throw new RuntimeException(msg);
+                }
+                addEnvVar(knownVariables, v.getName(), argValue);
+            }
+            return knownVariables;
         }
 
         private String readLine(InputStream in) throws IOException {

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/config.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/config.jelly
@@ -8,18 +8,33 @@
                 Docker image must have <a href="https://go.java">Java</a> installed.
             </li>
             <li>
-                Entrypoint must be able to accept jenkins slave connection parameters.
-                See docker container
-                <a href="https://hub.docker.com/r/jenkins/jnlp-slave">jenkins/jnlp-slave</a>
-                and/or source
-                <a href="https://github.com/jenkinsci/docker-jnlp-slave">jenkinsci/docker-jnlp-slave</a>
-                as an example.
+                Docker image CMD must either be empty or simply sit and wait forever, e.g. /bin/bash.
             </li>
         </ul>
+        The Jenkins remote agent code will be copied into the container
+        and then run using the Java that's installed in the container.
+        <br/>
+        See docker container
+        <a href="https://hub.docker.com/r/jenkins/agent">jenkins/agent</a>
+        and/or source
+        <a href="https://github.com/jenkinsci/docker-agent">jenkinsci/docker-agent</a>
+        as an example.
     </f:block>
 
     <f:entry title="${%User}" field="user">
         <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%Java Executable}" field="javaExe">
+        <f:textbox/>
+    </f:entry>
+
+    <f:entry title="${%JVM Arguments}" field="jvmArgsString">
+        <f:expandableTextbox />
+    </f:entry>
+
+    <f:entry title="${%EntryPoint Cmd}" field="entryPointCmdString">
+        <f:expandableTextbox />
     </f:entry>
 
 </j:jelly>

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/help-entryPointCmdString.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/help-entryPointCmdString.jelly
@@ -1,0 +1,39 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div>
+    <p>
+      Overrides the command passed to <code>docker exec</code> when the remote agent code is run on the container.
+    </p>
+    <p>
+      <b>NOTE:</b>
+      This field is a multi-line string.
+      Each (non-empty) line defines a separate argument.
+      If you require more than one argument
+      (e.g. copying one of the examples below)
+      then you will need to expand the field,
+      otherwise you'll end up with one long line instead of multiple lines.
+    </p>
+    <p>
+      Limited variable substitution (using $${VARIABLE_NAME} syntax) is carried out on the configured strings prior to starting the container.
+      In addition to any globally configured environment variables, the variables that can be used here are:
+      <dl>
+        <j:forEach var="entry" items="${app.getDescriptor('io.jenkins.docker.connector.DockerComputerAttachConnector').entryPointCmdVariables}">
+          <dt><tt>${entry.name}</tt></dt>
+          <dd>${entry.description}</dd>
+        </j:forEach>
+      </dl>
+    </p>
+    <p>
+      If this field is left blank then it defaults to arguments
+      suitable for the standard
+      Jenkins Agent Docker image, 
+      <a href="https://github.com/jenkinsci/docker-agent">jenkins/agent</a>,
+      which are:
+      <blockquote>
+        <j:forEach var="entry" items="${app.getDescriptor('io.jenkins.docker.connector.DockerComputerAttachConnector').defaultEntryPointCmd}">
+          <tt>${entry}</tt><br/>
+        </j:forEach>
+      </blockquote>
+    </p>
+  </div>
+</j:jelly>

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/help-javaExe.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/help-javaExe.jelly
@@ -1,0 +1,22 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div>
+    <p>
+      The java command to be <code>exec</code>ed on the container in order to run the remote agent code.
+      <br/>
+      If this is not an absolute pathname then the executable must be on the container's PATH.
+      <br/>
+      Defaults to <code>${app.getDescriptor('io.jenkins.docker.connector.DockerComputerAttachConnector').defaultJavaExe}</code>.
+    </p>
+    <p>
+      <b>NOTE:</b>
+      This sets the
+      ${app.getDescriptor('io.jenkins.docker.connector.DockerComputerAttachConnector').javaExeVariableName}
+      in the entry point command.
+      If you override the entry point command
+      but do <em>not</em> include the
+      ${app.getDescriptor('io.jenkins.docker.connector.DockerComputerAttachConnector').javaExeVariableName}
+      variable then this setting will have no effect.
+    </p>
+  </div>
+</j:jelly>

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/help-jvmArgsString.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerAttachConnector/help-jvmArgsString.jelly
@@ -1,0 +1,20 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+  <div>
+    <p>
+      Any arguments to be passed to the JVM executable.
+      <br/>
+      Defaults to nothing at all.
+    </p>
+    <p>
+      <b>NOTE:</b>
+      This sets the
+      ${app.getDescriptor('io.jenkins.docker.connector.DockerComputerAttachConnector').jvmArgsVariableName}
+      in the entry point command.
+      If you override the entry point command
+      but do <em>not</em> include the
+      ${app.getDescriptor('io.jenkins.docker.connector.DockerComputerAttachConnector').jvmArgsVariableName}
+      variable then this setting will have no effect.
+    </p>
+  </div>
+</j:jelly>

--- a/src/main/resources/io/jenkins/docker/pipeline/DockerNodeStep/config.jelly
+++ b/src/main/resources/io/jenkins/docker/pipeline/DockerNodeStep/config.jelly
@@ -19,6 +19,8 @@
         <c:select/>
       </f:entry>
 
+      <f:dropdownDescriptorSelector field="connector" title="Connect method"/>
+
   </f:advanced>
 
 </j:jelly>

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerImagePullStrategyTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerImagePullStrategyTest.java
@@ -2,7 +2,6 @@ package com.nirima.jenkins.plugins.docker;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -44,15 +43,12 @@ public class DockerImagePullStrategyTest {
                 {true, "repo/name:latest", DockerImagePullStrategy.PULL_NEVER, false},
                 {false, "repo/name:1.0", DockerImagePullStrategy.PULL_NEVER, false},
                 {true, "repo/name:1.0", DockerImagePullStrategy.PULL_NEVER, false},
-
         });
     }
 
     @Test
     public void shouldPullImageTest() {
-
         DockerClient dockerClient = mockDockerClient();
-
         assertEquals(shouldPull, pullStrategy.shouldPullImage(dockerClient, imageName));
     }
 
@@ -63,29 +59,12 @@ public class DockerImagePullStrategyTest {
         this.shouldPull = shouldPull;
     }
 
-    // util methods
-    private DockerCloud createDockerCloud() {
-        return new DockerCloud("name",
-                Collections.<DockerTemplate>emptyList(), //templates
-                "http://localhost:4243", //serverUrl
-                100, //containerCap,
-                10, // connectTimeout,
-                10, // readTimeout,
-                null, // credentialsId,
-                null, //version
-                null); // dockerHostname
-    }
-
-
     private DockerClient mockDockerClient() {
-
         InspectImageCmd cmd = mock(InspectImageCmd.class);
-
         if (existedImage)
             when(cmd.exec()).thenReturn(mock(InspectImageResponse.class));
         else
             when(cmd.exec()).thenThrow(new NotFoundException("not found"));
-
         DockerClient dockerClient = mock(DockerClient.class);
         when(dockerClient.inspectImageCmd(imageName)).thenReturn(cmd);
 

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
@@ -2,6 +2,13 @@ package io.jenkins.docker.connector;
 
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
 import com.nirima.jenkins.plugins.docker.DockerTemplateBase;
+
+import io.jenkins.docker.connector.DockerComputerAttachConnector.ArgumentVariables;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import org.junit.Test;
 
 public class DockerComputerAttachConnectorTest extends DockerComputerConnectorTest {
@@ -9,12 +16,38 @@ public class DockerComputerAttachConnectorTest extends DockerComputerConnectorTe
 
     @Test
     public void connectAgentViaDirectAttach() throws Exception {
+        final DockerComputerAttachConnector connector = new DockerComputerAttachConnector(COMMON_IMAGE_USERNAME);
+        final String testName = "connectAgentViaDirectAttach";
+        testAgentCanStartAndConnect(connector, testName);
+    }
+
+    @Test
+    public void connectAgentViaDirectAttachWithCustomCmd() throws Exception {
+        final DockerComputerAttachConnector connector = new DockerComputerAttachConnector(COMMON_IMAGE_USERNAME);
+        // We could setJavaExe("/usr/local/openjdk-8/bin/java") too, but that'd mean
+        // we'd break the instant that the public docker image's JVM updates to 9 or
+        // higher; best stick to just using the $PATH.
+        connector.setJvmArgsString("-Xmx1g"+"\n"
+                + "-Dfoo=bar\n");
+        connector.setEntryPointCmdString("java\n"
+            + "${" + ArgumentVariables.JvmArgs.getName() + "}\n"
+            + "-Dsomething=somethingElse\n"
+            + "-jar\n"
+            + "${" + ArgumentVariables.RemoteFs.getName() + "}/${" + ArgumentVariables.JarName.getName() + "}\n"
+            + "-noReconnect\n"
+            + "-noKeepAlive\n");
+        final String testName = "connectAgentViaDirectAttachWithCustomCmd";
+        testAgentCanStartAndConnect(connector, testName);
+    }
+
+    private void testAgentCanStartAndConnect(final DockerComputerAttachConnector connector, final String testName)
+            throws IOException, ExecutionException, InterruptedException, TimeoutException {
         final DockerTemplate template = new DockerTemplate(
                 new DockerTemplateBase(ATTACH_SLAVE_IMAGE_IMAGENAME),
-                new DockerComputerAttachConnector(COMMON_IMAGE_USERNAME),
+                connector,
                 LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );
-        template.setName("connectAgentViaDirectAttach");
+        template.setName(testName);
         should_connect_agent(template);
     }
 }


### PR DESCRIPTION
We keep getting unit-test failures on DockerNodeStepTest on jenkinsci builds ... but these don't seem to happen when run locally.  I've seen memory-allocation failures from the JVM which _might_ be each JVM allocating 25% of host ram on a host running more than 3 docker containers at once.

So, this enhances the "attach" connect method to make the command it runs fully configurable (like we can with JNLP nodes) and then uses that to specify a -Xmx limit in the dodgy test.