### PR TITLE
Document that local images can run with 'Never pull'

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ Then configure Agent templates,
 assigning them labels that you can use so your jobs select the appropriate template,
 and set the docker container to be run with whatever container settings you require.
 
+### Running self-made local Docker images
+
+By default the Jenkins Docker plugin will try to download ('pull') the latest version of the image. This will fail with custom images that are not on Docker Hub. You will see logs like:
+
+> com.nirima.jenkins.plugins.docker.DockerTemplate pullImage    
+> Pulling image '..'. This may take awhile...
+
+> com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"pull access denied for .., repository does not exist or may require 'docker login': denied: requested access to the resource is denied"}
+
+On the _Docker Agent template_ set **Pull strategy** to **Never pull**, Name, Docker Image, Remote File System Root, and checkbox Enabled.
+
+If you have docker only on your local Jenkins machine, set on _Docker Cloud details_ the textbox **Docker Host URI** to `unix:///var/run/docker.sock`, and checkbox Enabled.
+
 ### Creating a docker image
 
 You need a docker image that can be used to run Jenkins agent runtime.

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-pullStrategy.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplate/help-pullStrategy.html
@@ -1,3 +1,3 @@
 <div>
-    Pull strategy during provisioning before image run.
+    Pull strategy during provisioning before image run. Set to 'Never pull' to enable running self-made local Docker images.
 </div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Issue #599 mentions this option, but it's not documented in the interface. Took me a few months to find.

Given that you need to click the question marks to expand this text, it will probably still not be found by people. But hey, maybe this gets picked up by some documentation generator, I don't know.

### Testing done

Do you want UI tests? (and how do I do that?)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
