### PR TITLE
Converting "container cleanup" log message from INFO to DEBUG type

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerWatchdog.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerContainerWatchdog.java
@@ -220,7 +220,7 @@ public class DockerContainerWatchdog extends AsyncPeriodicWork {
 
             DockerDisabled dcDisabled = dc.getDisabled();
             if (dcDisabled.isDisabled()) {
-                LOGGER.info(
+                LOGGER.debug(
                         "Will not cleanup superfluous containers on DockerCloud [name={}, dockerURI={}], as it is disabled",
                         dc.getDisplayName(),
                         dc.getDockerApi().getDockerHost().getUri());


### PR DESCRIPTION
Just as described in #996, converting the bellow log message from **INFO** to **DEBUG** type will prevent it from being logged every 5 minutes on the Jenkins logs.
```sh
Jul 30, 2023 12:48:31 PM INFO com.nirima.jenkins.plugins.docker.DockerContainerWatchdog processCloud
Will not cleanup superfluous containers on DockerCloud [name=docker, dockerURI=unix:///var/run/docker.sock], as it is disabled
Jul 30, 2023 12:53:31 PM INFO com.nirima.jenkins.plugins.docker.DockerContainerWatchdog processCloud
Will not cleanup superfluous containers on DockerCloud [name=docker, dockerURI=unix:///var/run/docker.sock], as it is disabled
...
```

This message generates **unnecessary noise**, thus potentially obscuring developers from reading other logs with higher importance.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
