### PR TITLE
Improving uniqueness of templateID string (via template name)

### DIFF
--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-name.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-name.html
@@ -4,6 +4,7 @@
     Jenkins will append a unique ID to this name in order to create individual node names.
     <p>
     If blank or just whitespace, a default of "docker" will be used.
+    <p/>
     <p>
     When using the same docker image in multiple docker agent templates, make sure to set an individual name for each template.<br/>
 	This is needed for capping by number of container instance by template to work correctly.

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-name.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-name.html
@@ -4,4 +4,8 @@
     Jenkins will append a unique ID to this name in order to create individual node names.
     <p>
     If blank or just whitespace, a default of "docker" will be used.
+    <p>
+    When using the same docker image in multiple docker agent templates, make sure to set an individual name for each template.<br/>
+	This is needed for capping by number of container instance by template to work correctly.
+	</p>
 </div>

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
@@ -148,7 +148,7 @@ public abstract class DockerComputerConnectorTest {
                         return true;
                     }
                 }
-                final int containersInDocker = cloud.countContainersInDocker(null);
+                final int containersInDocker = cloud.countContainersInDocker(null, null);
                 if (containersInDocker > 0) {
                     return true;
                 }


### PR DESCRIPTION
Just as in #816 and #874, we want to distinguish templates that use the same docker image.

We do this pragmatically by using the user-supplied template name, so that the user is in control to make it unique.

So this fixes #816 as long as the user provides distinguished template names, which is explained by the help texts.

### Testing done

- unit testcases were extended and pass
- code has been used successfully in production for 10 months

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
