### PR TITLE
upgrade to docker-java-api 3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,20 +55,20 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.level>8</java.level>
         <groovy.version>2.4.7</groovy.version>
-        <jenkins.version>2.73.3</jenkins.version>
+        <jenkins.version>2.235.1</jenkins.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>bouncycastle-api</artifactId>
-            <version>2.16.2</version>
+            <version>2.18</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-java-api</artifactId>
-            <version>3.1.5</version>
+            <version>3.2.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
@@ -80,19 +80,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.3-2.0</version>
+            <version>4.5.10-2.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>1.9</version>
+            <version>1.11</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.22</version>
+            <version>1.30.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -103,6 +103,11 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
             <version>1.16</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jdk-tool</artifactId>
+            <version>1.4</version>
         </dependency>
 
         <dependency>
@@ -176,7 +181,7 @@
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -204,6 +209,11 @@
             <version>2.6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>trilead-api</artifactId>
+            <version>1.0.13</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -211,7 +221,64 @@
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>structs</artifactId>
-                <version>1.9</version>
+                <version>1.20</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>credentials-binding</artifactId>
+                <version>1.16</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>credentials</artifactId>
+                <version>2.3.14</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>plain-credentials</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>ssh-credentials</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.modules</groupId>
+                <artifactId>ssh-cli-auth</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.modules</groupId>
+                <artifactId>launchd-slave-installer</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>scm-api</artifactId>
+            </dependency>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.235.x</artifactId>
+                <version>21</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>log4j-over-slf4j</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-jdk14</artifactId>
+                <version>1.7.30</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -29,12 +29,12 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
                 isUseSSHKey() ? new DockerComputerSSHConnector.InjectSSHKey(user)
                           : new DockerComputerSSHConnector.ManuallyConfiguredSSHKey(sshConnector.getCredentialsId(), null);
         final DockerComputerSSHConnector connector = new DockerComputerSSHConnector(strategy);
-        connector.setJavaPath(sshConnector.javaPath);
-        connector.setJvmOptions(sshConnector.jvmOptions);
-        connector.setLaunchTimeoutSeconds(sshConnector.launchTimeoutSeconds);
+        connector.setJavaPath(sshConnector.getJavaPath());
+        connector.setJvmOptions(sshConnector.getJvmOptions());
+        connector.setLaunchTimeoutSeconds(sshConnector.getLaunchTimeoutSeconds());
         connector.setPort(sshConnector.port);
-        connector.setPrefixStartSlaveCmd(sshConnector.prefixStartSlaveCmd);
-        connector.setSuffixStartSlaveCmd(sshConnector.suffixStartSlaveCmd);
+        connector.setPrefixStartSlaveCmd(sshConnector.getPrefixStartSlaveCmd());
+        connector.setSuffixStartSlaveCmd(sshConnector.getSuffixStartSlaveCmd());
 
         return connector;
     }

--- a/src/main/java/io/jenkins/docker/client/DelegatingDockerClient.java
+++ b/src/main/java/io/jenkins/docker/client/DelegatingDockerClient.java
@@ -5,78 +5,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.AttachContainerCmd;
-import com.github.dockerjava.api.command.AuthCmd;
-import com.github.dockerjava.api.command.BuildImageCmd;
-import com.github.dockerjava.api.command.CommitCmd;
-import com.github.dockerjava.api.command.ConnectToNetworkCmd;
-import com.github.dockerjava.api.command.ContainerDiffCmd;
-import com.github.dockerjava.api.command.CopyArchiveFromContainerCmd;
-import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
-import com.github.dockerjava.api.command.CopyFileFromContainerCmd;
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.command.CreateImageCmd;
-import com.github.dockerjava.api.command.CreateNetworkCmd;
-import com.github.dockerjava.api.command.CreateServiceCmd;
-import com.github.dockerjava.api.command.CreateVolumeCmd;
-import com.github.dockerjava.api.command.DisconnectFromNetworkCmd;
-import com.github.dockerjava.api.command.EventsCmd;
-import com.github.dockerjava.api.command.ExecCreateCmd;
-import com.github.dockerjava.api.command.ExecStartCmd;
-import com.github.dockerjava.api.command.InfoCmd;
-import com.github.dockerjava.api.command.InitializeSwarmCmd;
-import com.github.dockerjava.api.command.InspectContainerCmd;
-import com.github.dockerjava.api.command.InspectExecCmd;
-import com.github.dockerjava.api.command.InspectImageCmd;
-import com.github.dockerjava.api.command.InspectNetworkCmd;
-import com.github.dockerjava.api.command.InspectServiceCmd;
-import com.github.dockerjava.api.command.InspectSwarmCmd;
-import com.github.dockerjava.api.command.InspectVolumeCmd;
-import com.github.dockerjava.api.command.JoinSwarmCmd;
-import com.github.dockerjava.api.command.KillContainerCmd;
-import com.github.dockerjava.api.command.LeaveSwarmCmd;
-import com.github.dockerjava.api.command.ListContainersCmd;
-import com.github.dockerjava.api.command.ListImagesCmd;
-import com.github.dockerjava.api.command.ListNetworksCmd;
-import com.github.dockerjava.api.command.ListServicesCmd;
-import com.github.dockerjava.api.command.ListSwarmNodesCmd;
-import com.github.dockerjava.api.command.ListTasksCmd;
-import com.github.dockerjava.api.command.ListVolumesCmd;
-import com.github.dockerjava.api.command.LoadImageCmd;
-import com.github.dockerjava.api.command.LogContainerCmd;
-import com.github.dockerjava.api.command.LogSwarmObjectCmd;
-import com.github.dockerjava.api.command.PauseContainerCmd;
-import com.github.dockerjava.api.command.PingCmd;
-import com.github.dockerjava.api.command.PruneCmd;
-import com.github.dockerjava.api.command.PullImageCmd;
-import com.github.dockerjava.api.command.PushImageCmd;
-import com.github.dockerjava.api.command.RemoveContainerCmd;
-import com.github.dockerjava.api.command.RemoveImageCmd;
-import com.github.dockerjava.api.command.RemoveNetworkCmd;
-import com.github.dockerjava.api.command.RemoveServiceCmd;
-import com.github.dockerjava.api.command.RemoveVolumeCmd;
-import com.github.dockerjava.api.command.RenameContainerCmd;
-import com.github.dockerjava.api.command.RestartContainerCmd;
-import com.github.dockerjava.api.command.SaveImageCmd;
-import com.github.dockerjava.api.command.SearchImagesCmd;
-import com.github.dockerjava.api.command.StartContainerCmd;
-import com.github.dockerjava.api.command.StatsCmd;
-import com.github.dockerjava.api.command.StopContainerCmd;
-import com.github.dockerjava.api.command.TagImageCmd;
-import com.github.dockerjava.api.command.TopContainerCmd;
-import com.github.dockerjava.api.command.UnpauseContainerCmd;
-import com.github.dockerjava.api.command.UpdateContainerCmd;
-import com.github.dockerjava.api.command.UpdateServiceCmd;
-import com.github.dockerjava.api.command.UpdateSwarmCmd;
-import com.github.dockerjava.api.command.UpdateSwarmNodeCmd;
-import com.github.dockerjava.api.command.VersionCmd;
-import com.github.dockerjava.api.command.WaitContainerCmd;
+import com.github.dockerjava.api.command.*;
 import com.github.dockerjava.api.exception.DockerException;
-import com.github.dockerjava.api.model.AuthConfig;
-import com.github.dockerjava.api.model.Identifier;
-import com.github.dockerjava.api.model.PruneType;
-import com.github.dockerjava.api.model.ServiceSpec;
-import com.github.dockerjava.api.model.SwarmSpec;
+import com.github.dockerjava.api.model.*;
 
 /**
  * Simple delegate class for the {@link DockerClient} interface. This makes it
@@ -316,6 +247,16 @@ public class DelegatingDockerClient implements DockerClient {
     }
 
     @Override
+    public ResizeContainerCmd resizeContainerCmd(String containerId) {
+        return getDelegate().resizeContainerCmd(containerId);
+    }
+
+    @Override
+    public ResizeExecCmd resizeExecCmd(String execId) {
+        return getDelegate().resizeExecCmd(execId);
+    }
+
+    @Override
     public RestartContainerCmd restartContainerCmd(String arg0) {
         return getDelegate().restartContainerCmd(arg0);
     }
@@ -323,6 +264,12 @@ public class DelegatingDockerClient implements DockerClient {
     @Override
     public SaveImageCmd saveImageCmd(String arg0) {
         return getDelegate().saveImageCmd(arg0);
+    }
+
+
+    @Override
+    public SaveImagesCmd saveImagesCmd() {
+        return getDelegate().saveImagesCmd();
     }
 
     @Override
@@ -453,5 +400,21 @@ public class DelegatingDockerClient implements DockerClient {
     @Override
     public PruneCmd pruneCmd(PruneType pruneType) {
         return getDelegate().pruneCmd(pruneType);
+    }
+
+
+    @Override
+    public ListSecretsCmd listSecretsCmd() {
+        return getDelegate().listSecretsCmd();
+    }
+
+    @Override
+    public CreateSecretCmd createSecretCmd(SecretSpec secretSpec) {
+        return getDelegate().createSecretCmd(secretSpec);
+    }
+
+    @Override
+    public RemoveSecretCmd removeSecretCmd(String secretId) {
+        return getDelegate().removeSecretCmd(secretId);
     }
 }

--- a/src/main/java/io/jenkins/docker/client/DockerAPI.java
+++ b/src/main/java/io/jenkins/docker/client/DockerAPI.java
@@ -2,6 +2,7 @@ package io.jenkins.docker.client;
 
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.DockerCmdExecFactory;
 import com.github.dockerjava.api.command.VersionCmd;
 import com.github.dockerjava.api.model.Version;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
@@ -242,7 +243,7 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> {
     @SuppressWarnings("resource")
     private static SharableDockerClient makeClient(final String dockerUri, final String credentialsId,
             final Integer readTimeoutInMillisecondsOrNull, final Integer connectTimeoutInMillisecondsOrNull) {
-        NettyDockerCmdExecFactory cmdExecFactory = null;
+        DockerCmdExecFactory cmdExecFactory = null;
         DockerClient actualClient = null;
         try {
             cmdExecFactory = new NettyDockerCmdExecFactory()


### PR DESCRIPTION
please see #825

notes:

* relies on docker-java-api being updated to use docker-java 3.2.2 (e.g. DO NOT MERGE :-) )
* requires docker-java-api remove the maven exclusion on bouncycastle
* Amazon ECR Credentials plugin no longer works with this.
