### PR TITLE
[JENKINS-72592] Fix inbound agent connector NPE on Jenkins 2.437+

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,19 +196,51 @@ and/or using the [JCasC plugin](https://plugins.jenkins.io/configuration-as-code
 
 If you're unsure which method to use, use JCasC.
 
+### JCasC plugin
+
+Install the [configuration-as-code plugin](https://plugins.jenkins.io/configuration-as-code/) and follow [its example](https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos/docker).
+
+As another alternative, a Docker daemon can listen to requests from remote hosts by following the [Docker documentation](https://docs.docker.com/config/daemon/remote-access/).
+The following configuration as code example creates a cloud named "my-docker-cloud" that uses the docker daemon at port 2375 on dockerhost.example.com to run up to 3 containerized agents at a time.
+Agents run the [Jenkins Alpine inbound agent container image](https://hub.docker.com/r/jenkins/inbound-agent) with Java 21.
+Thay use an inbound connection and run as the user ID 1000 with the home directory "/home/jenkins/agent".
+
+```yaml
+jenkins:
+  clouds:
+  - docker:
+      containerCap: 3
+      dockerApi:
+        connectTimeout: 23
+        dockerHost:
+          uri: "tcp://dockerhost.example.com:2375"
+        readTimeout: 43
+      errorDuration: 313
+      name: "my-docker-cloud"
+      templates:
+      - connector:
+          jnlp:
+            jenkinsUrl: "https://jenkins.example.com/"
+            user: "1000"
+        dockerTemplateBase:
+          cpuPeriod: 0
+          cpuQuota: 0
+          image: "jenkins/inbound-agent:latest-alpine-jdk21"
+        labelString: "alpine jdk21 alpine-jdk21 git-2.43"
+        name: "alpine-jdk21"
+        pullTimeout: 171
+        remoteFs: "/home/jenkins/agent"
+```
+
 ### Groovy script
 
 For example, this
 [configuration script](docs/attachments/docker-plugin-configuration-script.groovy)
 could be run automatically upon
-[Jenkins post-initialization](https://wiki.jenkins.io/display/JENKINS/Post-initialization+script)
+[Jenkins post-initialization](https://www.jenkins.io/doc/book/managing/groovy-hook-scripts/)
 or through the
-[Jenkins script console](https://wiki.jenkins.io/display/JENKINS/Jenkins+Script+Console).
+[Jenkins script console](https://www.jenkins.io/doc/book/managing/script-console/).
 If run,
 this script will configure the docker-plugin to look for a docker daemon running within the same OS as the Jenkins controller
 (connecting to Docker service through `unix:///var/run/docker.sock`)
 and with the containers connecting to Jenkins using the "attach" method.
-
-### JCasC plugin
-
-Install the [configuration-as-code plugin](https://plugins.jenkins.io/configuration-as-code/) and follow [its example](https://github.com/jenkinsci/configuration-as-code-plugin/tree/master/demos/docker).

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
   <properties>
     <revision>1.6</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.414.3</jenkins.version>
+    <jenkins.version>2.440</jenkins.version>
     <gitHubRepo>jenkinsci/docker-plugin</gitHubRepo>
     <!-- Our unit-tests that talk to a real docker deamon aren't very stable -->
     <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
@@ -76,7 +76,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.414.x</artifactId>
+        <artifactId>bom-2.440.x</artifactId>
         <version>2791.v707dc5a_1626d</version>
         <type>pom</type>
         <scope>import</scope>

--- a/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/launcher/DockerComputerJNLPLauncher.java
@@ -1,7 +1,6 @@
 package com.nirima.jenkins.plugins.docker.launcher;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.slaves.JNLPLauncher;
 import io.jenkins.docker.connector.DockerComputerConnector;
 import io.jenkins.docker.connector.DockerComputerJNLPConnector;
 
@@ -21,13 +20,11 @@ import io.jenkins.docker.connector.DockerComputerJNLPConnector;
 @Deprecated
 public class DockerComputerJNLPLauncher extends DockerComputerLauncher {
 
-    protected JNLPLauncher jnlpLauncher;
-
     protected String user;
 
     @Override
     public DockerComputerConnector convertToConnector() {
-        final DockerComputerJNLPConnector connector = new DockerComputerJNLPConnector(jnlpLauncher);
+        final DockerComputerJNLPConnector connector = new DockerComputerJNLPConnector();
         connector.setUser(user);
         return connector;
     }

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
@@ -3,7 +3,6 @@ package io.jenkins.docker.connector;
 import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.bldToString;
 import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.endToString;
 import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.fixEmpty;
-import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.makeCopy;
 import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.splitAndFilterEmpty;
 import static com.nirima.jenkins.plugins.docker.utils.JenkinsUtils.startToString;
 
@@ -43,22 +42,14 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
     @CheckForNull
     private String user;
 
-    private final JNLPLauncher jnlpLauncher;
-
     @CheckForNull
     private String jenkinsUrl;
 
     @CheckForNull
     private String[] entryPointArguments;
 
-    @Restricted(NoExternalUse.class)
-    public DockerComputerJNLPConnector() {
-        this(new JNLPLauncher(false));
-    }
-
     @DataBoundConstructor
-    public DockerComputerJNLPConnector(JNLPLauncher jnlpLauncher) {
-        this.jnlpLauncher = jnlpLauncher;
+    public DockerComputerJNLPConnector() {
     }
 
     @CheckForNull
@@ -113,16 +104,12 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
         return this;
     }
 
-    public JNLPLauncher getJnlpLauncher() {
-        return jnlpLauncher;
-    }
-
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
         result = prime * result + Arrays.hashCode(entryPointArguments);
-        result = prime * result + Objects.hash(jenkinsUrl, jnlpLauncher, user);
+        result = prime * result + Objects.hash(jenkinsUrl, user);
         return result;
     }
 
@@ -137,7 +124,6 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
         DockerComputerJNLPConnector other = (DockerComputerJNLPConnector) obj;
         return Arrays.equals(entryPointArguments, other.entryPointArguments)
                 && Objects.equals(jenkinsUrl, other.jenkinsUrl)
-                && Objects.equals(jnlpLauncher, other.jnlpLauncher)
                 && Objects.equals(user, other.user);
     }
 
@@ -145,7 +131,6 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
     public String toString() {
         final StringBuilder sb = startToString(this);
         bldToString(sb, "user", user);
-        bldToString(sb, "jnlpLauncher", jnlpLauncher);
         bldToString(sb, "jenkinsUrl", jenkinsUrl);
         bldToString(sb, "entryPointArguments", entryPointArguments);
         endToString(sb);
@@ -156,7 +141,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
     protected ComputerLauncher createLauncher(
             final DockerAPI api, final String workdir, final InspectContainerResponse inspect, TaskListener listener)
             throws IOException, InterruptedException {
-        return makeCopy(jnlpLauncher);
+        return new JNLPLauncher();
     }
 
     @Restricted(NoExternalUse.class)
@@ -165,11 +150,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
         Secret(
                 "JNLP_SECRET",
                 "The secret that must be passed to agent.jar's -secret argument to pass JNLP authentication."), //
-        JenkinsUrl("JENKINS_URL", "The Jenkins root URL."), //
-        TunnelArgument(
-                "TUNNEL_ARG",
-                "If a JNLP tunnel has been specified then this evaluates to '-tunnel', otherwise it evaluates to the empty string"), //
-        TunnelValue("TUNNEL", "The JNLP tunnel value");
+        JenkinsUrl("JENKINS_URL", "The Jenkins root URL.");
         private final String name;
         private final String description;
 
@@ -187,8 +168,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
         }
     }
 
-    private static final String DEFAULT_ENTRY_POINT_ARGUMENTS = "${" + ArgumentVariables.TunnelArgument.getName()
-            + "}\n${" + ArgumentVariables.TunnelValue.getName() + "}\n-url\n${" + ArgumentVariables.JenkinsUrl.getName()
+    private static final String DEFAULT_ENTRY_POINT_ARGUMENTS = "-url\n${" + ArgumentVariables.JenkinsUrl.getName()
             + "}\n${" + ArgumentVariables.Secret.getName() + "}\n${" + ArgumentVariables.NodeName.getName() + "}";
 
     @Override
@@ -199,7 +179,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
         final String nodeName = DockerTemplate.getNodeNameFromContainerConfig(cmd);
         final String secret = JnlpAgentReceiver.SLAVE_SECRET.mac(nodeName);
         final EnvVars knownVariables =
-                calculateVariablesForVariableSubstitution(nodeName, secret, jnlpLauncher.tunnel, effectiveJenkinsUrl);
+                calculateVariablesForVariableSubstitution(nodeName, secret, effectiveJenkinsUrl);
         final String configuredArgString = getEntryPointArgumentsString();
         final String effectiveConfiguredArgString =
                 StringUtils.isNotBlank(configuredArgString) ? configuredArgString : DEFAULT_ENTRY_POINT_ARGUMENTS;
@@ -224,7 +204,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
     }
 
     private static EnvVars calculateVariablesForVariableSubstitution(
-            final String nodeName, final String secret, final String jnlpTunnel, final String jenkinsUrl)
+            final String nodeName, final String secret, final String jenkinsUrl)
             throws IOException, InterruptedException {
         final EnvVars knownVariables = new EnvVars();
         final Jenkins j = Jenkins.get();
@@ -236,12 +216,6 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
             switch (v) {
                 case JenkinsUrl:
                     argValue = jenkinsUrl;
-                    break;
-                case TunnelArgument:
-                    argValue = StringUtils.isNotBlank(jnlpTunnel) ? "-tunnel" : "";
-                    break;
-                case TunnelValue:
-                    argValue = jnlpTunnel;
                     break;
                 case Secret:
                     argValue = secret;

--- a/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
+++ b/src/main/java/io/jenkins/docker/connector/DockerComputerJNLPConnector.java
@@ -49,8 +49,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
     private String[] entryPointArguments;
 
     @DataBoundConstructor
-    public DockerComputerJNLPConnector() {
-    }
+    public DockerComputerJNLPConnector() {}
 
     @CheckForNull
     public String getUser() {
@@ -178,8 +177,7 @@ public class DockerComputerJNLPConnector extends DockerComputerConnector {
                 StringUtils.isEmpty(jenkinsUrl) ? Jenkins.get().getRootUrl() : jenkinsUrl;
         final String nodeName = DockerTemplate.getNodeNameFromContainerConfig(cmd);
         final String secret = JnlpAgentReceiver.SLAVE_SECRET.mac(nodeName);
-        final EnvVars knownVariables =
-                calculateVariablesForVariableSubstitution(nodeName, secret, effectiveJenkinsUrl);
+        final EnvVars knownVariables = calculateVariablesForVariableSubstitution(nodeName, secret, effectiveJenkinsUrl);
         final String configuredArgString = getEntryPointArgumentsString();
         final String effectiveConfiguredArgString =
                 StringUtils.isNotBlank(configuredArgString) ? configuredArgString : DEFAULT_ENTRY_POINT_ARGUMENTS;

--- a/src/main/resources/io/jenkins/docker/connector/DockerComputerJNLPConnector/config.jelly
+++ b/src/main/resources/io/jenkins/docker/connector/DockerComputerJNLPConnector/config.jelly
@@ -28,5 +28,4 @@
         <f:expandableTextbox />
     </f:entry>
 
-    <f:property field="jnlpLauncher"/>
 </j:jelly>

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
@@ -2,7 +2,6 @@ package io.jenkins.docker.connector;
 
 import com.nirima.jenkins.plugins.docker.DockerTemplate;
 import com.nirima.jenkins.plugins.docker.DockerTemplateBase;
-import hudson.slaves.JNLPLauncher;
 import java.net.URI;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.lang3.SystemUtils;
@@ -40,7 +39,7 @@ public class DockerComputerJNLPConnectorTest extends DockerComputerConnectorTest
                 JNLP_AGENT_IMAGE_IMAGENAME + ':' + getJenkinsDockerImageVersionForThisEnvironment();
         final DockerTemplate template = new DockerTemplate(
                 new DockerTemplateBase(imagenameAndVersion),
-                new DockerComputerJNLPConnector(new JNLPLauncher(null))
+                new DockerComputerJNLPConnector()
                         .withUser(COMMON_IMAGE_USERNAME)
                         .withJenkinsUrl(uri.toString()),
                 getLabelForTemplate(),

--- a/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepExecutionTest.java
+++ b/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepExecutionTest.java
@@ -54,7 +54,7 @@ public class DockerNodeStepExecutionTest {
                 return "attach";
             }
         };
-        final DockerComputerConnector jnlp = new DockerComputerJNLPConnector(null) {
+        final DockerComputerConnector jnlp = new DockerComputerJNLPConnector() {
             @Override
             public String toString() {
                 return "jnlpNotSerializable";


### PR DESCRIPTION
Fixes #1047. Or so I suppose. I could not get an actual agent to connect but that is I guess an artifact of trying to run this plugin from `hpi:run`, since I do not have access to a system whereby the Jenkins controller would be accessible from containers:

```
java.io.IOException: Failed to connect to http://host.docker.internal:8080/jenkins/tcpSlaveAgentListener/: host.docker.internal
	at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:217)
	at hudson.remoting.Engine.innerRun(Engine.java:809)
	at hudson.remoting.Engine.run(Engine.java:563)
Caused by: java.net.UnknownHostException: host.docker.internal
	at java.base/sun.nio.ch.NioSocketImpl.connect(Unknown Source)
	at java.base/java.net.Socket.connect(Unknown Source)
	at java.base/sun.net.NetworkClient.doConnect(Unknown Source)
	at java.base/sun.net.www.http.HttpClient.openServer(Unknown Source)
	at java.base/sun.net.www.http.HttpClient.openServer(Unknown Source)
	at java.base/sun.net.www.http.HttpClient.<init>(Unknown Source)
	at java.base/sun.net.www.http.HttpClient.New(Unknown Source)
	at java.base/sun.net.www.http.HttpClient.New(Unknown Source)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.getNewHttpClient(Unknown Source)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect0(Unknown Source)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.plainConnect(Unknown Source)
	at java.base/sun.net.www.protocol.http.HttpURLConnection.connect(Unknown Source)
	at org.jenkinsci.remoting.engine.JnlpAgentEndpointResolver.resolve(JnlpAgentEndpointResolver.java:214)
	... 2 more
```

Not sure if https://github.com/moby/moby/pull/40007 was supposed to fix this or what.
