### PR TITLE
Update unit-tests to cope with recent changes in jenkins/ssh-agent docker image.

### DIFF
--- a/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
@@ -29,7 +29,20 @@ import java.util.Map;
 public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest {
 
     private static final String SSH_AGENT_IMAGE_IMAGENAME = "jenkins/ssh-agent";
-    private static final String SSH_AGENT_IMAGE_JAVAPATH = "/usr/local/openjdk-8/bin/java";
+    /**
+     * Where the JDK can be found.
+     * <p>
+     * <b>MAINTENANCE NOTE:</b> Originally, Java was on the PATH and the SSH
+     * connector found it there. Then, the image changed and java wasn't on the path
+     * anymore and had to be set in the unit-tests to
+     * <code>"/usr/local/openjdk-8/bin/java"</code>. Then, the image changed again
+     * and java was on the path again but had moved.
+     * </p>
+     * TL;DR: If java is on the path then this can (and should) be null, but if it
+     * isn't on the path then we'll need to set this to where java has been moved
+     * to.
+     */
+    private static final String SSH_AGENT_IMAGE_JAVAPATH = null;
 
     @Test
     public void connectAgentViaSSHUsingInjectSshKey() throws Exception {


### PR DESCRIPTION
The unit tests have broken due to changes in the jenkins/ssh-agent docker image.

jenkins/ssh-agent used to have Java at `/usr/local/openjdk-8/bin/java`
At one point it stopped putting that on the $PATH, so we had to tell Jenkins where to find it.
Now it's moved (to `/opt/java/openjdk/bin/java`) but it's back on the path so Jenkins will auto-find it again.

TL;DR: Removing this configuration seems to allow the test to pass again.