### PR TITLE
fix: Port binding is not respected for SSH port

### DIFF
--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -278,10 +278,12 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
         }
         final Ports portBindings = hostConfig.getPortBindings();
         if (portBindings != null) {
-            if(portBindings.getBindings().get(sshPortBinding.getExposedPort()).length == 0) {
-               portBindings.add(sshPortBinding);
-               hostConfig.withPortBindings(portBindings);
+            final Ports.Binding[] portBinding = portBindings.getBindings().get(sshPortBinding.getExposedPort());
+            // Only add default ssh port Binding when it is not already configured
+            if (portBinding == null || portBinding.length == 0) {
+                portBindings.add(sshPortBinding);
             }
+            hostConfig.withPortBindings(portBindings);
         } else {
             hostConfig.withPortBindings(sshPortBinding);
         }

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerSSHConnector.java
@@ -278,8 +278,10 @@ public class DockerComputerSSHConnector extends DockerComputerConnector {
         }
         final Ports portBindings = hostConfig.getPortBindings();
         if (portBindings != null) {
-            portBindings.add(sshPortBinding);
-            hostConfig.withPortBindings(portBindings);
+            if(portBindings.getBindings().get(sshPortBinding.getExposedPort()).length == 0) {
+               portBindings.add(sshPortBinding);
+               hostConfig.withPortBindings(portBindings);
+            }
         } else {
             hostConfig.withPortBindings(sshPortBinding);
         }

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
@@ -128,4 +128,46 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
         final String actualHostPortSpecForPort22 = actualBindingsForPort22[0].getHostPortSpec();
         Assert.assertNull(actualHostPortSpecForPort22);
     }
+    
+    @Test
+    public void testPortBindingPort22() throws IOException, InterruptedException {
+        // Given
+        DockerComputerSSHConnector connector =
+                new DockerComputerSSHConnector(Mockito.mock(DockerComputerSSHConnector.SSHKeyStrategy.class));
+        CreateContainerCmdImpl cmd = new CreateContainerCmdImpl(
+                Mockito.mock(CreateContainerCmd.Exec.class), Mockito.mock(AuthConfig.class), "");
+        HostConfig hostConfig = cmd.getHostConfig();
+        if (hostConfig == null) {
+            hostConfig = new HostConfig();
+            cmd.withHostConfig(hostConfig);
+        }
+        final PortBinding exportContainerPort42 = PortBinding.parse("42:42");
+        final PortBinding exportContainerPort22 = PortBinding.parse("3022:22");
+        hostConfig.withPortBindings(exportContainerPort42, exportContainerPort22);
+        final ExposedPort port42 = new ExposedPort(42);
+        final ExposedPort port22 = new ExposedPort(22);
+
+        // When
+        connector.setPort(22);
+        connector.beforeContainerCreated(Mockito.mock(DockerAPI.class), "/workdir", cmd);
+
+        // Then
+        final Ports actualPortBindings = cmd.getHostConfig().getPortBindings();
+        Assert.assertNotNull(actualPortBindings);
+        final Map<ExposedPort, Ports.Binding[]> actualBindingMap = actualPortBindings.getBindings();
+        Assert.assertNotNull(actualBindingMap);
+        Assert.assertEquals(2, actualBindingMap.size());
+
+        final Ports.Binding[] actualBindingsForPort42 = actualBindingMap.get(port42);
+        Assert.assertNotNull(actualBindingsForPort42);
+        Assert.assertEquals(1, actualBindingsForPort42.length);
+        final String actualHostPortSpecForPort42 = actualBindingsForPort42[0].getHostPortSpec();
+        Assert.assertEquals("42", actualHostPortSpecForPort42);
+
+        final Ports.Binding[] actualBindingsForPort22 = actualBindingMap.get(port22);
+        Assert.assertNotNull(actualBindingsForPort22);
+        Assert.assertEquals(1, actualBindingsForPort22.length);
+        final String actualHostPortSpecForPort22 = actualBindingsForPort22[0].getHostPortSpec();
+        Assert.assertEquals("3022",actualHostPortSpecForPort22);
+    }
 }

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
@@ -128,7 +128,7 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
         final String actualHostPortSpecForPort22 = actualBindingsForPort22[0].getHostPortSpec();
         Assert.assertNull(actualHostPortSpecForPort22);
     }
-    
+
     @Test
     public void testPortBindingPort22() throws IOException, InterruptedException {
         // Given
@@ -168,6 +168,6 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
         Assert.assertNotNull(actualBindingsForPort22);
         Assert.assertEquals(1, actualBindingsForPort22.length);
         final String actualHostPortSpecForPort22 = actualBindingsForPort22[0].getHostPortSpec();
-        Assert.assertEquals("3022",actualHostPortSpecForPort22);
+        Assert.assertEquals("3022", actualHostPortSpecForPort22);
     }
 }


### PR DESCRIPTION
1- Dashboard > Manage Jenkins > Configure Clouds
2- Add a new Cloud
3- Connect method SSH
4- Container settings
5- Port Bindings
     0.0.0.0:20000-20100:22
Expected Results
All docker-proxy process should use a port between 20000 and 20100

Tested for a year now with this fix and docker-proxy always gets a port in the specified range.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
