### PR TITLE
Document how to use `jenkins/ssh-agent` Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ for the Docker image to be used:
     injected in container on startup, you don't need any credential set
     as long as you use standard openssl sshd.
     ![](docs/images/connect-with-ssh.png)
+    When using the `jenkins/ssh-agent` Docker image, ensure that the user
+    is set to `jenkins`.
     For backward compatibility *or* non-standard sshd packaged in your
     docker image, you also have option to provide manually configured
     ssh credentials


### PR DESCRIPTION
It took me a huge amount of time to figure out how to get the Connect with SSH connection method to work, until I figured out that I needed to set the username to `jenkins` in order for the SSH key to be properly injected. This was particularly frustrating since I did not need to set the username for any of the other connection methods. This a shortcoming in `docker-plugin` that would presumably be addressed by #763. Until then, at least document the status quo to make the situation less frustrating for newcomers.