### PR TITLE
improve doc about launch attached

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ No new restrictions/conditions are permitted.
   * How is this failing?
   * What should happen instead?
 - Provide step-by-step instructions for how to reproduce the issue.
-  * Try to avoid relying on custom docker images or for the repro case. Ideally, reproduce with a `jenkins/(ssh-slave|jnlp-slave|slave)` image with a dumb freestyle job, as that makes life easier for everyone.
+  * Try to avoid relying on custom docker images or for the repro case. Ideally, reproduce with a `jenkins/(ssh-slave|jnlp-slave|agent)` image with a dumb freestyle job, as that makes life easier for everyone.
 - Specify the Jenkins core & plugin version (of all docker-related plugins) that you're seeing the issue with.
 - Check `Manage Jenkins` -> `Manage Old Data` for out of date configuration data and provide this info.
 - Check and provide errors from system jenkins.log and errors from `Manage Jenkins` -> `System Log`.

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ for the Docker image to be used:
 
 -   a JDK installed.
     You can use
-    [jenkins/slave](https://hub.docker.com/r/jenkins/slave/)
+    [jenkins/agent](https://hub.docker.com/r/jenkins/agent/)
     as a basis for a custom image. 
 
 To create a custom image and bundle your favorite tools,
 create a `Dockerfile` with the `FROM` to point to one of the
-jenkins/\*-slave
+jenkins/\*-slave or jenkins/agent
 reference images,
 and install everything needed for your own usage, e.g.
 


### PR DESCRIPTION
Image jenkins/slave seems to be deprecated (see documentation on https://hub.docker.com/r/jenkins/slave/). It is mention to use jenkins/agent instead of