### PR TITLE
Make PortUtilsTest less fussy about timings.

### DIFF
--- a/src/test/java/com/nirima/jenkins/plugins/docker/utils/PortUtilsTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/utils/PortUtilsTest.java
@@ -50,7 +50,7 @@ public class PortUtilsTest {
     public void shouldWaitForPortAvailableUntilTimeout() throws Exception {
         // Given
         // e.g. try, delay, try, delay, try = 3 tries, 2 delays.
-        final long minExpectedTime = RETRY_COUNT * DELAY;
+        final long minExpectedTime = RETRY_COUNT * DELAY - minimumFudgeFactor(DELAY);
         final long maxExpectedTime = (RETRY_COUNT + 1) * DELAY - 1;
 
         // When
@@ -83,6 +83,7 @@ public class PortUtilsTest {
         final long minExpectedTime = sshWaitDuringTry + waitBetweenTries + sshWaitDuringTry + waitBetweenTries
                 + sshWaitDuringTry + waitBetweenTries + sshWaitDuringTry;
         final long maxExpectedTime = minExpectedTime + waitBetweenTries - 1;
+        final long minAllowedTime = minExpectedTime - minimumFudgeFactor(waitBetweenTries);
 
         // When
         final long before = currentTimeMillis();
@@ -95,7 +96,7 @@ public class PortUtilsTest {
         // Then
         assertThat("Port is connectible", actual, equalTo(false));
         assertThat("Should wait for timeout", actualDuration,
-                allOf(greaterThanOrEqualTo(minExpectedTime), lessThanOrEqualTo(maxExpectedTime)));
+                allOf(greaterThanOrEqualTo(minAllowedTime), lessThanOrEqualTo(maxExpectedTime)));
     }
 
     @Test
@@ -124,6 +125,7 @@ public class PortUtilsTest {
         final long bringPortUpAfter = DELAY + DELAY/2;
         final long minExpectedTime = 2 * DELAY;
         final long maxExpectedTime = minExpectedTime + DELAY - 1;
+        final long minAllowedTime = minExpectedTime - minimumFudgeFactor(DELAY);
         server.stopAndRebindAfter(bringPortUpAfter, MILLISECONDS);
 
         // When
@@ -136,7 +138,17 @@ public class PortUtilsTest {
         // Then
         assertThat("Used port should be connectible", actual, equalTo(true));
         assertThat("Should wait then retry", actualDuration,
-                allOf(greaterThanOrEqualTo(minExpectedTime), lessThanOrEqualTo(maxExpectedTime)));
+                allOf(greaterThanOrEqualTo(minAllowedTime), lessThanOrEqualTo(maxExpectedTime)));
+    }
+
+    /**
+     * On Windows, timers seem to be less accurate and/or expire shortly before they should,
+     * meaning that tests can complete faster than they should,
+     * e.g. I've seen a timeout of 2000ms complete in 1998ms,
+     * so the tests must allow for that and not complain.
+     */
+    private static int minimumFudgeFactor(int oneUnitOfExpectedDelay) {
+        return oneUnitOfExpectedDelay / 20;
     }
 
     private class SomeServerRule extends ExternalResource {


### PR DESCRIPTION
A recent [build](https://ci.jenkins.io/job/Plugins/job/docker-plugin/job/master/227/testReport/junit/com.nirima.jenkins.plugins.docker.utils/PortUtilsTest/windows_8_2_204_4___Build__windows_8_2_204_4____shouldWaitForPortAvailableUntilTimeout/) of the docker-plugin master branch failed because a PortUtils unit-test failed on Windows.
```
java.lang.AssertionError: 
Should wait for timeout
Expected: (a value equal to or greater than <2000L> and a value less than or equal to <2999L>)
     but: a value equal to or greater than <2000L> <1998L> was less than <2000L>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at com.nirima.jenkins.plugins.docker.utils.PortUtilsTest.shouldWaitForPortAvailableUntilTimeout(PortUtilsTest.java:65)
```
So it seems that, on Windows, timeouts can happen _shortly before_ they should do, meaning that we need to adjust our idea of "how soon is too soon".

This code change allows for a 5% inaccuracy, so hopefully these unit-tests won't cause spurious failures again.
