### PR TITLE
fix readonly option parsing on mounts

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -889,8 +889,8 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         final String[] tokens = mnt.split(",");
         for (String token : tokens) {
             final String[] parts = token.split("=");
-            if (!(parts.length == 2 || parts.length == 1 && "readonly".equals(parts[0]))) {
-                throw new IllegalArgumentException("Invalid mount: expected key=value comma separated pairs, or 'readonly' keyword");
+            if (!(parts.length == 2 || parts.length == 1 && ("ro".equals(parts[0]) || "readonly".equals(parts[0])))) {
+                throw new IllegalArgumentException("Invalid mount: expected key=value comma separated pairs, or 'ro' / 'readonly' keywords");
             }
 
             switch (parts[0]) {
@@ -908,7 +908,12 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
                     break;
                 case "ro":
                 case "readonly":
-                    mount.withReadOnly(true);
+                    String value = parts.length == 2 && parts[1] != null ? parts[1].trim() : "";
+                    if (value.isEmpty() || "true".equalsIgnoreCase(value) || "1".equals(value)) {
+                        mount.withReadOnly(true);
+                    } else if ("false".equalsIgnoreCase(value) || "0".equals(value)) {
+                        mount.withReadOnly(false);
+                    }
                     break;
                 case "bind-propagation":
                     bindOptions = new BindOptions().withPropagation(BindPropagation.valueOf((parts[1].startsWith("r") ? "R_" + parts[1].substring(1) : parts[1]).toUpperCase()));

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
@@ -336,13 +336,33 @@ public class DockerTemplateBaseTest {
                 new Mount().withType(MountType.VOLUME).withSource("aVolume").withTarget("/aTarget"));
         testFillContainerMount("file", "type=volume,source=aVolume,destination=aFile",
                 new Mount().withType(MountType.VOLUME).withSource("aVolume").withTarget("aFile"));
+        testFillContainerMount("roFile", "source=aVolume,destination=aFile,ro",
+                new Mount().withType(MountType.VOLUME).withSource("aVolume").withTarget("aFile").withReadOnly(true));
         testFillContainerMount("readOnlyFile", "source=aVolume,destination=aFile,readonly",
                 new Mount().withType(MountType.VOLUME).withSource("aVolume").withTarget("aFile").withReadOnly(true));
 
         testFillContainerMount("bind", "type=bind,source=/aSource,target=/aTarget",
                 new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget"));
+        testFillContainerMount("roBind", "type=bind,source=/aSource,target=/aTarget,ro",
+                new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(true));
         testFillContainerMount("readOnlyBind", "type=bind,source=/aSource,target=/aTarget,readonly",
                 new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(true));
+        testFillContainerMount("roTrueBind", "type=bind,source=/aSource,target=/aTarget,ro=true",
+                new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(true));
+        testFillContainerMount("readOnlyTrueBind", "type=bind,source=/aSource,target=/aTarget,readonly=true",
+                new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(true));
+        testFillContainerMount("roOneBind", "type=bind,source=/aSource,target=/aTarget,ro=1",
+                new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(true));
+        testFillContainerMount("readOnlyOneBind", "type=bind,source=/aSource,target=/aTarget,readonly=1",
+                new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(true));
+        testFillContainerMount("roFalseBind", "type=bind,source=/aSource,target=/aTarget,ro=false",
+                new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(false));
+        testFillContainerMount("readOnlyFalseBind", "type=bind,source=/aSource,target=/aTarget,readonly=false",
+                new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(false));
+        testFillContainerMount("roZeroBind", "type=bind,source=/aSource,target=/aTarget,ro=0",
+                new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(false));
+        testFillContainerMount("readOnlyZeroBind", "type=bind,source=/aSource,target=/aTarget,readonly=0",
+                new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withReadOnly(false));
         testFillContainerMount("bindWithPropagation", "type=bind,source=/aSource,target=/aTarget,bind-propagation=rslave",
                 new Mount().withType(MountType.BIND).withSource("/aSource").withTarget("/aTarget").withBindOptions(new BindOptions().withPropagation(BindPropagation.R_SLAVE)));
 


### PR DESCRIPTION
Fix  #880, by improving option parsing like suggested in comments

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
