### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ You _can_ use an Entrypoint to run some side service inside your build agent con
 
 ## Further information
 
-More information can be obtained from the online help built into the Jenkins WebUI.
+More information can be obtained from the online help built into the Jenkins web UI.
 Most configurable fields have explanatory text.
 This,
 combined with knowledge of [docker itself](https://docs.docker.com/),


### PR DESCRIPTION
"WebUI" isn't an English word. "Web UI" makes sense as an adjective and an abbreviation of a noun.

But really, the point of this is to see if I get a passing CI build on the main branch with no changes to code.