### PR TITLE
Fix IllegalStateException in cloudstats by tracking agent lifecycle

### DIFF
--- a/src/main/java/io/jenkins/docker/FastNodeProvisionerStrategy.java
+++ b/src/main/java/io/jenkins/docker/FastNodeProvisionerStrategy.java
@@ -6,6 +6,7 @@ import static hudson.slaves.NodeProvisioner.StrategyDecision.CONSULT_REMAINING_S
 import static hudson.slaves.NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.SEVERE;
 
 import com.nirima.jenkins.plugins.docker.DockerCloud;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -15,6 +16,7 @@ import hudson.model.LoadStatistics;
 import hudson.model.Queue;
 import hudson.model.queue.QueueListener;
 import hudson.slaves.Cloud;
+import hudson.slaves.CloudProvisioningListener;
 import hudson.slaves.NodeProvisioner;
 import java.util.Collection;
 import java.util.logging.Logger;
@@ -70,6 +72,7 @@ public class FastNodeProvisionerStrategy extends Strategy {
             Collection<NodeProvisioner.PlannedNode> plannedNodes =
                     cloud.provision(label, currentDemand - availableCapacity);
             LOGGER.log(FINE, "Planned {0} new nodes", plannedNodes.size());
+            fireOnStarted(cloud, label, plannedNodes);
             state.recordPendingLaunches(plannedNodes);
             availableCapacity += plannedNodes.size();
             LOGGER.log(FINE, "After provisioning, available capacity={0}, currentDemand={1}", new Object[] {
@@ -83,6 +86,23 @@ public class FastNodeProvisionerStrategy extends Strategy {
         }
         LOGGER.log(FINE, "Provisioning not complete, consulting remaining strategies");
         return CONSULT_REMAINING_STRATEGIES;
+    }
+
+    /**
+     * Fire {@code onStarted} on all {@link CloudProvisioningListener}s for the given planned nodes.
+     * Mirrors {@code NodeProvisioner#fireOnStarted}. The custom strategy provisions directly,
+     * so it must fire CloudProvisioningListener.onStarted manually.
+     */
+    private static void fireOnStarted(Cloud cloud, Label label, Collection<NodeProvisioner.PlannedNode> plannedNodes) {
+        for (CloudProvisioningListener cl : CloudProvisioningListener.all()) {
+            try {
+                cl.onStarted(cloud, label, plannedNodes);
+            } catch (Error e) {
+                throw e;
+            } catch (Throwable e) {
+                LOGGER.log(SEVERE, "Unexpected uncaught exception in onStarted() of " + cl + " for label " + label, e);
+            }
+        }
     }
 
     /**

--- a/src/test/java/io/jenkins/docker/FastNodeProvisionerStrategyTest.java
+++ b/src/test/java/io/jenkins/docker/FastNodeProvisionerStrategyTest.java
@@ -1,0 +1,84 @@
+package io.jenkins.docker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.nirima.jenkins.plugins.docker.DockerCloud;
+import hudson.model.Label;
+import hudson.model.LoadStatistics;
+import hudson.model.Node;
+import hudson.slaves.Cloud;
+import hudson.slaves.CloudProvisioningListener;
+import hudson.slaves.NodeProvisioner;
+import io.jenkins.docker.client.DockerAPI;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+@WithJenkins
+class FastNodeProvisionerStrategyTest {
+
+    /**
+     * When FastNodeProvisionerStrategy provisions nodes, it must call CloudProvisioningListener.onStarted.
+     */
+    @Test
+    void firesOnStartedForProvisionedNodes(JenkinsRule j) {
+        Label label = Label.get("docker-fast-test");
+        List<NodeProvisioner.PlannedNode> planned = List.of(plannedNode("a"), plannedNode("b"));
+
+        j.jenkins.clouds.add(new FakeDockerCloud(planned));
+
+        LoadStatistics.LoadStatisticsSnapshot snapshot = mock(LoadStatistics.LoadStatisticsSnapshot.class);
+        when(snapshot.getAvailableExecutors()).thenReturn(0);
+        when(snapshot.getConnectingExecutors()).thenReturn(0);
+        when(snapshot.getQueueLength()).thenReturn(planned.size());
+
+        NodeProvisioner.StrategyState state = mock(NodeProvisioner.StrategyState.class);
+        when(state.getLabel()).thenReturn(label);
+        when(state.getSnapshot()).thenReturn(snapshot);
+        when(state.getPlannedCapacitySnapshot()).thenReturn(0);
+
+        new FastNodeProvisionerStrategy().apply(state);
+
+        assertEquals(planned, List.copyOf(RecordingProvisioningListener.started));
+    }
+
+    private static NodeProvisioner.PlannedNode plannedNode(String name) {
+        return new NodeProvisioner.PlannedNode(name, new CompletableFuture<Node>(), 1);
+    }
+
+    private static class FakeDockerCloud extends DockerCloud {
+        private final transient Collection<NodeProvisioner.PlannedNode> planned;
+
+        FakeDockerCloud(Collection<NodeProvisioner.PlannedNode> planned) {
+            super("fake-docker", (DockerAPI) null, List.of());
+            this.planned = planned;
+        }
+
+        @Override
+        public boolean canProvision(Label label) {
+            return true;
+        }
+
+        @Override
+        public Collection<NodeProvisioner.PlannedNode> provision(Label label, int excessWorkload) {
+            return planned;
+        }
+    }
+
+    @TestExtension
+    public static class RecordingProvisioningListener extends CloudProvisioningListener {
+        static final List<NodeProvisioner.PlannedNode> started = new CopyOnWriteArrayList<>();
+
+        @Override
+        public void onStarted(Cloud cloud, Label label, Collection<NodeProvisioner.PlannedNode> plannedNodes) {
+            started.addAll(plannedNodes);
+        }
+    }
+}


### PR DESCRIPTION
`FastNodeProvisionerStrategy` was not calling `CloudProvisioningListener#onStarted` so Nodes provisioned by it could not be tracked. Without this call, the `ProvisioningActivity` object is not created from the `TrackedPlannedNode` id. Without the `ProvisioningActivity`, the cloudstats plugin is not able to accurately track the lifecycle of the node.

This fix calls onStarted the same way it is done by `hudson.slaves.NodeProvisioner#fireOnStarted`. Fixes cloudstats ability to track nodes provisioned by `FastNodeProvisionerStrategy` and removes `IllegalStateException` tracebacks for:

`cloudstats.CloudStatistics#getActivityFor: No activity tracked for ...`

Fixes #1206

This patch addresses the issue by following the same pattern that NodeProvisioner uses: [fireOnStarted](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/slaves/NodeProvisioner.java#L904). It is a private method so I've inlined it into the strategy. 

### Testing done

This change was tested against the [reproduction script](https://gist.github.com/datGryphon/2a78242ebc0b21ca6254cde19cbd4b1e#file-reproduction-groovy) sited in #1206. The expected behavior in that issue description was produced using this code. There is also a unit test included to exercise the relevant lines. 


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed