### PR TITLE
Fix malformed Javadoc link

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -63,7 +63,7 @@ import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.startToString
 
 public class DockerTemplate implements Describable<DockerTemplate> {
     /**
-     * The default timeout in seconds ({@value)s} to wait during container shutdown
+     * The default timeout in seconds ({@value #DEFAULT_STOP_TIMEOUT}s) to wait during container shutdown
      * until it will be forcefully terminated.
      */
     public static final int DEFAULT_STOP_TIMEOUT = 10;


### PR DESCRIPTION
While the Javadoc has lots of warnings (mostly about missing things), this was causing an actual error.