### PR TITLE
[JENKINS-71959] Rename blank cloud names to be non-blank

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -138,6 +138,9 @@ public class DockerCloud extends Cloud {
         super(name);
         this.dockerApi = dockerApi;
         this.templates = templates;
+        if (name == null || name.isBlank()) {
+            LOGGER.warn("Docker cloud requires a non-blank name after Jenkins 2.402");
+        }
     }
 
     @Deprecated

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -730,6 +730,10 @@ public class DockerCloud extends Cloud {
             dockerApi = new DockerAPI(dockerHost, connectTimeout, readTimeout, version, dockerHostname);
         }
 
+        if (name == null || name.isBlank()) {
+            LOGGER.warn("Docker cloud requires a non-blank name after Jenkins 2.402");
+        }
+
         return this;
     }
 

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -143,6 +143,13 @@ public class DockerCloud extends Cloud {
         }
     }
 
+    /* Constructor to create a new DockerCloud based on an existing DockerCloud */
+    public DockerCloud(@NonNull String name, @NonNull DockerCloud source) {
+        super(name);
+        this.dockerApi = source.dockerApi;
+        this.templates = source.templates;
+    }
+
     @Deprecated
     public DockerCloud(
             String name,
@@ -731,7 +738,9 @@ public class DockerCloud extends Cloud {
         }
 
         if (name == null || name.isBlank()) {
-            LOGGER.warn("Docker cloud requires a non-blank name after Jenkins 2.402");
+            String newName = "docker-cloud-" + Integer.toHexString(hashCode());
+            LOGGER.warn("Docker cloud requires a non-blank name after Jenkins 2.402, using '" + newName + "'");
+            return new DockerCloud(newName, this);
         }
 
         return this;

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerCloudTest.java
@@ -78,6 +78,21 @@ public class DockerCloudTest {
         MatcherAssert.assertThat(lr.getMessages(), IsIterableContaining.hasItem(LOG_MESSAGE));
     }
 
+    @Issue("JENKINS-70729") // Handle null or empty cloud name
+    @Test
+    public void testCopyConstructor() {
+        lr.record(DockerCloud.class.getName(), Level.ALL).capture(16);
+        DockerCloud cloud =
+                new DockerCloud(null, new DockerAPI(new DockerServerEndpoint("uri", "credentialsId")), List.of());
+        Assert.assertEquals(cloud.getDisplayName(), null);
+        MatcherAssert.assertThat(lr.getMessages(), IsIterableContaining.hasItem(LOG_MESSAGE));
+        String newName = "docker-cloud-" + Integer.toHexString(cloud.hashCode());
+        DockerCloud copy = new DockerCloud(newName, cloud);
+        Assert.assertEquals(cloud.getDockerApi(), copy.getDockerApi());
+        Assert.assertEquals(cloud.getTemplates().hashCode(), copy.getTemplates().hashCode());
+        Assert.assertEquals(newName, copy.getDisplayName());
+    }
+
     @Test
     public void globalConfigRoundtrip() throws Exception {
 

--- a/src/test/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtilsTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/utils/JenkinsUtilsTest.java
@@ -28,12 +28,11 @@ public class JenkinsUtilsTest {
     public void getCloudByNameOrThrowGivenNameThenReturnsCloud() throws Exception {
         // Given
         final DockerAPI dockerApi = new DockerAPI(new DockerServerEndpoint("uri", "credentialsId"));
-        final DockerCloud cloudEmpty = new DockerCloud("", dockerApi, Collections.emptyList());
         final String expectedCloudName = "expectedCloudName";
         final DockerCloud cloudExpected = new DockerCloud(expectedCloudName, dockerApi, Collections.emptyList());
         final DockerCloud cloudOther = new DockerCloud("otherCloudName", dockerApi, Collections.emptyList());
         final OtherTypeOfCloud cloudForeign = new OtherTypeOfCloud("foreign");
-        final List<Cloud> clouds = List.of(cloudEmpty, cloudOther, cloudExpected, cloudForeign);
+        final List<Cloud> clouds = List.of(cloudOther, cloudExpected, cloudForeign);
         jenkins.getInstance().clouds.replaceBy(clouds);
 
         // When
@@ -47,14 +46,13 @@ public class JenkinsUtilsTest {
     public void getCloudByNameOrThrowGivenUnknownNameThenThrows() throws Exception {
         // Given
         final DockerAPI dockerApi = new DockerAPI(new DockerServerEndpoint("uri", "credentialsId"));
-        final DockerCloud cloudEmpty = new DockerCloud("", dockerApi, Collections.emptyList());
         final String requestedCloudName = "anUnknownCloudName";
         final String cloudName1 = "expectedCloudName";
         final DockerCloud cloud1 = new DockerCloud(cloudName1, dockerApi, Collections.emptyList());
         final String cloudName2 = "otherCloudName";
         final DockerCloud cloud2 = new DockerCloud(cloudName2, dockerApi, Collections.emptyList());
         final OtherTypeOfCloud cloudForeign = new OtherTypeOfCloud("foreign");
-        final List<Cloud> clouds = List.of(cloudEmpty, cloud2, cloud1, cloudForeign);
+        final List<Cloud> clouds = List.of(cloud2, cloud1, cloudForeign);
         jenkins.getInstance().clouds.replaceBy(clouds);
 
         try {
@@ -75,14 +73,13 @@ public class JenkinsUtilsTest {
     public void getCloudByNameOrThrowGivenForeignCloudNameThenThrows() throws Exception {
         // Given
         final DockerAPI dockerApi = new DockerAPI(new DockerServerEndpoint("uri", "credentialsId"));
-        final DockerCloud cloudEmpty = new DockerCloud("", dockerApi, Collections.emptyList());
         final String requestedCloudName = "foreign";
         final String cloudName1 = "DockerCloud1Name";
         final DockerCloud cloud1 = new DockerCloud(cloudName1, dockerApi, Collections.emptyList());
         final String cloudName2 = "DockerCloud2Name";
         final DockerCloud cloud2 = new DockerCloud(cloudName2, dockerApi, Collections.emptyList());
         final OtherTypeOfCloud cloudForeign = new OtherTypeOfCloud(requestedCloudName);
-        final List<Cloud> clouds = List.of(cloudEmpty, cloud2, cloud1, cloudForeign);
+        final List<Cloud> clouds = List.of(cloud2, cloud1, cloudForeign);
         jenkins.getInstance().clouds.replaceBy(clouds);
 
         try {


### PR DESCRIPTION
## [JENKINS-71959] Rename blank cloud names to be non-blank

https://github.com/jenkinsci/jenkins/pull/7658 reworks cloud management to use multiple pages instead of a single large page.  That rework also requires that a cloud may not be named with an empty string.

The docker plugin previously tested that a cloud was allowed to have an empty string as its name, but performed no other operations with a cloud named with an empty string.  Clouds named with an empty string may have worked prior to Jenkins 2.403, but they would have been complicated to manage, especially in a controller with multiple clouds defined.

A cloud named with an empty string is much more difficult to manage. It is better to mention in the changelog that clouds are no longer allowed to have an empty name rather than wrestling with all the ways that an empty name will break cloud administration.

* [JENKINS-70729](https://issues.jenkins.io/browse/JENKINS-70729) is the enhancement request that implements the change in Jenkins core 2.403
* [JENKINS-71825](https://issues.jenkins.io/browse/JENKINS-71825) is the bug report for the automated test failure that started this investigation
* [JENKINS-71959](https://issues.jenkins.io/browse/JENKINS-71959) is the bug report that a Docker cloud that uses a blank name cannot be edited in Jenkins 2.403 or later without the fix in this pull request

### Testing done

Confirmed that a Docker cloud named with an empty string can be edited in 2.401.3 with no apparent loss of functionality and when that cloud with the empty named string is loaded into the plugin changes with this pull request, it is assigned a name `docker-cloud-[hashCode]`.  That cloud can be edited in Jenkins 2.414.1 without any issue.

Discovered that a Docker cloud name uniqueness check is not performed.  I was able to create two distinct Docker clouds with the same name.  Editing the Docker clouds that shared the same name resulted in erratic behavior.  I could delete one of the two clouds that used the duplicate name, but immediately after that the other cloud with the same name would fail some operations.  Handling duplicate Docker cloud names is out of scope for this pull request.  Another pull request can be filed to handle that case.

Confirmed that Jenkins 2.421 automated tests fail as reported in [JENKINS-71825](https://issues.jenkins.io/browse/JENKINS-71825) without this change.

Confirmed that Jenkins 2.421 automated tests pass with this change.

Confirmed that Jenkins 2.421 already rejects an empty cloud name from the cloud creation page, whether or not this change is implemented.

Confirmed that Jenkins 2.421 accepts an empty cloud name from an earlier version but then rejects all attempts to use the cloud configuration page to modify the definition.  I modified the XML file that configures the cloud so that the cloud name was an empty string to perform that interactive test.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
