### PR TITLE
Add support for build-time variables (build args) to the `DockerBuilderPublisher` step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 A pre-release can be downloaded from https://ci.jenkins.io/job/Plugins/job/docker-plugin/job/master/
+* Enhancement: Add support for build-time variables (build args) [#730](https://github.com/jenkinsci/docker-plugin/issues/730), [JENKINS-48512](https://issues.jenkins.io/browse/JENKINS-48512)
 
 ## 1.2.6
 _2021-12-13_

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/config.jelly
@@ -23,6 +23,10 @@
         <f:expandableTextbox/>
     </f:entry>
 
+    <f:entry title="${%Build Args}" field="buildArgsString">
+        <f:expandableTextbox/>
+    </f:entry>
+
     <f:entry title="${%Push image}" field="pushOnSuccess">
         <f:checkbox/>
     </f:entry>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-buildArgs.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-buildArgs.html
@@ -1,0 +1,3 @@
+<div>
+    <p>A map of <em>build-time variables</em>.</p>
+</div>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-buildArgsString.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/builder/DockerBuilderPublisher/help-buildArgsString.html
@@ -1,0 +1,3 @@
+<div>
+    <p>A list of new line separated <em>build-time variables</em>, specified in the form <code>"name=value"</code>.</p>
+</div>


### PR DESCRIPTION
Either by using a `Map<String,string>` named `buildArgs` or by using a `String` named `buildArgsString` with each key-value pair separated by a new line, e.g.
```
arg1=value1
arg2=value2
```

see also [JENKINS-48512](https://issues.jenkins.io/browse/JENKINS-48512)

fixes #730
