### PR TITLE
Require Jenkins 2.332.4 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.361.3', '2.375'])
+buildPlugin(jenkinsVersions: [null, '2.361.3'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.303.3'])
+buildPlugin(jenkinsVersions: [null, '2.361.3', '2.375'])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ buildPlugin(
   failFast: false,
   // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
   configurations: [
-    [platform: 'windows', jdk: '17', jenkins: '2.386'],
+    [platform: 'windows', jdk: '17'],
     [platform: 'linux',   jdk: '11'],
   ]
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.361.3'])
+buildPlugin()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,14 @@
-buildPlugin()
+#!/usr/bin/env groovy
+
+/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin(
+  // Container agents won't work for testing this plugin
+  useContainerAgent: false,
+  // Show failures on all configurations
+  failFast: false,
+  // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
+  configurations: [
+    [platform: 'windows', jdk: '17', jenkins: '2.386'],
+    [platform: 'linux',   jdk: '11'],
+  ]
+)

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.50</version>
+        <version>4.51</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <changelist>-SNAPSHOT</changelist>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groovy.version>2.4.7</groovy.version>
-        <jenkins.version>2.346.3</jenkins.version>
+        <jenkins.version>2.332.4</jenkins.version>
         <gitHubRepo>jenkinsci/docker-plugin</gitHubRepo>
         <!-- Our unit-tests that talk to a real docker deamon aren't very stable -->
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
@@ -184,7 +184,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
+                <artifactId>bom-2.332.x</artifactId>
                 <version>1763.v092b_8980a_f5e</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -116,24 +116,11 @@
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
             <scope>test</scope>
-            <exclusions>
-            	<!-- We get apache commons lang from docker-java and that version can conflict with what JCasC says it needs -->
-            	<exclusion>
-            		<groupId>org.apache.commons</groupId>
-            		<artifactId>commons-lang3</artifactId>
-            	</exclusion>
-            </exclusions> 
         </dependency>
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
-            <exclusions>
-              <exclusion>
-                <groupId>org.jenkins-ci.main</groupId>
-                <artifactId>jenkins-test-harness</artifactId>
-              </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.346.x</artifactId>
-                <version>1742.vb_70478c1b_25f</version>
+                <version>1763.v092b_8980a_f5e</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.346.x</artifactId>
-                <version>1678.vc1feb_6a_3c0f1</version>
+                <version>1742.vb_70478c1b_25f</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <changelist>-SNAPSHOT</changelist>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <groovy.version>2.4.7</groovy.version>
-        <jenkins.version>2.303.3</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
         <gitHubRepo>jenkinsci/docker-plugin</gitHubRepo>
         <!-- Our unit-tests that talk to a real docker deamon aren't very stable -->
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
@@ -126,6 +126,12 @@
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>org.jenkins-ci.main</groupId>
+                <artifactId>jenkins-test-harness</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -189,8 +195,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.303.x</artifactId>
-                <version>1409.v7659b_c072f18</version>
+                <artifactId>bom-2.346.x</artifactId>
+                <version>1678.vc1feb_6a_3c0f1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Require Jenkins 2.332.4 or newer

According to the [installation data](https://stats.jenkins.io/pluginversions/docker-plugin.html), 50% of all installations of this plugin are running either the most recent release (1.2.10) or the release one prior to the most recent release (1.2.9) and are running on Jenkins 2.346.1 or newer.  Since there are known security issues in 2.332.3 and earlier, let's rely on 2.332.4 as required minimum Jenkins version.  

2.346.3 fails plugin tests consistently and I don't have the time or stamina to diagnose the failures.  2.332.4 passes the tests on the 3 different Linux computers that I checked.

Also exclude a dependency on jenkins-test-harness brought from the configuration as code tests.  Rely on the test harness provided by core.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
