### PR TITLE
Do not use `<h1>` in summary

### DIFF
--- a/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildAction/summary.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildAction/summary.jelly
@@ -4,7 +4,7 @@
     xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <t:summary icon="symbol-logo-docker plugin-ionicons-api">
 
-    <h1>Docker Build Data</h1>
+    <p>Docker build metadata:</p>
 
     <ul>
       <j:choose>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction/summary.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction/summary.jelly
@@ -4,7 +4,7 @@
         >
     <t:summary icon="symbol-logo-docker plugin-ionicons-api">
 
-        <h1>Docker Image Build / Publish</h1>
+        <p>Docker image build metadata:</p>
 
         <b>Host:</b>
         ${it.containerHost}


### PR DESCRIPTION
The `<h1>` tag in the summary looked off and seemed to only be there to facilitate re-use of the summary in the full view, which was ripped out recently in #911. I looked at other summaries in popular plugins and none of them had headings at all, let alone `<h1>` which is surely inappropriate for a summary item.

CC @jenkinsci/sig-ux 