### PR TITLE
Drop dependency on Commons Codec

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -27,7 +27,6 @@ import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
-import org.apache.commons.codec.binary.Base64;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryToken;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
@@ -45,6 +44,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -899,7 +899,7 @@ public class DockerCloud extends Cloud {
         // What docker-commons claim to be a "token" is actually configuration storage
         // see https://github.com/docker/docker-ce/blob/v17.09.0-ce/components/cli/cli/config/configfile/file.go#L214
         // i.e base64 encoded username : password
-        final String decode = new String(Base64.decodeBase64(token), StandardCharsets.UTF_8);
+        final String decode = new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
         int i = decode.indexOf(':');
         if (i > 0) {
             String username = decode.substring(0, i);

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -57,6 +57,7 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,6 @@ import java.util.concurrent.TimeUnit;
 import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.bldToString;
 import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.endToString;
 import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.startToString;
-import static hudson.remoting.Base64.encode;
 
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
@@ -452,7 +452,7 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
         @Override
         public String getInjectedKey() throws IOException {
             InstanceIdentity id = InstanceIdentity.get();
-            return "ssh-rsa " + encode(new RSAKeyAlgorithm().encodePublicKey(id.getPublic()));
+            return "ssh-rsa " + Base64.getEncoder().encodeToString(new RSAKeyAlgorithm().encodePublicKey(id.getPublic()));
         }
 
         @Extension

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
@@ -21,9 +21,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import static hudson.remoting.Base64.encode;
-
 import java.io.IOException;
+import java.util.Base64;
 import java.util.Map;
 
 public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest {
@@ -62,7 +61,7 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
     public void connectAgentViaSSHUsingCredentialsKey() throws Exception {
         final InstanceIdentity id = InstanceIdentity.get();
         final String privateKey = PEMEncodable.create(id.getPrivate()).encode();
-        final String publicKey = "ssh-rsa " + encode(new RSAKeyAlgorithm().encodePublicKey(id.getPublic()));
+        final String publicKey = "ssh-rsa " + Base64.getEncoder().encodeToString(new RSAKeyAlgorithm().encodePublicKey(id.getPublic()));
         final String credentialsId = "tempCredId";
         final StandardUsernameCredentials credentials = DockerComputerSSHConnector.makeCredentials(credentialsId, COMMON_IMAGE_USERNAME, privateKey);
         SystemCredentialsProvider.getInstance().getCredentials().add(credentials);


### PR DESCRIPTION
Java 8 includes a built-in Base64 encoder/decoder, so there is no reason to depend on a third-party library. Using the built-in Java Platform functionality simplifies maintenance.