### PR TITLE
Replace deprecated getPastTimeString with getTimeSpanString

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerDisabled.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerDisabled.java
@@ -120,7 +120,7 @@ public class DockerDisabled extends AbstractDescribableImpl<DockerDisabled> impl
         final long now = readTimeNowInNanoseconds();
         final long howLongAgoInNanoseconds = now - nanotimeWhenDisabledBySystem;
         final long howLongAgoInMilliseconds = TimeUnit.NANOSECONDS.toMillis(howLongAgoInNanoseconds);
-        return Util.getPastTimeString(howLongAgoInMilliseconds);
+        return Util.getTimeSpanString(howLongAgoInMilliseconds);
     }
 
     /**


### PR DESCRIPTION
## Replace deprecated getPastTimeString with getTimeSpanString

Replaced with OpenRewrite command:

```
mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
      -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-jenkins:RELEASE \
      -Drewrite.activeRecipes=org.openrewrite.jenkins.migrate.hudson.UtilGetPastTimeStringToGetTimeSpanString
```

https://github.com/jenkinsci/jenkins/pull/4174 deprecates the API in a 2019 release of Jenkins core.

https://javadoc.jenkins.io/hudson/Util.html#getPastTimeString(long) declares it deprecated.

### Testing done

Confirmed automated tests continue to pass with the change and that the modified line is executed in the automated tests.

Did not confirm that there is an assertion specifically targeting the `getWhenDisabledBySystemString`, but the deprecation message says that the API calls are equivalent.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
