### PR TITLE
Try to improve unittest robustness

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.204.4'])
+buildPlugin(jenkinsVersions: [null, '2.222.4'])

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.level>8</java.level>
         <groovy.version>2.4.7</groovy.version>
-        <jenkins.version>2.204.4</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
     </properties>
 
     <dependencies>

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
@@ -42,8 +42,9 @@ public class DockerComputerAttachConnectorTest extends DockerComputerConnectorTe
 
     private void testAgentCanStartAndConnect(final DockerComputerAttachConnector connector, final String testName)
             throws IOException, ExecutionException, InterruptedException, TimeoutException {
-        final DockerTemplate template = new DockerTemplate(
-                new DockerTemplateBase(ATTACH_AGENT_IMAGE_IMAGENAME),
+        final String imagenameAndVersion = ATTACH_AGENT_IMAGE_IMAGENAME + ':' + getJenkinsDockerImageVersionForThisEnvironment();
+		final DockerTemplate template = new DockerTemplate(
+                new DockerTemplateBase(imagenameAndVersion),
                 connector,
                 LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
@@ -35,8 +35,9 @@ public class DockerComputerJNLPConnectorTest extends DockerComputerConnectorTest
                     uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
         }
 
-        final DockerTemplate template = new DockerTemplate(
-                new DockerTemplateBase(JNLP_AGENT_IMAGE_IMAGENAME),
+        final String imagenameAndVersion = JNLP_AGENT_IMAGE_IMAGENAME + ':' + getJenkinsDockerImageVersionForThisEnvironment();
+		final DockerTemplate template = new DockerTemplate(
+                new DockerTemplateBase(imagenameAndVersion),
                 new DockerComputerJNLPConnector(new JNLPLauncher(null, null)).withUser(COMMON_IMAGE_USERNAME)
                         .withJenkinsUrl(uri.toString()),
                         LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
@@ -48,8 +48,10 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
         final DockerComputerSSHConnector.SSHKeyStrategy sshKeyStrategy = new DockerComputerSSHConnector.InjectSSHKey(COMMON_IMAGE_USERNAME);
         final DockerComputerSSHConnector connector = new DockerComputerSSHConnector(sshKeyStrategy);
         connector.setJavaPath(SSH_AGENT_IMAGE_JAVAPATH);
+        final String imagenameAndVersion = SSH_AGENT_IMAGE_IMAGENAME + ':' + getJenkinsDockerImageVersionForThisEnvironment();
+
         final DockerTemplate template = new DockerTemplate(
-                new DockerTemplateBase(SSH_AGENT_IMAGE_IMAGENAME),
+                new DockerTemplateBase(imagenameAndVersion),
                 connector,
                 LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );
@@ -68,8 +70,9 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
         final DockerComputerSSHConnector.SSHKeyStrategy sshKeyStrategy = new DockerComputerSSHConnector.ManuallyConfiguredSSHKey(credentialsId, new NonVerifyingKeyVerificationStrategy());
         final DockerComputerSSHConnector connector = new DockerComputerSSHConnector(sshKeyStrategy);
         connector.setJavaPath(SSH_AGENT_IMAGE_JAVAPATH);
+        final String imagenameAndVersion = SSH_AGENT_IMAGE_IMAGENAME + ':' + getJenkinsDockerImageVersionForThisEnvironment();
         final DockerTemplate template = new DockerTemplate(
-                new DockerTemplateBase(SSH_AGENT_IMAGE_IMAGENAME),
+                new DockerTemplateBase(imagenameAndVersion),
                 connector,
                 LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );


### PR DESCRIPTION
Existing unit-tests that spin up a docker image are flaky on the official Jenkins CI and it's unclear why.
...but one possible cause is that we're using the "wrong" docker image, as there's more than one "latest" to chose from, e.g. there's a Java8 and a Java11 version.
This PR makes these unit-tests automatically chose a version based on the JVM version.

...and also aligns the minimum Jenkins version with the BOM so we're testing against 2.222.4 instead of 2.204.4.
