### PR TITLE
Add sidebar to Docker build action

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildAction.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildAction.java
@@ -5,27 +5,32 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import hudson.Extension;
-import hudson.model.Action;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.model.Run;
 import io.jenkins.docker.DockerTransientNode;
 import io.jenkins.docker.client.DockerAPI;
 import java.io.IOException;
 import java.io.Serializable;
 import jenkins.model.Jenkins;
+import jenkins.model.RunAction2;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * Created by magnayn on 10/01/2014.
  */
 @ExportedBean
-public class DockerBuildAction implements Action, Serializable, Describable<DockerBuildAction> {
+public class DockerBuildAction implements RunAction2, Serializable, Describable<DockerBuildAction> {
 
     private String cloudId;
     private final String containerHost;
     private final String containerId;
     private String inspect;
     private String taggedId;
+
+    private transient Run<?, ?> run;
 
     public DockerBuildAction(String containerHost, String containerId, String taggedId) {
         this.containerHost = containerHost;
@@ -72,6 +77,11 @@ public class DockerBuildAction implements Action, Serializable, Describable<Dock
         return inspect;
     }
 
+    @Restricted(DoNotUse.class) // for Jelly
+    public Run<?, ?> getRun() {
+        return run;
+    }
+
     @Override
     public String getIconFileName() {
         return "symbol-logo-docker plugin-ionicons-api";
@@ -90,6 +100,16 @@ public class DockerBuildAction implements Action, Serializable, Describable<Dock
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) Jenkins.get().getDescriptorOrDie(getClass());
+    }
+
+    @Override
+    public void onAttached(Run<?, ?> run) {
+        this.run = run;
+    }
+
+    @Override
+    public void onLoad(Run<?, ?> run) {
+        this.run = run;
     }
 
     /**

--- a/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction.java
@@ -108,7 +108,7 @@ public class DockerBuildImageAction implements RunAction2, Serializable, Describ
 
     @Override
     public String getUrlName() {
-        return "docker";
+        return "dockerImage";
     }
 
     @Override

--- a/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction.java
@@ -1,13 +1,15 @@
 package com.nirima.jenkins.plugins.docker.action;
 
 import hudson.Extension;
-import hudson.model.Action;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
+import hudson.model.Run;
 import java.io.Serializable;
 import java.util.List;
 import jenkins.model.Jenkins;
+import jenkins.model.RunAction2;
 import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -15,7 +17,7 @@ import org.kohsuke.stapler.export.ExportedBean;
  * Created by magnayn on 10/01/2014.
  */
 @ExportedBean
-public class DockerBuildImageAction implements Action, Serializable, Describable<DockerBuildImageAction> {
+public class DockerBuildImageAction implements RunAction2, Serializable, Describable<DockerBuildImageAction> {
 
     public final String containerHost;
     public final String containerId;
@@ -32,6 +34,8 @@ public class DockerBuildImageAction implements Action, Serializable, Describable
     public final boolean pushOnSuccess;
     public /* almost final */ boolean noCache;
     public /* almost final */ boolean pull;
+
+    private transient Run<?, ?> run;
 
     @Deprecated
     public DockerBuildImageAction(
@@ -87,6 +91,11 @@ public class DockerBuildImageAction implements Action, Serializable, Describable
         this.noCache = noCache;
     }
 
+    @Restricted(DoNotUse.class) // for Jelly
+    public Run<?, ?> getRun() {
+        return run;
+    }
+
     @Override
     public String getIconFileName() {
         return "symbol-logo-docker plugin-ionicons-api";
@@ -105,6 +114,16 @@ public class DockerBuildImageAction implements Action, Serializable, Describable
     @Override
     public DescriptorImpl getDescriptor() {
         return (DescriptorImpl) Jenkins.get().getDescriptorOrDie(getClass());
+    }
+
+    @Override
+    public void onAttached(Run<?, ?> run) {
+        this.run = run;
+    }
+
+    @Override
+    public void onLoad(Run<?, ?> run) {
+        this.run = run;
     }
 
     /**

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildAction/index.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildAction/index.jelly
@@ -1,6 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <l:layout title="Docker">
+    <st:include it="${it.run}" page="sidepanel.jelly" />
     <l:main-panel>
 
       <h1>Docker Build Data</h1>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction/index.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction/index.jelly
@@ -1,6 +1,7 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
     <l:layout title="Docker">
+        <st:include it="${it.run}" page="sidepanel.jelly" />
         <l:main-panel>
             <h1>Docker Image Build / Publish</h1>
 

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction/index.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction/index.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
     <l:layout title="Docker">
         <st:include it="${it.run}" page="sidepanel.jelly" />
         <l:main-panel>


### PR DESCRIPTION
It seemed really weird to me that this page wouldn't have a sidebar like everything else. I looked at other run actions and they generally seemed to have a sidebar. To test this I loaded the **Docker Build Data** page and verified it had a sidebar.

CC @jenkinsci/sig-ux 