### PR TITLE
Disable capacity check to improve provision performance

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -126,8 +126,8 @@ public class DockerCloud extends Cloud {
      * Disables slow Docker API capacity checks during provisioning.
      * WARNING: When enabled, capacity limits are not enforced.
      */
-    private static final boolean DISABLE_PROVISION_CAPACITY_CHECK = Boolean.parseBoolean(
-        System.getProperty("com.nirima.jenkins.plugins.docker.DockerCloud.DISABLE_PROVISION_CAPACITY_CHECK", "false"));
+    private static final boolean DISABLE_PROVISION_CAPACITY_CHECK = Boolean.parseBoolean(System.getProperty(
+            "com.nirima.jenkins.plugins.docker.DockerCloud.DISABLE_PROVISION_CAPACITY_CHECK", "false"));
 
     /**
      * Indicate if docker host used to run container is exposed inside container as DOCKER_HOST environment variable

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerCloud.java
@@ -123,6 +123,13 @@ public class DockerCloud extends Cloud {
     static final Map<String, Map<String, Integer>> CONTAINERS_IN_PROGRESS = new HashMap<>();
 
     /**
+     * Disables slow Docker API capacity checks during provisioning.
+     * WARNING: When enabled, capacity limits are not enforced.
+     */
+    private static final boolean DISABLE_PROVISION_CAPACITY_CHECK = Boolean.parseBoolean(
+        System.getProperty("com.nirima.jenkins.plugins.docker.DockerCloud.DISABLE_PROVISION_CAPACITY_CHECK", "false"));
+
+    /**
      * Indicate if docker host used to run container is exposed inside container as DOCKER_HOST environment variable
      */
     private boolean exposeDockerHost;
@@ -645,6 +652,11 @@ public class DockerCloud extends Cloud {
      * Check not too many already running.
      */
     private boolean canAddProvisionedAgent(DockerTemplate t) throws Exception {
+        if (DISABLE_PROVISION_CAPACITY_CHECK) {
+            LOGGER.info("Provisioning '{}' without capacity check (disabled via system property)", t.getImage());
+            return true;
+        }
+
         final String templateImage = t.getImage();
         final int templateContainerCap = t.instanceCap;
         final int cloudContainerCap = getContainerCap();


### PR DESCRIPTION
The `countContainersInDocker` seemed to be causing delays up-to a minute, experimenting disabling the capacity check by proposing system property,
```
-Dcom.nirima.jenkins.plugins.docker.DockerCloud.DISABLE_PROVISION_CAPACITY_CHECK=true
```

### Testing done

TBU

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
