### PR TITLE
Remove unnecessary SpotBugs warning

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerRegistry.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerRegistry.java
@@ -1,5 +1,6 @@
 package com.nirima.jenkins.plugins.docker;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
@@ -7,7 +8,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 @Deprecated
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+@SuppressFBWarnings(
         value = "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
         justification = "Deprecated; required for backwards compatibility only.")
 public class DockerRegistry implements Describable<DockerRegistry> {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerSlave.java
@@ -1,6 +1,7 @@
 package com.nirima.jenkins.plugins.docker;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.model.Descriptor;
 import hudson.model.Slave;
 import hudson.slaves.ComputerLauncher;
@@ -13,7 +14,7 @@ import java.io.UncheckedIOException;
  * @deprecated use {@link DockerTransientNode}
  */
 @Deprecated
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+@SuppressFBWarnings(
         value = "SE_NO_SERIALVERSIONID",
         justification = "Deprecated; required for backwards compatibility only.")
 public class DockerSlave extends Slave {

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplate.java
@@ -497,9 +497,6 @@ public class DockerTemplate implements Describable<DockerTemplate> {
      * Initializes data structure that we don't persist.
      * @return this, but populated
      */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
-            value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-            justification = "This method's job is to ensure that things aren't null where they shouldn't be.")
     protected Object readResolve() {
         try {
             // https://github.com/jenkinsci/docker-plugin/issues/270

--- a/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher.java
@@ -1,5 +1,6 @@
 package com.nirima.jenkins.plugins.docker.launcher;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.slaves.JNLPLauncher;
 import io.jenkins.docker.connector.DockerComputerConnector;
 import io.jenkins.docker.connector.DockerComputerJNLPConnector;
@@ -14,7 +15,7 @@ import io.jenkins.docker.connector.DockerComputerJNLPConnector;
  *
  * @author Kanstantsin Shautsou
  */
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+@SuppressFBWarnings(
         value = "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",
         justification = "Deprecated; required for backwards compatibility only.")
 @Deprecated

--- a/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerSSHLauncher.java
@@ -1,5 +1,6 @@
 package com.nirima.jenkins.plugins.docker.launcher;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.plugins.sshslaves.SSHConnector;
 import io.jenkins.docker.connector.DockerComputerConnector;
 import io.jenkins.docker.connector.DockerComputerSSHConnector;
@@ -8,7 +9,7 @@ import io.jenkins.docker.connector.DockerComputerSSHConnector;
  * Configurable SSH launcher that expected ssh port to be exposed from docker container.
  */
 @Deprecated
-@edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+@SuppressFBWarnings(
         value = {
             "UWF_UNWRITTEN_FIELD",
             "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD",


### PR DESCRIPTION
``RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` is unnecessary in recent versions of SpotBugs with proper Java 11 support. While I was here I also cleaned up the imports.