### PR TITLE
Avoid deprecated arguments in help text

### DIFF
--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerJNLPConnector/help-entryPointArgumentsString.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerJNLPConnector/help-entryPointArgumentsString.jelly
@@ -34,7 +34,7 @@
       <blockquote>
         <tt>sh</tt><br/>
         <tt>-c</tt><br/>
-        <tt>wget $${JENKINS_URL}jnlpJars/agent.jar &amp;&amp; java -jar agent.jar -jnlpUrl $${JENKINS_URL}computer/$${NODE_NAME}/slave-agent.jnlp -secret $${JNLP_SECRET}</tt><br/>
+        <tt>wget $${JENKINS_URL}jnlpJars/agent.jar &amp;&amp; java -jar agent.jar -url $${JENKINS_URL} -secret $${JNLP_SECRET} -name $${NODE_NAME}</tt><br/>
       </blockquote>
     </p>
     <p>


### PR DESCRIPTION
The `-jnlpUrl` argument has been deprecated in recent versions of Remoting, so this PR switches the help text to use its non-deprecated replacement.