### PR TITLE
Fix compatibility with both 3.1 and 3.2 APIs

### DIFF
--- a/src/main/java/io/jenkins/docker/client/DockerAPI.java
+++ b/src/main/java/io/jenkins/docker/client/DockerAPI.java
@@ -8,7 +8,6 @@ import com.github.dockerjava.core.AbstractDockerCmdExecFactory;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.SSLConfig;
-import com.github.dockerjava.netty.NettyDockerCmdExecFactory;
 
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
@@ -244,12 +243,12 @@ public class DockerAPI extends AbstractDescribableImpl<DockerAPI> {
     @SuppressWarnings("resource")
     private static SharableDockerClient makeClient(final String dockerUri, final String credentialsId,
             final Integer readTimeoutInMillisecondsOrNull, final Integer connectTimeoutInMillisecondsOrNull) {
-    	AbstractDockerCmdExecFactory cmdExecFactory = null;
+        NettyDockerCmdExecFactoryCompat cmdExecFactory = null;
         DockerClient actualClient = null;
         try {
-            cmdExecFactory = new NettyDockerCmdExecFactory()
-                    .withReadTimeout(readTimeoutInMillisecondsOrNull)
-                    .withConnectTimeout(connectTimeoutInMillisecondsOrNull);
+            cmdExecFactory = new NettyDockerCmdExecFactoryCompat()
+                .withReadTimeoutCompat(readTimeoutInMillisecondsOrNull)
+                .withConnectTimeoutCompat(connectTimeoutInMillisecondsOrNull);
             final DefaultDockerClientConfig.Builder configBuilder = new DefaultDockerClientConfig.Builder()
                     .withDockerHost(dockerUri)
                     .withCustomSslConfig(toSSlConfig(credentialsId));

--- a/src/main/java/io/jenkins/docker/client/NettyDockerCmdExecFactoryCompat.java
+++ b/src/main/java/io/jenkins/docker/client/NettyDockerCmdExecFactoryCompat.java
@@ -1,0 +1,61 @@
+package io.jenkins.docker.client;
+
+import java.lang.reflect.Method;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.dockerjava.core.AbstractDockerCmdExecFactory;
+import com.github.dockerjava.netty.NettyDockerCmdExecFactory;
+
+/**
+ * Wrapper class to allow compatibility between 3.1 and 3.2 APIs
+ *
+ * @author bguerin
+ */
+public class NettyDockerCmdExecFactoryCompat extends NettyDockerCmdExecFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DockerAPI.class);
+
+    public NettyDockerCmdExecFactoryCompat withConnectTimeoutCompat(Integer connectTimeout) {
+        Method method = getMethod(NettyDockerCmdExecFactory.class, "withConnectTimeout");
+        if (method == null) {
+            method = getMethod(AbstractDockerCmdExecFactory.class, "withConnectTimeout");
+        }
+
+        invoke(method, connectTimeout, "withConnectTimeout");
+
+        return this;
+    }
+
+    public NettyDockerCmdExecFactoryCompat withReadTimeoutCompat(Integer readTimeout) {
+        Method method = getMethod(NettyDockerCmdExecFactory.class, "withReadTimeout");
+        if (method == null) {
+            method = getMethod(AbstractDockerCmdExecFactory.class, "withReadTimeout");
+        }
+
+        invoke(method, readTimeout, "withReadTimeout");
+
+        return this;
+    }
+
+    private Method getMethod(Class<?> clazz, String name) {
+        try {
+            return clazz.getMethod(name, Integer.class);
+        } catch (NoSuchMethodException ex) {
+            return null;
+        }
+    }
+
+    private void invoke(Method method, Integer arg, String name) {
+        if (method != null) {
+            try {
+                method.invoke(this, arg);
+            } catch (Exception ex) {
+                LOGGER.error("Error invoking method {} on *DockerCmdExecFactory", name, ex);
+            }
+        } else {
+            LOGGER.error("Could not find method {} on *DockerCmdExecFactory", name);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #884

Root cause is https://github.com/docker-java/docker-java/commit/978ac882a2c004e8edd317c2c80e4e2c855a1bc3 : methods `withReadTimeout` and `withConnectTimeout` moved from `NettyDockerCmdExecFactory` to `AbstractDockerCmdExecFactory` between 3.1 and 3.2

I do not see how to add unit test for this change. I have build the whole plugin, running tests, on both docker-java-plugin 3.1 and 3.2, and tested the modified code on my Jenkins, with both docker-java-plugin 3.1 and 3.2

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
