### PR TITLE
Prepare for sunset icon removal from core

### DIFF
--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerManagement/index.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerManagement/index.jelly
@@ -4,7 +4,7 @@
     <l:layout title="${%Docker hosts}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerManagementServer/index.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerManagementServer/index.jelly
@@ -12,7 +12,7 @@
         </l:header>
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>


### PR DESCRIPTION
This is a preparation for `https://github.com/jenkinsci/jenkins/pull/5778` which removes sunset icons.

Otherwise we're lacking an icon here:
![](https://i.imgur.com/XCH5R6G.png)

Which has been mitigated:
![](https://i.imgur.com/hU2bqS7.png)

cc @pjdarton 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue