### PR TITLE
Improve unit tests on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 A pre-release can be downloaded from https://ci.jenkins.io/job/Plugins/job/docker-plugin/job/master/
 
+* Fix PortUtilsTest unit test on Windows [#901](https://github.com/jenkinsci/docker-plugin/pull/901)
 * Fix JCasC parsing of volume/mounts [#852](https://github.com/jenkinsci/docker-plugin/issues/852)
 * Docker-attach should inject JAR before starting container [#898](https://github.com/jenkinsci/docker-plugin/pull/898)
 * Bump min Jenkins version from 2.204.4 to 2.303.3 [#897](https://github.com/jenkinsci/docker-plugin/pull/897)

--- a/src/test/java/com/nirima/jenkins/plugins/docker/utils/PortUtilsTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/utils/PortUtilsTest.java
@@ -1,6 +1,5 @@
 package com.nirima.jenkins.plugins.docker.utils;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExternalResource;
@@ -14,10 +13,11 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.Matchers.allOf;
 
 /**
  * @author lanwen (Merkushev Kirill)
@@ -33,14 +33,22 @@ public class PortUtilsTest {
 
     @Test
     public void shouldConnectToServerSuccessfully() throws Exception {
-        assertThat("Server is up and should connect",
-                PortUtils.connectionCheck(server.host(), server.port()).executeOnce(), equalTo(true));
+        // When
+        boolean actual = PortUtils.connectionCheck(server.host(), server.port())
+        		.executeOnce();
+
+        // Then
+		assertThat("Server is up and should connect", actual, equalTo(true));
     }
 
     @Test
     public void shouldNotConnectToUnusedPort() throws Exception {
-        assertThat("Unused port should not be connectible", PortUtils.connectionCheck("localhost", 0).executeOnce(),
-                equalTo(false));
+        // When
+        boolean actual = PortUtils.connectionCheck("localhost", 0)
+        		.executeOnce();
+
+        // Then
+		assertThat("Unused port should not be connectible", actual, equalTo(false));
     }
 
     @Test
@@ -52,8 +60,10 @@ public class PortUtilsTest {
 
         // When
         final long before = currentTimeMillis();
-        final boolean actual = PortUtils.connectionCheck("localhost", 0).withRetries(RETRY_COUNT)
-                .withEveryRetryWaitFor(DELAY, MILLISECONDS).execute();
+        final boolean actual = PortUtils.connectionCheck("localhost", 0)
+        		.withRetries(RETRY_COUNT)
+                .withEveryRetryWaitFor(DELAY, MILLISECONDS)
+                .execute();
         final long after = currentTimeMillis();
         final long actualDuration = after - before;
 
@@ -65,13 +75,23 @@ public class PortUtilsTest {
 
     @Test
     public void shouldThrowIllegalStateExOnNotAvailPort() throws Exception {
+        // Given
+    	final Class<IllegalStateException> expectedType = IllegalStateException.class;
+
+    	// When
+    	Throwable thrown = null; 
         try {
-	        PortUtils.connectionCheck("localhost", 0).withRetries(RETRY_COUNT).withEveryRetryWaitFor(DELAY, MILLISECONDS)
-	                .useSSH().execute();
-	        Assert.fail("Expected " + IllegalStateException.class);
-        } catch ( IllegalStateException expected ) {
-        	// pass
+	        PortUtils.connectionCheck("localhost", 0)
+	        		.withRetries(RETRY_COUNT)
+	        		.withEveryRetryWaitFor(DELAY, MILLISECONDS)
+	                .useSSH()
+	                .execute();
+        } catch ( Throwable expected ) {
+        	thrown = expected;
         }
+
+        // Then
+		assertThat(expectedType.getSimpleName() + " thrown", thrown, instanceOf(expectedType));
     }
 
     @Test
@@ -88,9 +108,11 @@ public class PortUtilsTest {
 
         // When
         final long before = currentTimeMillis();
-        final boolean actual = PortUtils.connectionCheck(server.host(), server.port()).withRetries(retries)
+        final boolean actual = PortUtils.connectionCheck(server.host(), server.port())
+        		.withRetries(retries)
                 .withEveryRetryWaitFor(waitBetweenTries, MILLISECONDS).useSSH()
-                .withSSHTimeout(sshWaitDuringTry, MILLISECONDS).execute();
+                .withSSHTimeout(sshWaitDuringTry, MILLISECONDS)
+                .execute();
         final long after = currentTimeMillis();
         final long actualDuration = after - before;
 
@@ -108,7 +130,8 @@ public class PortUtilsTest {
         // When
         final long before = currentTimeMillis();
         final boolean actual = PortUtils.connectionCheck(server.host(), server.port())
-                .withEveryRetryWaitFor(DELAY, MILLISECONDS).execute();
+                .withEveryRetryWaitFor(DELAY, MILLISECONDS)
+                .execute();
         final long after = currentTimeMillis();
         final long actualDuration = after - before;
 
@@ -126,20 +149,27 @@ public class PortUtilsTest {
         final long bringPortUpAfter = DELAY + DELAY/2;
         final long minExpectedTime = 2 * DELAY;
         final long maxExpectedTime = minExpectedTime + DELAY - 1;
-        final long minAllowedTime = minExpectedTime - minimumFudgeFactor(DELAY);
+        // It can take so long to test for the port availability that it's available
+        // by the time the test completes (this is especially common on Windows where the
+        // "can we open this socket?" test takes a couple of seconds the first time it's
+        // done) and hence the test might "pass" the instant we make the socket available
+        // instead of forcing us to retry.
+        final long minAllowedTime = bringPortUpAfter - minimumFudgeFactor(DELAY);
         server.stopAndRebindAfter(bringPortUpAfter, MILLISECONDS);
 
         // When
         final long before = currentTimeMillis();
-        final boolean actual = PortUtils.connectionCheck(server.host(), server.port()).withRetries(retries)
-                .withEveryRetryWaitFor(DELAY, MILLISECONDS).execute();
+        final boolean actual = PortUtils.connectionCheck(server.host(), server.port())
+        		.withRetries(retries)
+                .withEveryRetryWaitFor(DELAY, MILLISECONDS)
+                .execute();
         final long after = currentTimeMillis();
         final long actualDuration = after - before;
 
         // Then
         assertThat("Used port should be connectible", actual, equalTo(true));
-        assertThat("Should wait then retry", actualDuration,
-                allOf(greaterThanOrEqualTo(minAllowedTime), lessThanOrEqualTo(maxExpectedTime)));
+		assertThat("Should try, fail, wait " + DELAY + ", retry(1), fail, wait " + DELAY + ", retry(2) and succeed",
+				actualDuration, allOf(greaterThanOrEqualTo(minAllowedTime), lessThanOrEqualTo(maxExpectedTime)));
     }
 
     /**

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
@@ -43,10 +43,10 @@ public class DockerComputerAttachConnectorTest extends DockerComputerConnectorTe
     private void testAgentCanStartAndConnect(final DockerComputerAttachConnector connector, final String testName)
             throws IOException, ExecutionException, InterruptedException, TimeoutException {
         final String imagenameAndVersion = ATTACH_AGENT_IMAGE_IMAGENAME + ':' + getJenkinsDockerImageVersionForThisEnvironment();
-		final DockerTemplate template = new DockerTemplate(
+        final DockerTemplate template = new DockerTemplate(
                 new DockerTemplateBase(imagenameAndVersion),
                 connector,
-                LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
+                getLabelForTemplate(), COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );
         template.setName(testName);
         should_connect_agent(template);

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
@@ -36,11 +36,11 @@ public class DockerComputerJNLPConnectorTest extends DockerComputerConnectorTest
         }
 
         final String imagenameAndVersion = JNLP_AGENT_IMAGE_IMAGENAME + ':' + getJenkinsDockerImageVersionForThisEnvironment();
-		final DockerTemplate template = new DockerTemplate(
+        final DockerTemplate template = new DockerTemplate(
                 new DockerTemplateBase(imagenameAndVersion),
                 new DockerComputerJNLPConnector(new JNLPLauncher(null, null)).withUser(COMMON_IMAGE_USERNAME)
                         .withJenkinsUrl(uri.toString()),
-                        LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
+                        getLabelForTemplate(), COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );
 
         if (SystemUtils.IS_OS_LINUX) {

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
@@ -54,7 +54,7 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
         final DockerTemplate template = new DockerTemplate(
                 new DockerTemplateBase(imagenameAndVersion),
                 connector,
-                LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
+                getLabelForTemplate(), COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );
         template.setName("connectAgentViaSSHUsingInjectSshKey");
         should_connect_agent(template);
@@ -75,7 +75,7 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
         final DockerTemplate template = new DockerTemplate(
                 new DockerTemplateBase(imagenameAndVersion),
                 connector,
-                LABEL, COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
+                getLabelForTemplate(), COMMON_IMAGE_HOMEDIR, INSTANCE_CAP
         );
         template.getDockerTemplateBase().setEnvironmentsString("JENKINS_SLAVE_SSH_PUBKEY=" + publicKey);
         template.setName("connectAgentViaSSHUsingCredentialsKey");
@@ -84,20 +84,20 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
 
     @Test
     public void testPortBinding() throws IOException, InterruptedException {
-    	// Given
+        // Given
         DockerComputerSSHConnector connector = new DockerComputerSSHConnector(Mockito.mock(DockerComputerSSHConnector.SSHKeyStrategy.class));
         CreateContainerCmdImpl cmd = new CreateContainerCmdImpl(Mockito.mock(CreateContainerCmd.Exec.class), Mockito.mock(AuthConfig.class), "");
         HostConfig hostConfig = cmd.getHostConfig();
         if( hostConfig==null ) {
-        	hostConfig = new HostConfig();
-        	cmd.withHostConfig(hostConfig);
+            hostConfig = new HostConfig();
+            cmd.withHostConfig(hostConfig);
         }
         final PortBinding exportContainerPort42 = PortBinding.parse("42:42");
-		hostConfig.withPortBindings(exportContainerPort42);
-		final ExposedPort port42 = new ExposedPort(42);
-		final ExposedPort port22 = new ExposedPort(22);
+        hostConfig.withPortBindings(exportContainerPort42);
+        final ExposedPort port42 = new ExposedPort(42);
+        final ExposedPort port22 = new ExposedPort(22);
 
-		// When
+        // When
         connector.setPort(22);
         connector.beforeContainerCreated(Mockito.mock(DockerAPI.class), "/workdir", cmd);
 
@@ -108,16 +108,16 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
         Assert.assertNotNull(actualBindingMap);
         Assert.assertEquals(2, actualBindingMap.size());
 
-		final Ports.Binding[] actualBindingsForPort42 = actualBindingMap.get(port42);
+        final Ports.Binding[] actualBindingsForPort42 = actualBindingMap.get(port42);
         Assert.assertNotNull(actualBindingsForPort42);
         Assert.assertEquals(1, actualBindingsForPort42.length);
         final String actualHostPortSpecForPort42 = actualBindingsForPort42[0].getHostPortSpec();
-		Assert.assertEquals("42", actualHostPortSpecForPort42);
+        Assert.assertEquals("42", actualHostPortSpecForPort42);
 
-		final Ports.Binding[] actualBindingsForPort22 = actualBindingMap.get(port22);
+        final Ports.Binding[] actualBindingsForPort22 = actualBindingMap.get(port22);
         Assert.assertNotNull(actualBindingsForPort22);
         Assert.assertEquals(1, actualBindingsForPort22.length);
         final String actualHostPortSpecForPort22 = actualBindingsForPort22[0].getHostPortSpec();
-		Assert.assertNull(actualHostPortSpecForPort22);
+        Assert.assertNull(actualHostPortSpecForPort22);
     }
 }


### PR DESCRIPTION
Running the unit-tests on Windows has always been problematic.
 - Timers behave differently
 - socket tests take a non-trivial amount of time and throw timing-based unit tests off
 - ... and we still assume that there's no docker daemon on Windows.

This improves the docker-connector unit tests, fixes a bug in PortUtilsTest that made it unreliable on Windows, and gets us closer to enabling docker-dependent tests on Windows (but doesn't because the Windows VMs on the Jenkins CI still don't include docker)
