### PR TITLE
Place plugin configuration page in the 'System Configuration' section

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagement.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerManagement.java
@@ -2,6 +2,7 @@ package com.nirima.jenkins.plugins.docker;
 
 import com.github.dockerjava.api.DockerClient;
 import com.nirima.jenkins.plugins.docker.utils.JenkinsUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
@@ -73,6 +74,12 @@ public class DockerManagement extends ManagementLink implements StaplerProxy, De
     public Object getTarget() {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
         return this;
+    }
+
+    @NonNull
+    @Override
+    public Category getCategory() {
+        return ManagementLink.Category.CONFIGURATION;
     }
 
     public Collection<String> getServerNames() {


### PR DESCRIPTION
## Place plugin configuration page in the 'System Configuration' section

Previously it was placed in the "Uncategorized" section of the "Manage Jenkins" page.  It makes sense to have it in the same section as "Clouds" and "Nodes".

### Testing done

Confirmed that before the Docker configuration page was in "Uncategorized" before this change and is in "System Configuration" after this change.

### Before this pull request

![before-the-change](https://github.com/user-attachments/assets/b0ec6afd-56e7-4920-b4aa-96d0e699760b)

### After this pull request

![after-the-change](https://github.com/user-attachments/assets/a192ec55-7d50-488d-bc3e-647a893b7ea6)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
