### PR TITLE
Make DockerTransientNode extend AbstractCloudSlave

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/strategy/DockerOnceRetentionStrategy.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/strategy/DockerOnceRetentionStrategy.java
@@ -111,7 +111,7 @@ public class DockerOnceRetentionStrategy extends RetentionStrategy<DockerCompute
             Queue.withLock( () -> {
                 DockerTransientNode node = c.getNode();
                 if (node != null) {
-                    node.terminate(c.getListener());
+                    node._terminate(c.getListener());
                 }
             });
         });

--- a/src/main/java/io/jenkins/docker/DockerComputer.java
+++ b/src/main/java/io/jenkins/docker/DockerComputer.java
@@ -2,7 +2,7 @@ package io.jenkins.docker;
 
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import hudson.EnvVars;
-import hudson.slaves.SlaveComputer;
+import hudson.slaves.AbstractCloudComputer;
 import io.jenkins.docker.client.DockerAPI;
 import javax.annotation.CheckForNull;
 import java.io.IOException;
@@ -13,7 +13,7 @@ import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
  *
  * @author magnayn
  */
-public class DockerComputer extends SlaveComputer {
+public class DockerComputer extends AbstractCloudComputer<DockerTransientNode> {
     // private static final Logger LOGGER = Logger.getLogger(DockerComputer.class.getName());
 
     public DockerComputer(DockerTransientNode node) {
@@ -24,12 +24,6 @@ public class DockerComputer extends SlaveComputer {
     public DockerCloud getCloud() {
         final DockerTransientNode nodeOrNull = getNode();
         return nodeOrNull == null ? null : nodeOrNull.getCloud();
-    }
-
-    @CheckForNull
-    @Override
-    public DockerTransientNode getNode() {
-        return (DockerTransientNode) super.getNode();
     }
 
     @CheckForNull

--- a/src/main/java/io/jenkins/docker/connector/DockerDelegatingComputerLauncher.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerDelegatingComputerLauncher.java
@@ -30,7 +30,7 @@ class DockerDelegatingComputerLauncher extends DelegatingComputerLauncher {
             // Container has been removed
             Queue.withLock(() -> {
                 DockerTransientNode node = (DockerTransientNode) computer.getNode();
-                node.terminate(listener);
+                node._terminate(listener);
             });
             return;
         }

--- a/src/main/java/io/jenkins/docker/pipeline/DockerNodeStepExecution.java
+++ b/src/main/java/io/jenkins/docker/pipeline/DockerNodeStepExecution.java
@@ -222,7 +222,7 @@ class DockerNodeStepExecution extends StepExecution {
             if (node != null) {
                 TaskListener listener = context.get(TaskListener.class);
                 listener.getLogger().println("Terminating docker node ...");
-                node.terminate(listener);
+                node._terminate(listener);
                 Jenkins.get().removeNode(node);
             }
         }

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
@@ -78,7 +78,7 @@ public abstract class DockerComputerConnectorTest {
         for( final Node n : j.jenkins.getNodes() ) {
             if( n instanceof DockerTransientNode ) {
                 final DockerTransientNode dn = (DockerTransientNode)n;
-                dn.terminate(tl);
+                dn._terminate(tl);
             }
         }
     }


### PR DESCRIPTION
The [jobConfigHistory plugin](https://plugins.jenkins.io/jobConfigHistory/) does not interact well with the docker plugin because it (quite reasonably) assumes that any node that isn't an AbstractCloudSlave needs to be recorded. This means that if you're using both the jobConfigHistory plugin and this plugin, your filesystem will drown under backups of docker nodes that you don't want.

However, while our DockerTransientNode did (once upon a time) extend AbstractCloudSlave, it was later amended to just extend Slave. The reasons for this are "lost in time" and it's hoped that nothing bad will come of reversing this (a hope backed up by the belief that other cloud plugins all use AbstractCloudSlave too so we ought to be able to do so without a problem either).

So this PR changes this plugin's agents to be identified as cloud agents and hence to be treated like any other cloud plugin's agents, and hence be ignored by the jobConfigHistory plugin (as originally intended).

In theory, there should be no functional differences within this plugin from this change.
In theory, this should be 100% backwards (and forwards) compatible with old code/configuration too.