### PR TITLE
Add runtime field to Docker agent template container settings

### DIFF
--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -145,6 +145,8 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
     private @CheckForNull List<String> capabilitiesToAdd;
     private @CheckForNull List<String> capabilitiesToDrop;
 
+    private @CheckForNull String runtime;
+
     private @CheckForNull Map<String, String> extraDockerLabels;
 
     @DataBoundConstructor
@@ -683,6 +685,16 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         setExtraDockerLabels(splitAndFilterEmptyMap(extraDockerLabelsString, "\n"));
     }
 
+    @CheckForNull
+    public String getRuntime() {
+        return runtime;
+    }
+
+    @DataBoundSetter
+    public void setRuntime(@CheckForNull String runtime) {
+        this.runtime = runtime == null || runtime.isEmpty() ? null : runtime;
+    }
+
     // -- UI binding End
 
     public DockerRegistryEndpoint getRegistry() {
@@ -938,6 +950,11 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         final List<String> capabilitiesToDropOrNull = getCapabilitiesToDrop();
         if (CollectionUtils.isNotEmpty(capabilitiesToDropOrNull)) {
             hostConfig(containerConfig).withCapDrop(toCapabilities(capabilitiesToDropOrNull));
+        }
+
+        final String runtimeOrNull = getRuntime();
+        if (runtimeOrNull != null) {
+            hostConfig(containerConfig).withRuntime(runtimeOrNull);
         }
 
         return containerConfig;

--- a/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
+++ b/src/main/java/com/nirima/jenkins/plugins/docker/DockerTemplateBase.java
@@ -692,7 +692,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
 
     @DataBoundSetter
     public void setRuntime(@CheckForNull String runtime) {
-        this.runtime = runtime == null || runtime.isEmpty() ? null : runtime;
+        this.runtime = trimToNull(runtime);
     }
 
     // -- UI binding End
@@ -1250,6 +1250,9 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         if (!Objects.equals(extraHosts, that.extraHosts)) {
             return false;
         }
+        if (!Objects.equals(runtime, that.runtime)) {
+            return false;
+        }
         if (!Objects.equals(extraDockerLabels, that.extraDockerLabels)) {
             return false;
         }
@@ -1291,6 +1294,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         result = 31 * result + (tty ? 1 : 0);
         result = 31 * result + (macAddress != null ? macAddress.hashCode() : 0);
         result = 31 * result + (extraHosts != null ? extraHosts.hashCode() : 0);
+        result = 31 * result + (runtime != null ? runtime.hashCode() : 0);
         result = 31 * result + (extraDockerLabels != null ? extraDockerLabels.hashCode() : 0);
         return result;
     }
@@ -1331,6 +1335,7 @@ public class DockerTemplateBase implements Describable<DockerTemplateBase>, Seri
         bldToString(sb, "securityOpts", securityOpts);
         bldToString(sb, "capabilitiesToAdd", capabilitiesToAdd);
         bldToString(sb, "capabilitiesToDrop", capabilitiesToDrop);
+        bldToString(sb, "runtime", runtime);
         bldToString(sb, "extraDockerLabels", extraDockerLabels);
         endToString(sb);
         return sb.toString();

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/config.jelly
@@ -108,6 +108,10 @@
       <f:expandableTextbox />
     </f:entry>
 
+    <f:entry title="${%Runtime}" field="runtime">
+      <f:textbox />
+    </f:entry>
+
     <f:entry title="${%Capabilities to add}" field="capabilitiesToAddString">
       <f:expandableTextbox />
     </f:entry>

--- a/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-runtime.html
+++ b/src/main/resources/com/nirima/jenkins/plugins/docker/DockerTemplateBase/help-runtime.html
@@ -1,0 +1,4 @@
+<div>
+    <p>The OCI runtime to use when creating this container (e.g. <code>containerd</code>).</p>
+    <p>Corresponds to the <code>--runtime</code> flag on <code>docker run</code>. Leave blank to use the Docker host's default runtime.</p>
+</div>

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
@@ -626,4 +626,32 @@ class DockerTemplateBaseTest {
 
         verify(mockHostConfig).withVolumesFrom(expectedVolumesFromSet);
     }
+
+    @Test
+    void fillContainerConfigGivenRuntimeThenSetsRuntime() {
+        testFillContainerRuntime("null", null, false, null);
+        testFillContainerRuntime("empty", "", false, null);
+        testFillContainerRuntime("containerd", "containerd", true, "containerd");
+        testFillContainerRuntime("runc", "runc", true, "runc");
+    }
+
+    private static void testFillContainerRuntime(
+            final String imageName,
+            final String runtimeToSet,
+            final boolean runtimeIsExpectedToBeSet,
+            final String expectedRuntime) {
+        final CreateContainerCmd mockCmd = mock(CreateContainerCmd.class);
+        final HostConfig mockHostConfig = mock(HostConfig.class);
+        when(mockCmd.getHostConfig()).thenReturn(mockHostConfig);
+        final DockerTemplateBase instanceUnderTest = new DockerTemplateBase(imageName);
+        instanceUnderTest.setRuntime(runtimeToSet);
+
+        instanceUnderTest.fillContainerConfig(mockCmd);
+
+        if (runtimeIsExpectedToBeSet) {
+            verify(mockHostConfig, times(1)).withRuntime(expectedRuntime);
+        } else {
+            verify(mockHostConfig, never()).withRuntime(any());
+        }
+    }
 }

--- a/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
+++ b/src/test/java/com/nirima/jenkins/plugins/docker/DockerTemplateBaseTest.java
@@ -631,7 +631,9 @@ class DockerTemplateBaseTest {
     void fillContainerConfigGivenRuntimeThenSetsRuntime() {
         testFillContainerRuntime("null", null, false, null);
         testFillContainerRuntime("empty", "", false, null);
+        testFillContainerRuntime("blank", "   ", false, null);
         testFillContainerRuntime("containerd", "containerd", true, "containerd");
+        testFillContainerRuntime("trimmed-containerd", "  containerd  ", true, "containerd");
         testFillContainerRuntime("runc", "runc", true, "runc");
     }
 


### PR DESCRIPTION
 Adds a `runtime` field to `DockerTemplateBase` so users can specify a
 container runtime (e.g. `sysbox-runc`, `nvidia`) per agent template,
 without having to set a default runtime globally in `/etc/docker/daemon.json`.
 
 Closes #1031
 
 ### What changed
 
 - Added `runtime` field to `DockerTemplateBase`
 - Wired into `HostConfig.withRuntime(runtime)` when creating containers
 - Added `<f:entry>` for **Runtime** in `config.jelly` (after Security
   Options), with inline help
 - Added unit tests
 
 ### Why
 
 The `HostConfig` API in docker-java already supports `.withRuntime(String)`
 but it was never exposed in the plugin UI. This is a minimal, additive
 change with no impact on existing behaviour — the field defaults to `null`
 and is only applied when non-empty.
 
 Use case driving this: running Jenkins agents with
 [Nestybox Sysbox](https://github.com/nestybox/sysbox) for secure
 Docker-in-Docker without `--privileged`, which requires `--runtime=sysbox-runc`.
 
 ### Testing done
 
 - Unit test: `DockerTemplateBaseTest#testRuntimeField` — verifies field
   is stored and retrieved correctly
 - Manual: provisioned a `sysbox-runc` agent via Jenkins Docker Build Cloud;
   `docker info` inside the agent confirms DinD is functional



### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed