### PR TITLE
Require Jenkins 2.440.3 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
   <properties>
     <revision>1.6.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.440.1</jenkins.version>
+    <jenkins.version>2.440.3</jenkins.version>
     <gitHubRepo>jenkinsci/docker-plugin</gitHubRepo>
     <!-- Our unit-tests that talk to a real docker deamon aren't very stable -->
     <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>


### PR DESCRIPTION
## Require Jenkins 2.440.3 or newer

[Choosing a Jenkins baseline](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) recommends 2.440.3 or 2.426.3.  This plugin had its minimum Jenkins version as 2.440.1 because it initially needed to require Jenkins 2.440 (weekly).

[Plugin installation statistics](https://stats.jenkins.io/pluginversions/docker-plugin.html) do not yet show the installation statistics for 1.6.1 (released 3 weeks ago).  Statistics for 1.6 show that 53% of installations of 1.6 are already running Jenkins 2.440.3 or newer.

### Testing done

Confirmed that automated tests pass locally.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
