### PR TITLE
Skip Docker-based tests when Docker is not available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>1.20.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerAttachConnectorTest.java
@@ -6,13 +6,16 @@ import io.jenkins.docker.connector.DockerComputerAttachConnector.ArgumentVariabl
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import org.junit.Assume;
 import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
 
 public class DockerComputerAttachConnectorTest extends DockerComputerConnectorTest {
     private static final String ATTACH_AGENT_IMAGE_IMAGENAME = "jenkins/agent";
 
     @Test
     public void connectAgentViaDirectAttach() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         final DockerComputerAttachConnector connector = new DockerComputerAttachConnector(COMMON_IMAGE_USERNAME);
         final String testName = "connectAgentViaDirectAttach";
         testAgentCanStartAndConnect(connector, testName);
@@ -20,6 +23,7 @@ public class DockerComputerAttachConnectorTest extends DockerComputerConnectorTe
 
     @Test
     public void connectAgentViaDirectAttachWithCustomCmd() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         final DockerComputerAttachConnector connector = new DockerComputerAttachConnector(COMMON_IMAGE_USERNAME);
         // We could setJavaExe("/opt/jdk-11/bin/java") too, but that'd
         // mean we'd break the instant that the public docker image's JVM

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerJNLPConnectorTest.java
@@ -5,13 +5,16 @@ import com.nirima.jenkins.plugins.docker.DockerTemplateBase;
 import java.net.URI;
 import jenkins.model.JenkinsLocationConfiguration;
 import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assume;
 import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
 
 public class DockerComputerJNLPConnectorTest extends DockerComputerConnectorTest {
     private static final String JNLP_AGENT_IMAGE_IMAGENAME = "jenkins/inbound-agent";
 
     @Test
     public void connectAgentViaJNLP() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
 
         final JenkinsLocationConfiguration location = JenkinsLocationConfiguration.get();
         URI uri = URI.create(location.getUrl());

--- a/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
+++ b/src/test/java/io/jenkins/docker/connector/DockerComputerSSHConnectorTest.java
@@ -20,8 +20,10 @@ import java.util.Map;
 import jenkins.bouncycastle.api.PEMEncodable;
 import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.testcontainers.DockerClientFactory;
 
 public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest {
 
@@ -43,6 +45,7 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
 
     @Test
     public void connectAgentViaSSHUsingInjectSshKey() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         final DockerComputerSSHConnector.SSHKeyStrategy sshKeyStrategy =
                 new DockerComputerSSHConnector.InjectSSHKey(COMMON_IMAGE_USERNAME);
         final DockerComputerSSHConnector connector = new DockerComputerSSHConnector(sshKeyStrategy);
@@ -62,6 +65,7 @@ public class DockerComputerSSHConnectorTest extends DockerComputerConnectorTest 
 
     @Test
     public void connectAgentViaSSHUsingCredentialsKey() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         final InstanceIdentity id = InstanceIdentity.get();
         final String privateKey = PEMEncodable.create(id.getPrivate()).encode();
         final String publicKey =

--- a/src/test/java/io/jenkins/docker/pipeline/DockerAgentTest.java
+++ b/src/test/java/io/jenkins/docker/pipeline/DockerAgentTest.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -13,6 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.testcontainers.DockerClientFactory;
 
 public class DockerAgentTest {
 
@@ -38,6 +40,7 @@ public class DockerAgentTest {
 
     @Test
     public void smokes() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         WorkflowJob j = r.createProject(WorkflowJob.class, "p");
         j.setDefinition(new CpsFlowDefinition(
                 "pipeline {\n" + "  agent {\n"
@@ -57,6 +60,7 @@ public class DockerAgentTest {
 
     @Test
     public void withArgs() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         WorkflowJob j = r.createProject(WorkflowJob.class, "p");
         j.setDefinition(new CpsFlowDefinition(
                 "pipeline {\n" + "  agent {\n"

--- a/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepTest.java
+++ b/src/test/java/io/jenkins/docker/pipeline/DockerNodeStepTest.java
@@ -77,6 +77,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
 import org.jvnet.hudson.test.TestExtension;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.testcontainers.DockerClientFactory;
 
 public class DockerNodeStepTest {
 
@@ -170,6 +171,7 @@ public class DockerNodeStepTest {
 
     @Test
     public void simpleProvision() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -192,6 +194,7 @@ public class DockerNodeStepTest {
 
     @Test
     public void withinNode() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -219,6 +222,7 @@ public class DockerNodeStepTest {
     @Issue("JENKINS-36913")
     @Test
     public void toolInstall() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -259,6 +263,7 @@ public class DockerNodeStepTest {
     @Issue("JENKINS-33510")
     @Test
     public void changeDir() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -288,6 +293,7 @@ public class DockerNodeStepTest {
     @Issue("JENKINS-41894")
     @Test
     public void deleteDir() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -319,6 +325,7 @@ public class DockerNodeStepTest {
     @Issue("JENKINS-46831")
     @Test
     public void nodeWithinDockerNodeWithinNode() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -368,6 +375,7 @@ public class DockerNodeStepTest {
 
     @Test
     public void defaults() {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         story.then(r -> {
             DockerNodeStep s = new DockerNodeStep("foo");
             s.setCredentialsId("");
@@ -395,6 +403,7 @@ public class DockerNodeStepTest {
     @Issue("JENKINS-47805")
     @Test
     public void pathModification() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {
@@ -423,6 +432,7 @@ public class DockerNodeStepTest {
 
     @Test
     public void dockerBuilderPublisher() throws Exception {
+        Assume.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
         story.addStep(new Statement() {
             @Override
             public void evaluate() throws Throwable {


### PR DESCRIPTION
Skip tests rather than failing when Docker is not available to allow this plugin to be included in BOM.

CC @darinpope 