### PR TITLE
Use https: for scm URL, not ssh:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
     </dependencyManagement>
 
     <scm>
-        <connection>scm:git:ssh://github.com/jenkinsci/docker-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/docker-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/docker-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/docker-plugin</url>
         <tag>${scmTag}</tag>


### PR DESCRIPTION
## Use https:// URL instead of git:// URL in pom

The regular SCM URL should be readable without authentication.  GitHub no longer supports the unauthenticated and unencrypted git:// protocol.  Replace it with https:// protocol for read access to the git repository.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
