### PR TITLE
Compatibility for old `DockerAgentScript`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,9 @@
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <!-- TODO until in BOM -->
-    <pipeline-model-definition.version>2.2236.va_b_88ceec798f</pipeline-model-definition.version>
+    <!-- TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/770 -->
+    <pipeline-model-definition.version>2.2243.v46879d3a_96b_e</pipeline-model-definition.version>
+    <useBeta>true</useBeta>
     <gitHubRepo>jenkinsci/docker-plugin</gitHubRepo>
     <!-- Our unit-tests that talk to a real docker deamon aren't very stable -->
     <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>

--- a/pom.xml
+++ b/pom.xml
@@ -37,8 +37,7 @@
     <jenkins.baseline>2.479</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <!-- TODO until in BOM -->
-    <!-- TODO https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/770 -->
-    <pipeline-model-definition.version>2.2243.v46879d3a_96b_e</pipeline-model-definition.version>
+    <pipeline-model-definition.version>2.2247.va_423189a_7dff</pipeline-model-definition.version>
     <useBeta>true</useBeta>
     <gitHubRepo>jenkinsci/docker-plugin</gitHubRepo>
     <!-- Our unit-tests that talk to a real docker deamon aren't very stable -->

--- a/src/main/java/io/jenkins/docker/pipeline/DockerAgent.java
+++ b/src/main/java/io/jenkins/docker/pipeline/DockerAgent.java
@@ -8,6 +8,7 @@ import hudson.model.Descriptor;
 import hudson.model.Item;
 import hudson.util.ListBoxModel;
 import io.jenkins.docker.connector.DockerComputerConnector;
+import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,7 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
+import org.jenkinsci.plugins.pipeline.modeldefinition.parser.CompatibilityLoader;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -125,6 +127,16 @@ public class DockerAgent extends DeclarativeAgent<DockerAgent> {
         public List<Descriptor<? extends DockerComputerConnector>> getAcceptableConnectorDescriptors() {
             return ExtensionList.lookupSingleton(DockerNodeStep.DescriptorImpl.class)
                     .getAcceptableConnectorDescriptors();
+        }
+    }
+
+    @Extension
+    public static final class Compat implements CompatibilityLoader {
+        @Override
+        public URL loadGroovySource(String clazz) {
+            return "io.jenkins.docker.pipeline.DockerAgentScript".equals(clazz)
+                    ? DockerAgent.class.getResource("DockerAgentScript-old.groovy")
+                    : null;
         }
     }
 }

--- a/src/main/java/io/jenkins/docker/pipeline/DockerAgent.java
+++ b/src/main/java/io/jenkins/docker/pipeline/DockerAgent.java
@@ -130,7 +130,7 @@ public class DockerAgent extends DeclarativeAgent<DockerAgent> {
         }
     }
 
-    @Extension
+    @Extension(optional = true)
     public static final class Compat implements CompatibilityLoader {
         @Override
         public URL loadGroovySource(String clazz) {

--- a/src/main/resources/io/jenkins/docker/pipeline/DockerAgentScript-old.groovy
+++ b/src/main/resources/io/jenkins/docker/pipeline/DockerAgentScript-old.groovy
@@ -1,0 +1,28 @@
+package io.jenkins.docker.pipeline
+
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.CheckoutScript
+import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentScript
+import org.jenkinsci.plugins.workflow.cps.CpsScript
+
+class DockerAgentScript extends DeclarativeAgentScript<DockerAgent> {
+
+    DockerAgentScript(CpsScript s, DockerAgent a) {
+        super(s, a)
+    }
+
+    @Override
+    Closure run(Closure body) {
+        return {
+            try {
+                script.dockerNode(describable.asArgs) {
+                    CheckoutScript.doCheckout(script, describable, null, body).call()
+                }
+            } catch (Exception e) {
+                script.getProperty("currentBuild").result = Utils.getResultFromException(e)
+                throw e
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Amending #1131 using https://github.com/jenkinsci/pipeline-model-definition-plugin/pull/770. Verified interactively by starting an `agent dockerContainer` build using 1.9.0; upgrading to trunk and seeing that the build failed to resume; then resetting the build record and updating to this PR and seeing that it resumed without error.