### PR TITLE
Unit-test robustness

### DIFF
--- a/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerConnector.java
@@ -130,7 +130,7 @@ public abstract class DockerComputerConnector extends AbstractDescribableImpl<Do
      * @throws IOException if Jenkins is unable to persist the details.
      */
     protected void ensureNodeIsKnown(DockerTransientNode node) throws IOException {
-        Jenkins.get().addNode(node);
+        node.robustlyAddToJenkins();
     }
 
     /**

--- a/src/main/java/io/jenkins/docker/pipeline/DockerNodeStepExecution.java
+++ b/src/main/java/io/jenkins/docker/pipeline/DockerNodeStepExecution.java
@@ -142,7 +142,7 @@ class DockerNodeStepExecution extends StepExecution {
             node = t.provisionNode(api, listener);
             node.setDockerAPI(api);
             node.setAcceptingTasks(false); // Prevent this node to be used by tasks from build queue
-            Jenkins.get().addNode(node);
+            node.robustlyAddToJenkins();
 
             listener.getLogger().println("Waiting for node to be online ...");
             // TODO maybe rely on ComputerListener to catch onOnline() event ?
@@ -230,7 +230,7 @@ class DockerNodeStepExecution extends StepExecution {
                 TaskListener listener = context.get(TaskListener.class);
                 listener.getLogger().println("Terminating docker node ...");
                 node._terminate(listener);
-                Jenkins.get().removeNode(node);
+                node.robustlyRemoveFromJenkins();
             }
         }
     }

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
@@ -191,7 +191,7 @@ public abstract class DockerComputerConnectorTest {
         final Result actualBuildResult;
         final List<String> actualBuildLog;
         try {
-            final FreeStyleBuild build = scheduledBuild.get(90L, TimeUnit.SECONDS);
+            final FreeStyleBuild build = scheduledBuild.get(120L, TimeUnit.SECONDS);
             actualBuildResult = build.getResult();
             actualBuildLog = build.getLog(1000);
         } finally {


### PR DESCRIPTION
The unit-tests are a bit flakey in places, leading to false-negative builds on the official Jenkins CI.
This PR makes some of the code less flakey.

 - `DockerMultiplexedInputStreamTest` wasn't waiting for threads to finish before testing results
 - `DockerComputerConnectorTest` sometimes takes more than 90 seconds if docker is slow
 - The code sometimes called `Jenkins.get().addNode(...)` directly instead of from within a retry loop

Only the latter point affects non-test behaviour, which _might_ have contributed to unreliability on agents not using SSH (i.e. JNLP & "direct") ... although that'd be hard to prove because, in "real world" usage, Jenkins would retry and a failure should merely cause a provisioning delay rather than a hard failure.