### PR TITLE
DockerBuilderPublisher now throws a better cloud-not-found error.

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -828,20 +828,6 @@ public class DockerCloud extends Cloud {
 
     @Restricted(NoExternalUse.class)
     @CheckForNull
-    static DockerCloud findCloudByName(final String cloudName) {
-        for (Cloud cloud : Jenkins.getInstance().clouds) {
-            if (cloud instanceof DockerCloud) {
-                final String thisCloudName = cloud.getDisplayName();
-                if (cloudName.equals(thisCloudName)) {
-                    return (DockerCloud) cloud;
-                }
-            }
-        }
-        return null;
-    }
-
-    @Restricted(NoExternalUse.class)
-    @CheckForNull
     static DockerCloud findCloudForTemplate(final DockerTemplate template) {
         for (DockerCloud cloud : instances()) {
             if ( cloud.hasTemplate(template) ) {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -40,6 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -813,18 +815,33 @@ public class DockerCloud extends Cloud {
         return TimeUnit.SECONDS.toMillis(ERROR_DURATION_DEFAULT_SECONDS);
     }
 
+    @Nonnull
     public static List<DockerCloud> instances() {
         List<DockerCloud> instances = new ArrayList<>();
         for (Cloud cloud : Jenkins.getInstance().clouds) {
             if (cloud instanceof DockerCloud) {
                 instances.add((DockerCloud) cloud);
             }
-
         }
         return instances;
     }
 
     @Restricted(NoExternalUse.class)
+    @CheckForNull
+    static DockerCloud findCloudByName(final String cloudName) {
+        for (Cloud cloud : Jenkins.getInstance().clouds) {
+            if (cloud instanceof DockerCloud) {
+                final String thisCloudName = cloud.getDisplayName();
+                if (cloudName.equals(thisCloudName)) {
+                    return (DockerCloud) cloud;
+                }
+            }
+        }
+        return null;
+    }
+
+    @Restricted(NoExternalUse.class)
+    @CheckForNull
     static DockerCloud findCloudForTemplate(final DockerTemplate template) {
         for (DockerCloud cloud : instances()) {
             if ( cloud.hasTemplate(template) ) {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagement.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagement.java
@@ -81,12 +81,7 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
     }
 
     public Collection<String> getServerNames() {
-        return Collections2.transform(JenkinsUtils.getServers(), new Function<DockerCloud, String>() {
-            @Override
-            public String apply(DockerCloud input) {
-                return input.getDisplayName();
-            }
-        });
+        return JenkinsUtils.getServerNames();
     }
 
     public static class ServerDetail {
@@ -109,13 +104,13 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
                 }
                 return "(" + containers.size() + ")";
             } catch (Exception ex) {
-                return "Error";
+                return "Error: " + ex;
             }
         }
     }
 
     public Collection<ServerDetail> getServers() {
-        return Collections2.transform(JenkinsUtils.getServers(), new Function<DockerCloud, ServerDetail>() {
+        return Collections2.transform(DockerCloud.instances(), new Function<DockerCloud, ServerDetail>() {
             @Override
             public ServerDetail apply(@Nullable DockerCloud input) {
                 return new ServerDetail(input);

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagementServer.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagementServer.java
@@ -36,7 +36,7 @@ public class DockerManagementServer implements Describable<DockerManagementServe
 
     public DockerManagementServer(String name) {
         this.name = name;
-        theCloud = JenkinsUtils.getServer(name);
+        theCloud = JenkinsUtils.getCloudByNameOrThrow(name);
     }
 
     public Collection getImages(){

--- a/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher.java
@@ -246,7 +246,7 @@ public class DockerBuilderPublisher extends Builder implements SimpleBuildStep {
         DockerCloud theCloud;
         final VirtualChannel channel = launcher.getChannel();
         if (!Strings.isNullOrEmpty(cloud)) {
-            theCloud = JenkinsUtils.getServer(cloud);
+            theCloud = JenkinsUtils.getCloudByNameOrThrow(cloud);
         } else {
             if(channel instanceof Channel) {
                 final Node node = Jenkins.getInstance().getNode(((Channel)channel).getName() );
@@ -263,7 +263,7 @@ public class DockerBuilderPublisher extends Builder implements SimpleBuildStep {
         // Triton can't do docker build. Ensure we're not trying to do that.
         if (theCloud.isTriton()) {
             LOGGER.warn("Selected cloud for build does not support this feature. Finding an alternative");
-            for (DockerCloud dc : JenkinsUtils.getServers()) {
+            for (DockerCloud dc : DockerCloud.instances()) {
                 if (!dc.isTriton()) {
                     LOGGER.warn("Picked {} cloud instead", dc.getDisplayName());
                     theCloud = dc;

--- a/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
@@ -96,8 +96,7 @@ public class JenkinsUtils {
     @Nonnull
     public static DockerCloud getCloudByNameOrThrow(final String serverName) {
         try {
-            final DockerCloud resultOrNull;
-            resultOrNull = DockerCloud.getCloudByName(serverName);
+            final DockerCloud resultOrNull = DockerCloud.getCloudByName(serverName);
             if (resultOrNull != null) {
                 return resultOrNull;
             }

--- a/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtils.java
@@ -95,9 +95,14 @@ public class JenkinsUtils {
     @Restricted(NoExternalUse.class)
     @Nonnull
     public static DockerCloud getCloudByNameOrThrow(final String serverName) {
-        final DockerCloud resultOrNull = DockerCloud.getCloudByName(serverName);
-        if (resultOrNull != null) {
-            return resultOrNull;
+        try {
+            final DockerCloud resultOrNull;
+            resultOrNull = DockerCloud.getCloudByName(serverName);
+            if (resultOrNull != null) {
+                return resultOrNull;
+            }
+        } catch (ClassCastException treatedAsCloudNotFound) {
+            // we found a cloud of that name, but it wasn't one of ours.
         }
         throw new IllegalArgumentException("No " + DockerCloud.class.getSimpleName() + " with name '" + serverName
                 + "'.  Known names are " + getServerNames());

--- a/src/test/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtilsTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtilsTest.java
@@ -1,0 +1,118 @@
+package com.nirima.jenkins.plugins.docker.utils;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.nirima.jenkins.plugins.docker.DockerCloud;
+
+import hudson.model.Label;
+import hudson.slaves.Cloud;
+import hudson.slaves.NodeProvisioner.PlannedNode;
+import io.jenkins.docker.client.DockerAPI;
+
+public class JenkinsUtilsTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void getCloudByNameOrThrowGivenNameThenReturnsCloud() throws Exception {
+        // Given
+        final DockerAPI dockerApi = new DockerAPI(new DockerServerEndpoint("uri", "credentialsId"));
+        final DockerCloud cloudEmpty = new DockerCloud("", dockerApi, Collections.emptyList());
+        final String expectedCloudName = "expectedCloudName";
+        final DockerCloud cloudExpected = new DockerCloud(expectedCloudName, dockerApi, Collections.emptyList());
+        final DockerCloud cloudOther = new DockerCloud("otherCloudName", dockerApi, Collections.emptyList());
+        final OtherTypeOfCloud cloudForeign = new OtherTypeOfCloud("foreign");
+        final List<Cloud> clouds = Arrays.asList(cloudEmpty, cloudOther, cloudExpected, cloudForeign);
+        jenkins.getInstance().clouds.replaceBy(clouds);
+
+        // When
+        final DockerCloud actual = JenkinsUtils.getCloudByNameOrThrow(expectedCloudName);
+
+        // Then
+        assertThat(actual, sameInstance(cloudExpected));
+    }
+
+    @Test
+    public void getCloudByNameOrThrowGivenUnknownNameThenThrows() throws Exception {
+        // Given
+        final DockerAPI dockerApi = new DockerAPI(new DockerServerEndpoint("uri", "credentialsId"));
+        final DockerCloud cloudEmpty = new DockerCloud("", dockerApi, Collections.emptyList());
+        final String requestedCloudName = "anUnknownCloudName";
+        final String cloudName1 = "expectedCloudName";
+        final DockerCloud cloud1 = new DockerCloud(cloudName1, dockerApi, Collections.emptyList());
+        final String cloudName2 = "otherCloudName";
+        final DockerCloud cloud2 = new DockerCloud(cloudName2, dockerApi, Collections.emptyList());
+        final OtherTypeOfCloud cloudForeign = new OtherTypeOfCloud("foreign");
+        final List<Cloud> clouds = Arrays.asList(cloudEmpty, cloud2, cloud1, cloudForeign);
+        jenkins.getInstance().clouds.replaceBy(clouds);
+
+        try {
+            // When
+            JenkinsUtils.getCloudByNameOrThrow(requestedCloudName);
+            Assert.fail("Expected " + IllegalArgumentException.class.getCanonicalName());
+        } catch (IllegalArgumentException ex) {
+            // Then
+            final String actualMsg = ex.getMessage();
+            assertThat(actualMsg, containsString(requestedCloudName));
+            assertThat(actualMsg, containsString(cloudName1));
+            assertThat(actualMsg, containsString(cloudName2));
+            assertThat(actualMsg, not(containsString(cloudForeign.name)));
+        }
+    }
+
+    @Test
+    public void getCloudByNameOrThrowGivenForeignCloudNameThenThrows() throws Exception {
+        // Given
+        final DockerAPI dockerApi = new DockerAPI(new DockerServerEndpoint("uri", "credentialsId"));
+        final DockerCloud cloudEmpty = new DockerCloud("", dockerApi, Collections.emptyList());
+        final String requestedCloudName = "foreign";
+        final String cloudName1 = "DockerCloud1Name";
+        final DockerCloud cloud1 = new DockerCloud(cloudName1, dockerApi, Collections.emptyList());
+        final String cloudName2 = "DockerCloud2Name";
+        final DockerCloud cloud2 = new DockerCloud(cloudName2, dockerApi, Collections.emptyList());
+        final OtherTypeOfCloud cloudForeign = new OtherTypeOfCloud(requestedCloudName);
+        final List<Cloud> clouds = Arrays.asList(cloudEmpty, cloud2, cloud1, cloudForeign);
+        jenkins.getInstance().clouds.replaceBy(clouds);
+
+        try {
+            // When
+            JenkinsUtils.getCloudByNameOrThrow(requestedCloudName);
+            Assert.fail("Expected " + IllegalArgumentException.class.getCanonicalName());
+        } catch (IllegalArgumentException ex) {
+            // Then
+            final String actualMsg = ex.getMessage();
+            assertThat(actualMsg, containsString(requestedCloudName));
+            assertThat(actualMsg, containsString(cloudName1));
+            assertThat(actualMsg, containsString(cloudName2));
+        }
+    }
+
+    private static class OtherTypeOfCloud extends Cloud {
+        protected OtherTypeOfCloud(String name) {
+            super(name);
+        }
+
+        @Override
+        public Collection<PlannedNode> provision(Label label, int excessWorkload) {
+            return null;
+        }
+
+        @Override
+        public boolean canProvision(Label label) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
One of my co-workers foudn their build failed with the following (rather unhelpful) error:
```
ERROR: Build step failed with exception
java.util.NoSuchElementException
	at com.google.common.collect.AbstractIterator.next(AbstractIterator.java:154)
	at com.google.common.collect.Iterators.find(Iterators.java:722)
	at com.google.common.collect.Iterables.find(Iterables.java:643)
	at com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.getServer(JenkinsUtils.java:100)
	at com.nirima.jenkins.plugins.docker.builder.DockerBuilderPublisher.getCloud(DockerBuilderPublisher.java:234)
	at com.nirima.jenkins.plugins.docker.builder.DockerBuilderPublisher.perform(DockerBuilderPublisher.java:453)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:78)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:741)
	at hudson.model.Build$BuildExecution.build(Build.java:206)
	at hudson.model.Build$BuildExecution.doRun(Build.java:163)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
	at hudson.model.Run.execute(Run.java:1856)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:428)
Build step 'Build / Publish Docker Image' marked build as failure
```

This PR is intended to improve that error so that the solution is more self-evident.