### PR TITLE
Bugfix for Issue #709: Fixes addition of :latest to digests

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -898,7 +898,18 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
     public String getFullImageId() {
         NameParser.ReposTag repostag = NameParser.parseRepositoryTag(image);
         // if image was specified without tag, then treat as latest
-        return repostag.repos + ":" + (repostag.tag.isEmpty() ? "latest" : repostag.tag);
+        if(repostag.tag.isEmpty()){
+            if(repostag.repos.contains("@sha256:")){
+                // image has no tag but instead use a digest, do not append anything!
+                return  repostag.repos;
+            }else{
+                // no tag provided, append latest as tag
+                return repostag.repos + ":" + "latest";
+            }
+        }else{
+            // use declared tag:
+            return repostag.repos + ":" + repostag.tag;
+        }
     }
 
     @Override

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
@@ -1,5 +1,8 @@
 package com.nirima.jenkins.plugins.docker;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyLong;
@@ -228,5 +231,49 @@ public class DockerTemplateBaseTest {
         } else {
             verify(mockCmd, never()).withCapDrop(anyList());
         }
+    }
+
+    @Test
+    public void doNotOverrideDigestsWhenCalculatingFullName(){
+        String simpleBaseImage = "jenkins/inbound-agent";
+        String imageWithRegistry = "registry.example.org/"+simpleBaseImage;
+        String tag = ":4.3-9-jdk8-nanoserver-1809";
+        String digest = "@sha256:3e64707b1244724e6d958f8aea840cc307fc2777c0bff4b236757f636a83da46";
+
+        assertThat(
+            "fall back to latest tag if none given",
+            new DockerTemplateBase(simpleBaseImage).getFullImageId(),
+            endsWithIgnoringCase(":latest")
+        );
+
+        assertThat(
+            "fall back to latest tag if none given",
+            new DockerTemplateBase(imageWithRegistry).getFullImageId(),
+            endsWithIgnoringCase(":latest")
+        );
+
+        assertThat(
+            "preserve provided tags",
+            new DockerTemplateBase(simpleBaseImage+tag).getFullImageId(),
+            endsWithIgnoringCase(tag)
+        );
+
+        assertThat(
+            "preserve provided tags",
+            new DockerTemplateBase(imageWithRegistry+tag).getFullImageId(),
+            endsWithIgnoringCase(tag)
+        );
+
+        assertThat(
+            "preserve provided digest",
+            new DockerTemplateBase(simpleBaseImage+digest).getFullImageId(),
+            endsWithIgnoringCase(digest)
+        );
+
+        assertThat(
+            "preserve provided digest",
+            new DockerTemplateBase(imageWithRegistry+digest).getFullImageId(),
+            endsWithIgnoringCase(digest)
+        );
     }
 }

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
@@ -247,6 +247,18 @@ public class DockerTemplateBaseTest {
         );
 
         assertThat(
+            "handle missing tag but existing colon",
+            new DockerTemplateBase(simpleBaseImage+":").getFullImageId(),
+            endsWithIgnoringCase(":latest")
+        );
+
+        assertThat(
+            "do not fix missing sha256 checksum with a tag",
+            new DockerTemplateBase(simpleBaseImage+"@sha256:").getFullImageId(),
+            not(endsWithIgnoringCase("latest"))
+        );
+
+        assertThat(
             "fall back to latest tag if none given",
             new DockerTemplateBase(imageWithRegistry).getFullImageId(),
             endsWithIgnoringCase(":latest")


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->

Added more Checks to [DockerTemplateBase.getFullImageId()](https://github.com/jenkinsci/docker-plugin/blob/master/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java#L898) that prevent the addition of ':latest' to images if the NameParser does not recognize a tag.
This addition causes problems if you specify an image not by tag but by digest. See #709 for more iformation and links

Provided tests check that images tags and digests are preserved and latest is only added if no tag AND no digest is specified