### PR TITLE
Bump min version of Jenkins to 2.204.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 A pre-release can be downloaded from https://ci.jenkins.io/job/Plugins/job/docker-plugin/job/master/
+* Fix DockerNodeStepTest unit test by bumping min Jenkins version from 2.73.3 to 2.204.4
 
 ## 1.2.2
 _2021-01-25_

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.73.3', '2.89.4', '2.107.1'])
+buildPlugin(jenkinsVersions: [null, '2.204.4'])

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.level>8</java.level>
         <groovy.version>2.4.7</groovy.version>
-        <jenkins.version>2.73.3</jenkins.version>
+        <jenkins.version>2.204.4</jenkins.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.56</version>
+        <version>4.0</version>
         <relativePath />
     </parent>
 
@@ -62,107 +62,75 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>bouncycastle-api</artifactId>
-            <version>2.16.2</version>
+            <version>2.18</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-java-api</artifactId>
             <version>3.1.5</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpcore</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.3-2.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>1.9</version>
+            <version>1.16</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.22</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>2.3</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>durable-task</artifactId>
-            <version>1.16</version>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.23.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.14</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.16</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.17</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.12.2</version>
-            <optional>true</optional>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.41</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>script-security</artifactId>
-            <version>1.36</version>
-            <optional>true</optional>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-common</artifactId>
-            <version>2.0.4</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.kohlschutter.junixsocket</groupId>
             <artifactId>junixsocket-native-common</artifactId>
-            <version>2.0.4</version>
+            <version>2.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest</artifactId>
             <version>2.2</version>
             <scope>test</scope>
         </dependency>
@@ -170,13 +138,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
@@ -185,23 +152,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness-tools</artifactId>
-            <version>2.2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.16</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -209,9 +167,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>structs</artifactId>
-                <version>1.9</version>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.222.x</artifactId>
+                <version>10</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -233,44 +193,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-      <!-- Workaround to add new dependency for Jenkins Version 2.86+ as it's removed from Jenkins Core  -->
-      <profile>
-        <id>jenkins_2_89</id>
-        <activation>
-            <property>
-                <name>jenkins.version</name>
-                <value>2.89.4</value>
-            </property>
-        </activation>
-        <dependencies>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>command-launcher</artifactId>
-                <version>1.2</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-      </profile>
-      <profile>
-        <id>jenkins_2_107</id>
-        <activation>
-            <property>
-                <name>jenkins.version</name>
-                <value>2.107.1</value>
-            </property>
-        </activation>
-        <dependencies>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>command-launcher</artifactId>
-                <version>1.2</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-      </profile>
-    </profiles>
 
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/docker-plugin.git</connection>

--- a/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -29,12 +29,12 @@ public class DockerComputerSSHLauncher extends DockerComputerLauncher {
                 isUseSSHKey() ? new DockerComputerSSHConnector.InjectSSHKey(user)
                           : new DockerComputerSSHConnector.ManuallyConfiguredSSHKey(sshConnector.getCredentialsId(), null);
         final DockerComputerSSHConnector connector = new DockerComputerSSHConnector(strategy);
-        connector.setJavaPath(sshConnector.javaPath);
-        connector.setJvmOptions(sshConnector.jvmOptions);
-        connector.setLaunchTimeoutSeconds(sshConnector.launchTimeoutSeconds);
+        connector.setJavaPath(sshConnector.getJavaPath());
+        connector.setJvmOptions(sshConnector.getJvmOptions());
+        connector.setLaunchTimeoutSeconds(sshConnector.getLaunchTimeoutSeconds());
         connector.setPort(sshConnector.port);
-        connector.setPrefixStartSlaveCmd(sshConnector.prefixStartSlaveCmd);
-        connector.setSuffixStartSlaveCmd(sshConnector.suffixStartSlaveCmd);
+        connector.setPrefixStartSlaveCmd(sshConnector.getPrefixStartSlaveCmd());
+        connector.setSuffixStartSlaveCmd(sshConnector.getSuffixStartSlaveCmd());
 
         return connector;
     }

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
@@ -7,6 +7,7 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 import com.nirima.jenkins.plugins.docker.strategy.DockerOnceRetentionStrategy;
 import hudson.model.Node;
+import hudson.util.Secret;
 import io.jenkins.docker.client.DockerAPI;
 import io.jenkins.docker.connector.DockerComputerAttachConnector;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerCredentials;
@@ -47,7 +48,7 @@ public class DockerCloudTest {
 
         // Create fake credentials, so they are selectable on configuration for during configuration roundtrip
         final CredentialsStore store = CredentialsProvider.lookupStores(jenkins.getInstance()).iterator().next();
-        DockerServerCredentials dc = new DockerServerCredentials(SYSTEM, "credentialsId", "test", null, null, null);
+        DockerServerCredentials dc = new DockerServerCredentials(SYSTEM, "credentialsId", "test", (Secret)null, null, null);
         store.addCredentials(Domain.global(), dc);
         UsernamePasswordCredentials rc = new UsernamePasswordCredentialsImpl(SYSTEM, "pullCredentialsId", null, null, null);
         store.addCredentials(Domain.global(), rc);

--- a/src/test/java/com/nirima/jenkins/plugins/docker/TestableDockerContainerWatchdog.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/TestableDockerContainerWatchdog.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
 import org.junit.Assert;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -95,10 +95,10 @@ public class TestableDockerContainerWatchdog extends DockerContainerWatchdog {
         ListContainersCmd listContainerCmd = Mockito.mock(ListContainersCmd.class);
         Mockito.when(client.listContainersCmd()).thenReturn(listContainerCmd);
         Mockito.when(listContainerCmd.withShowAll(true)).thenReturn(listContainerCmd);
-        Mockito.when(listContainerCmd.withLabelFilter(Matchers.anyMap())).thenAnswer( new Answer<ListContainersCmd>() {
+        Mockito.when(listContainerCmd.withLabelFilter(ArgumentMatchers.anyMap())).thenAnswer( new Answer<ListContainersCmd>() {
             @Override
             public ListContainersCmd answer(InvocationOnMock invocation) throws Throwable {
-                Map<String, String> arg = invocation.getArgumentAt(0, Map.class);
+                Map<String, String> arg = invocation.getArgument(0);
                 String jenkinsInstanceIdInFilter = arg.get(DockerContainerLabelKeys.JENKINS_INSTANCE_ID);
                 Assert.assertEquals(UNITTEST_JENKINS_ID, jenkinsInstanceIdInFilter);
                 return listContainerCmd;

--- a/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepTest.java
+++ b/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepTest.java
@@ -244,7 +244,7 @@ public class DockerNodeStepTest {
                 story.j.jenkins.getDescriptorByType(Maven.DescriptorImpl.class).setInstallations(mvnInst);
                 WorkflowJob j = story.j.jenkins.createProject(WorkflowJob.class, "toolInstall");
                 j.setDefinition(new CpsFlowDefinition(dockerNodeJenkinsAgent() + " {\n" +
-                        "  def mvnHome = tool id: 'maven', name: 'myMaven'\n" +
+                        "  def mvnHome = tool name: 'myMaven'\n" +
                         "  assert fileExists(mvnHome + '/bin/mvn')\n" +
                         "}\n", true));
                 story.j.buildAndAssertSuccess(j);


### PR DESCRIPTION
We currently have a failing unit test in #835 that does not appear to be related to that PR.
What we're seeing is that the `DockerNodeStepTest` unit test is failing with exception:
```
WARNING	h.m.DownloadService$Downloadable#updateNow: signature check failed for http://localhost:37881/updates/hudson.tasks.Maven.MavenInstaller.json
ERROR: Signature verification failed in downloadable 'hudson.tasks.Maven.MavenInstaller' java.security.SignatureException: Signature length not correct: got 512 but was expecting 256
	at sun.security.rsa.RSASignature.engineVerify(RSASignature.java:189)
	at java.security.Signature$Delegate.engineVerify(Signature.java:1222)
	at java.security.Signature.verify(Signature.java:655)
	at sun.security.x509.X509CertImpl.verify(X509CertImpl.java:444)
	at sun.security.provider.certpath.BasicChecker.verifySignature(BasicChecker.java:166)
	at sun.security.provider.certpath.BasicChecker.check(BasicChecker.java:147)
	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
Caused: java.security.cert.CertPathValidatorException: signature check failed
	at sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:135)
	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:233)
	at sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:141)
	at sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:80)
	at java.security.cert.CertPathValidator.validate(CertPathValidator.java:292)
	at org.jvnet.hudson.crypto.CertificateUtil.validatePath(CertificateUtil.java:93)
	at jenkins.util.JSONSignatureValidator.verifySignature(JSONSignatureValidator.java:78)
	at hudson.model.DownloadService$Downloadable.updateNow(DownloadService.java:416)
	at io.jenkins.docker.pipeline.DockerNodeStepTest$3.runTest(DockerNodeStepTest.java:237)
	at io.jenkins.docker.pipeline.DockerNodeStepTest$3.evaluate(DockerNodeStepTest.java:228)
	at org.jvnet.hudson.test.RestartableJenkinsRule$6.evaluate(RestartableJenkinsRule.java:272)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:596)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```

This may be related to [JENKINS-31089](https://issues.jenkins.io/browse/JENKINS-31089) and that said it was fixed in later versions of Jenkins, so this PR fixes this issue by updating our "minimum" version of Jenkins to the oldest officially supported (2.204.4 according to [this page](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) at the time this was written) ... and doing that _seems_ to work...

However, the docker-plugin's dependencies have, traditionally, been largely left unloved and unmaintained.
This test failure seems to be the point where we've hit a breaking point and to fix this has (I think) necessitated a dependency move forwards, and the best way of doing that is to also move the way these dependencies are handled "forwards" too.

What this PR is attempting to do is to bump the minimum version of Jenkins to the oldest officially supported (2.204.4) and then to use the Jenkins "BOM" plugin to then figure out what version of everything else that we use needs to be (in order to avoid the dreaded "upper bounds" maven error).
This has required numerous changes to the pom.xml file that really need reveiwing by someone who understands this better than I do.
(There's also a few changes elsewhere in the code as a result of dependencies changing to non-ancient versions, but they're trivial by comparison.)