### PR TITLE
Should inject JAR before starting container

### DIFF
--- a/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerAttachConnector.java
@@ -161,7 +161,7 @@ public class DockerComputerAttachConnector extends DockerComputerConnector imple
     }
 
     @Override
-    public void afterContainerStarted(DockerAPI api, String workdir, DockerTransientNode node) throws IOException, InterruptedException {
+    public void beforeContainerStarted(DockerAPI api, String workdir, DockerTransientNode node) throws IOException, InterruptedException {
         final String containerId = node.getContainerId();
         try(final DockerClient client = api.getClient()) {
             injectRemotingJar(containerId, workdir, client);


### PR DESCRIPTION
Fix #867 using much simpler changes than #872

Looks like the code used the wrong callback and thus tried to inject the JAR _after_ the container had started.
The Javadocs were fairly clear on what should happen and when, but the code used the wrong method.
This change fixes that (so if this doesn't work then then Javadoc is wrong 😉 )
