### PR TITLE
Clean up summaries

### DIFF
--- a/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildAction/summary.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildAction/summary.jelly
@@ -1,11 +1,7 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
-    xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"
-    xmlns:f="/lib/form" xmlns:i="jelly:fmt">
-    <t:summary icon="symbol-logo-docker plugin-ionicons-api">
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+  <t:summary icon="symbol-logo-docker plugin-ionicons-api">
     <p>Docker build metadata:</p>
-
     <ul>
       <j:choose>
         <j:when test="${it.cloudId != null}">
@@ -15,11 +11,10 @@
           <li><b>Host:</b> ${it.containerHost}</li>
         </j:otherwise>
       </j:choose>
-      <li><b>Container Id:</b> ${it.containerId}</li>
+      <li><b>Container ID:</b> ${it.containerId}</li>
       <j:if test="${it.taggedId != null}">
-        <li><b>Committed Container Id:</b> ${it.taggedId}</li>
+        <li><b>Committed Container ID:</b> ${it.taggedId}</li>
       </j:if>
     </ul>
-
-    </t:summary>
+  </t:summary>
 </j:jelly>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction/summary.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/action/DockerBuildImageAction/summary.jelly
@@ -1,21 +1,11 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core"
-         xmlns:t="/lib/hudson"
-        >
-    <t:summary icon="symbol-logo-docker plugin-ionicons-api">
-
-        <p>Docker image build metadata:</p>
-
-        <b>Host:</b>
-        ${it.containerHost}
-        <br/>
-
-        <b>Original Container Id:</b>
-        ${it.containerId}
-        <br/>
-        <b>Committed Container Id(s):</b>
-        ${it.tags}
-        <br/>
-
-    </t:summary>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson">
+  <t:summary icon="symbol-logo-docker plugin-ionicons-api">
+    <p>Docker image build metadata:</p>
+    <ul>
+      <li><b>Host:</b> ${it.containerHost}</li>
+      <li><b>Original Container ID:</b> ${it.containerId}</li>
+      <li><b>Committed Container ID(s):</b> ${it.tags}</li>
+    </ul>
+  </t:summary>
 </j:jelly>


### PR DESCRIPTION
While testing #967 I noticed that the summaries for these two actions were inconsistent, which was even more glaring when they were both placed on the same page. This change makes the summaries consistent with each other and makes the Docker image summary look reasonable as well as reformatting both Jelly files and fixing the capitalization of "ID."