### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,6 @@ buildPlugin(
   // Test Java 11, 17, and 21
   configurations: [
     [platform: 'linux', jdk: 17],
-    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
+    [platform: 'linux',   jdk: '21', jenkins: '2.401.3'],
     [platform: 'windows', jdk: 11],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,9 @@ buildPlugin(
   useContainerAgent: false,
   // Show failures on all configurations
   failFast: false,
-  // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
+  // Test Java 11, 17, and 21
   configurations: [
     [platform: 'linux', jdk: 17],
+    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
     [platform: 'windows', jdk: 11],
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,8 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(
+  // Run a JVM per core in tests
+  forkCount: '1C',
   // Container agents won't work for testing this plugin
   useContainerAgent: false,
   // Show failures on all configurations

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,6 @@
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(
-  // Run a JVM per core in tests
-  forkCount: '1C',
   // Container agents won't work for testing this plugin
   useContainerAgent: false,
   // Show failures on all configurations

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
@@ -21,9 +21,9 @@ public class DockerComputerAttachConnectorTest extends DockerComputerConnectorTe
     @Test
     public void connectAgentViaDirectAttachWithCustomCmd() throws Exception {
         final DockerComputerAttachConnector connector = new DockerComputerAttachConnector(COMMON_IMAGE_USERNAME);
-        // We could setJavaExe("/usr/local/openjdk-8/bin/java") too, but that'd mean
-        // we'd break the instant that the public docker image's JVM updates to 9 or
-        // higher; best stick to just using the $PATH.
+        // We could setJavaExe("/opt/jdk-11/bin/java") too, but that'd
+        // mean we'd break the instant that the public docker image's JVM
+        // updates to a newer JDK; best stick to just using the $PATH.
         connector.setJvmArgsString("-Xmx1g" + "\n" + "-Dfoo=bar\n");
         connector.setEntryPointCmdString("java\n"
                 + "${" + ArgumentVariables.JvmArgs.getName() + "}\n"

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
@@ -48,19 +48,12 @@ public abstract class DockerComputerConnectorTest {
         final String systemPropertyName = "java.version";
         final String javaVersion = System.getProperty(systemPropertyName);
         try {
-            if (javaVersion.startsWith("1.")) {
-                // we're using Java 8 or lower so the syntax is 1.x where x is the version we
-                // want.
-                // ... and we know that x will be a single digit.
-                // e.g. 1.8.1 is Java 8, 1.6.3 is Java 6 etc.
-                final String secondNumber = javaVersion.substring(2, 3);
-                return Integer.parseInt(secondNumber);
-            }
-            // otherwise we're using Java 9 or higher so the syntax is x.n...
+            // We're using Java 9 or higher so the syntax is x.n...
             // ... but x might be multiple digits.
             // e.g. 9.0 is Java 9, 11.123.4 is Java 11 etc.
+            // Early access builds report as "21-ea".  Remove all text after "-".
             final int indexOfPeriod = javaVersion.indexOf('.');
-            final String firstNumber = indexOfPeriod < 0 ? javaVersion : javaVersion.substring(0, indexOfPeriod);
+            final String firstNumber = javaVersion.replaceAll("[-.].*$", "");
             return Integer.parseInt(firstNumber);
         } catch (RuntimeException ex) {
             throw new IllegalStateException(

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerConnectorTest.java
@@ -53,7 +53,7 @@ public abstract class DockerComputerConnectorTest {
             // e.g. 9.0 is Java 9, 11.123.4 is Java 11 etc.
             // Early access builds report as "21-ea".  Remove all text after "-".
             final int indexOfPeriod = javaVersion.indexOf('.');
-            final String firstNumber = javaVersion.replaceAll("[-.].*$", "");
+            final String firstNumber = javaVersion.replaceAll("[-.].*", "");
             return Integer.parseInt(firstNumber);
         } catch (RuntimeException ex) {
             throw new IllegalStateException(


### PR DESCRIPTION
## Test with Java 21

- Remove Java 8 test support
- Test with Java 21

We want to support Java 21 shortly after its release in September.  Testing the plugins with Java 21 is a good step to that support.

### Testing done

Confirmed tests pass with Java 21 on my Debian Linux testing distribution with latest docker engine installed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
