### PR TITLE
Fix some issues with `dockerNode` mixed with `node`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,17 +81,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- Avoid exposing ourselves to a bug introduced in https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180 -->
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-basic-steps</artifactId>
-        <version>994.vd57e3ca_46d24</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jenkins-ci.plugins.workflow</groupId>
-        <artifactId>workflow-durable-task-step</artifactId>
-        <version>1199.v02b_9244f8064</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Closes #948, adapting to https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180. I would not be surprised if there are some more corner cases (like https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/292) affecting something you should never do—hold onto two (or more) executors at once—which generally results from misunderstanding, especially in a Declarative Pipeline which may obscure the control flow. Also doing the equivalent of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/128 since I noticed that had been forgotten here. See also #557.